### PR TITLE
camera_server & camera: SET_CAMERA_FOCUS support

### DIFF
--- a/c/src/cmavsdk/plugins/camera/camera.cpp
+++ b/c/src/cmavsdk/plugins/camera/camera.cpp
@@ -2580,3 +2580,146 @@ mavsdk_camera_focus_range(
 
     return translate_result(ret_value);
 }
+
+// FocusMeters async
+void mavsdk_camera_focus_meters_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    float distance_m,
+    mavsdk_camera_focus_meters_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_meters_async(
+        component_id,
+        distance_m,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusMeters sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_meters(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    float distance_m)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_meters(        component_id,        distance_m);
+
+    return translate_result(ret_value);
+}
+
+// FocusAuto async
+void mavsdk_camera_focus_auto_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_auto_async(
+        component_id,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusAuto sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto(
+    mavsdk_camera_t camera,
+    int32_t component_id)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_auto(        component_id);
+
+    return translate_result(ret_value);
+}
+
+// FocusAutoSingle async
+void mavsdk_camera_focus_auto_single_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_single_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_auto_single_async(
+        component_id,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusAutoSingle sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto_single(
+    mavsdk_camera_t camera,
+    int32_t component_id)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_auto_single(        component_id);
+
+    return translate_result(ret_value);
+}
+
+// FocusAutoContinuous async
+void mavsdk_camera_focus_auto_continuous_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_continuous_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_auto_continuous_async(
+        component_id,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusAutoContinuous sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto_continuous(
+    mavsdk_camera_t camera,
+    int32_t component_id)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_auto_continuous(        component_id);
+
+    return translate_result(ret_value);
+}

--- a/c/src/cmavsdk/plugins/camera/camera.cpp
+++ b/c/src/cmavsdk/plugins/camera/camera.cpp
@@ -2368,6 +2368,76 @@ mavsdk_camera_track_stop(
     return translate_result(ret_value);
 }
 
+// FocusInStep async
+void mavsdk_camera_focus_in_step_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_in_step_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_in_step_async(
+        component_id,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusInStep sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_in_step(
+    mavsdk_camera_t camera,
+    int32_t component_id)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_in_step(        component_id);
+
+    return translate_result(ret_value);
+}
+
+// FocusOutStep async
+void mavsdk_camera_focus_out_step_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_out_step_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    wrapper->cpp_plugin->focus_out_step_async(
+        component_id,
+        [callback, user_data](
+            mavsdk::Camera::Result result) {
+                if (callback) {
+                    callback(
+                        translate_result(result),
+                        user_data);
+                }
+        });
+}
+
+
+// FocusOutStep sync
+mavsdk_camera_result_t
+mavsdk_camera_focus_out_step(
+    mavsdk_camera_t camera,
+    int32_t component_id)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_wrapper*>(camera);
+
+    auto ret_value = wrapper->cpp_plugin->focus_out_step(        component_id);
+
+    return translate_result(ret_value);
+}
+
 // FocusInStart async
 void mavsdk_camera_focus_in_start_async(
     mavsdk_camera_t camera,

--- a/c/src/cmavsdk/plugins/camera/camera.h
+++ b/c/src/cmavsdk/plugins/camera/camera.h
@@ -1011,6 +1011,10 @@ typedef void (*mavsdk_camera_focus_in_start_callback_t)(const mavsdk_camera_resu
 typedef void (*mavsdk_camera_focus_out_start_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_focus_stop_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_focus_range_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_meters_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_auto_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_auto_single_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_auto_continuous_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 
 // ===== Camera Creation/Destruction =====
 CMAVSDK_EXPORT mavsdk_camera_t mavsdk_camera_create(mavsdk_system_t system);
@@ -2179,6 +2183,141 @@ mavsdk_camera_focus_range(
     mavsdk_camera_t camera,
     int32_t component_id,
     float range);
+
+
+/**
+ * @brief Focus at a distance in meters.
+ * 
+ *  Note that there is no message to get the valid focus range of the camera,
+ *  so this can only be used for cameras where the range is known.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ * @param distance_m  Focus distance in meters
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_meters_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    float distance_m,
+    mavsdk_camera_focus_meters_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus meters (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_meters_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_meters(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    float distance_m);
+
+
+/**
+ * @brief Focus automatically.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_auto_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus auto (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_auto_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto(
+    mavsdk_camera_t camera,
+    int32_t component_id);
+
+
+/**
+ * @brief Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_auto_single_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_single_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus auto single (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_auto_single_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto_single(
+    mavsdk_camera_t camera,
+    int32_t component_id);
+
+
+/**
+ * @brief Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_auto_continuous_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_auto_continuous_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus auto continuous (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_auto_continuous_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_auto_continuous(
+    mavsdk_camera_t camera,
+    int32_t component_id);
 
 
 #ifdef __cplusplus

--- a/c/src/cmavsdk/plugins/camera/camera.h
+++ b/c/src/cmavsdk/plugins/camera/camera.h
@@ -1005,6 +1005,8 @@ typedef void (*mavsdk_camera_zoom_range_callback_t)(const mavsdk_camera_result_t
 typedef void (*mavsdk_camera_track_point_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_track_rectangle_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_track_stop_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_in_step_callback_t)(const mavsdk_camera_result_t result, void* user_data);
+typedef void (*mavsdk_camera_focus_out_step_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_focus_in_start_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_focus_out_start_callback_t)(const mavsdk_camera_result_t result, void* user_data);
 typedef void (*mavsdk_camera_focus_stop_callback_t)(const mavsdk_camera_result_t result, void* user_data);
@@ -1979,6 +1981,70 @@ CMAVSDK_EXPORT void mavsdk_camera_track_stop_async(
 CMAVSDK_EXPORT
 mavsdk_camera_result_t
 mavsdk_camera_track_stop(
+    mavsdk_camera_t camera,
+    int32_t component_id);
+
+
+/**
+ * @brief Step focus in.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_in_step_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_in_step_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus in step (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_in_step_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_in_step(
+    mavsdk_camera_t camera,
+    int32_t component_id);
+
+
+/**
+ * @brief Step focus out.
+ *
+ * @param camera The camera instance.
+ * @param component_id  Component ID
+ * 
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ */
+CMAVSDK_EXPORT void mavsdk_camera_focus_out_step_async(
+    mavsdk_camera_t camera,
+    int32_t component_id,
+    mavsdk_camera_focus_out_step_callback_t callback,
+    void* user_data);
+
+
+/**
+ * @brief Get the current focus out step (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param focus_out_step_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_result_t
+mavsdk_camera_focus_out_step(
     mavsdk_camera_t camera,
     int32_t component_id);
 

--- a/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
@@ -719,6 +719,10 @@ struct mavsdk_camera_server_wrapper {
     std::vector<mavsdk::CameraServer::FocusOutStartHandle*> focus_out_start_handles;
     std::vector<mavsdk::CameraServer::FocusStopHandle*> focus_stop_handles;
     std::vector<mavsdk::CameraServer::FocusRangeHandle*> focus_range_handles;
+    std::vector<mavsdk::CameraServer::FocusMetersHandle*> focus_meters_handles;
+    std::vector<mavsdk::CameraServer::FocusAutoHandle*> focus_auto_handles;
+    std::vector<mavsdk::CameraServer::FocusAutoSingleHandle*> focus_auto_single_handles;
+    std::vector<mavsdk::CameraServer::FocusAutoContinuousHandle*> focus_auto_continuous_handles;
     std::vector<mavsdk::CameraServer::TrackingPointCommandHandle*> tracking_point_command_handles;
     std::vector<mavsdk::CameraServer::TrackingRectangleCommandHandle*> tracking_rectangle_command_handles;
     std::vector<mavsdk::CameraServer::TrackingOffCommandHandle*> tracking_off_command_handles;
@@ -848,6 +852,26 @@ void mavsdk_camera_server_destroy(mavsdk_camera_server_t camera_server) {
             delete h;
         }
         wrapper->focus_range_handles.clear();
+        for (auto* h : wrapper->focus_meters_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_meters(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_meters_handles.clear();
+        for (auto* h : wrapper->focus_auto_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_auto(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_auto_handles.clear();
+        for (auto* h : wrapper->focus_auto_single_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_auto_single(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_auto_single_handles.clear();
+        for (auto* h : wrapper->focus_auto_continuous_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_auto_continuous(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_auto_continuous_handles.clear();
         for (auto* h : wrapper->tracking_point_command_handles) {
             wrapper->cpp_plugin->unsubscribe_tracking_point_command(std::move(*h));
             delete h;
@@ -2151,6 +2175,254 @@ mavsdk_camera_server_respond_focus_range(
     auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
 
     auto ret_value = wrapper->cpp_plugin->respond_focus_range(        translate_camera_feedback_from_c(focus_range_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusMeters async
+mavsdk_camera_server_focus_meters_handle_t mavsdk_camera_server_subscribe_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_meters_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_meters(
+        [callback, user_data](
+            float value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusMetersHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_meters_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_meters_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_meters_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusMetersHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_meters_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_meters(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusMeters sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_meters_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_meters(        translate_camera_feedback_from_c(focus_meters_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusAuto async
+mavsdk_camera_server_focus_auto_handle_t mavsdk_camera_server_subscribe_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_auto(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusAutoHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_auto_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_auto_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusAutoHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_auto_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_auto(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusAuto sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_auto(        translate_camera_feedback_from_c(focus_auto_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusAutoSingle async
+mavsdk_camera_server_focus_auto_single_handle_t mavsdk_camera_server_subscribe_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_single_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_auto_single(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusAutoSingleHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_auto_single_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_auto_single_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_single_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusAutoSingleHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_auto_single_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_auto_single(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusAutoSingle sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_single_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_auto_single(        translate_camera_feedback_from_c(focus_auto_single_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusAutoContinuous async
+mavsdk_camera_server_focus_auto_continuous_handle_t mavsdk_camera_server_subscribe_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_continuous_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_auto_continuous(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusAutoContinuousHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_auto_continuous_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_auto_continuous_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_continuous_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusAutoContinuousHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_auto_continuous_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_auto_continuous(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusAutoContinuous sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_continuous_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_auto_continuous(        translate_camera_feedback_from_c(focus_auto_continuous_feedback));
 
     return translate_result(ret_value);
 }

--- a/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.cpp
@@ -713,6 +713,12 @@ struct mavsdk_camera_server_wrapper {
     std::vector<mavsdk::CameraServer::ZoomOutStartHandle*> zoom_out_start_handles;
     std::vector<mavsdk::CameraServer::ZoomStopHandle*> zoom_stop_handles;
     std::vector<mavsdk::CameraServer::ZoomRangeHandle*> zoom_range_handles;
+    std::vector<mavsdk::CameraServer::FocusInStepHandle*> focus_in_step_handles;
+    std::vector<mavsdk::CameraServer::FocusOutStepHandle*> focus_out_step_handles;
+    std::vector<mavsdk::CameraServer::FocusInStartHandle*> focus_in_start_handles;
+    std::vector<mavsdk::CameraServer::FocusOutStartHandle*> focus_out_start_handles;
+    std::vector<mavsdk::CameraServer::FocusStopHandle*> focus_stop_handles;
+    std::vector<mavsdk::CameraServer::FocusRangeHandle*> focus_range_handles;
     std::vector<mavsdk::CameraServer::TrackingPointCommandHandle*> tracking_point_command_handles;
     std::vector<mavsdk::CameraServer::TrackingRectangleCommandHandle*> tracking_rectangle_command_handles;
     std::vector<mavsdk::CameraServer::TrackingOffCommandHandle*> tracking_off_command_handles;
@@ -812,6 +818,36 @@ void mavsdk_camera_server_destroy(mavsdk_camera_server_t camera_server) {
             delete h;
         }
         wrapper->zoom_range_handles.clear();
+        for (auto* h : wrapper->focus_in_step_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_in_step(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_in_step_handles.clear();
+        for (auto* h : wrapper->focus_out_step_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_out_step(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_out_step_handles.clear();
+        for (auto* h : wrapper->focus_in_start_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_in_start(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_in_start_handles.clear();
+        for (auto* h : wrapper->focus_out_start_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_out_start(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_out_start_handles.clear();
+        for (auto* h : wrapper->focus_stop_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_stop(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_stop_handles.clear();
+        for (auto* h : wrapper->focus_range_handles) {
+            wrapper->cpp_plugin->unsubscribe_focus_range(std::move(*h));
+            delete h;
+        }
+        wrapper->focus_range_handles.clear();
         for (auto* h : wrapper->tracking_point_command_handles) {
             wrapper->cpp_plugin->unsubscribe_tracking_point_command(std::move(*h));
             delete h;
@@ -1743,6 +1779,378 @@ mavsdk_camera_server_respond_zoom_range(
     auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
 
     auto ret_value = wrapper->cpp_plugin->respond_zoom_range(        translate_camera_feedback_from_c(zoom_range_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusInStep async
+mavsdk_camera_server_focus_in_step_handle_t mavsdk_camera_server_subscribe_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_step_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_in_step(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusInStepHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_in_step_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_in_step_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_step_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusInStepHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_in_step_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_in_step(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusInStep sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_in_step_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_in_step(        translate_camera_feedback_from_c(focus_in_step_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusOutStep async
+mavsdk_camera_server_focus_out_step_handle_t mavsdk_camera_server_subscribe_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_step_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_out_step(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusOutStepHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_out_step_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_out_step_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_step_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusOutStepHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_out_step_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_out_step(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusOutStep sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_out_step_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_out_step(        translate_camera_feedback_from_c(focus_out_step_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusInStart async
+mavsdk_camera_server_focus_in_start_handle_t mavsdk_camera_server_subscribe_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_start_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_in_start(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusInStartHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_in_start_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_in_start_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_start_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusInStartHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_in_start_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_in_start(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusInStart sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_in_start_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_in_start(        translate_camera_feedback_from_c(focus_in_start_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusOutStart async
+mavsdk_camera_server_focus_out_start_handle_t mavsdk_camera_server_subscribe_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_start_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_out_start(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusOutStartHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_out_start_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_out_start_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_start_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusOutStartHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_out_start_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_out_start(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusOutStart sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_out_start_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_out_start(        translate_camera_feedback_from_c(focus_out_start_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusStop async
+mavsdk_camera_server_focus_stop_handle_t mavsdk_camera_server_subscribe_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_stop_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_stop(
+        [callback, user_data](
+            int32_t value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusStopHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_stop_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_stop_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_stop_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusStopHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_stop_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_stop(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusStop sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_stop_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_stop(        translate_camera_feedback_from_c(focus_stop_feedback));
+
+    return translate_result(ret_value);
+}
+
+// FocusRange async
+mavsdk_camera_server_focus_range_handle_t mavsdk_camera_server_subscribe_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_range_callback_t callback,
+    void* user_data)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto cpp_handle =    wrapper->cpp_plugin->subscribe_focus_range(
+        [callback, user_data](
+            float value) {
+                if (callback) {
+                    callback(
+                        value,
+                        user_data);
+                }
+        });
+
+    auto cpp_handle_ptr = new mavsdk::CameraServer::FocusRangeHandle(std::move(cpp_handle));
+
+    {
+        std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+        wrapper->focus_range_handles.push_back(cpp_handle_ptr);
+    }
+
+    return reinterpret_cast<mavsdk_camera_server_focus_range_handle_t>(cpp_handle_ptr);
+}
+
+void mavsdk_camera_server_unsubscribe_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_range_handle_t handle)
+{
+    if (handle) {
+        auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+        auto cpp_handle = reinterpret_cast<mavsdk::CameraServer::FocusRangeHandle*>(handle);
+
+        {
+            std::lock_guard<std::mutex> lock(wrapper->handles_mutex);
+            auto& vec = wrapper->focus_range_handles;
+            vec.erase(std::remove(vec.begin(), vec.end(), cpp_handle), vec.end());
+        }
+
+        wrapper->cpp_plugin->unsubscribe_focus_range(std::move(*cpp_handle));
+        delete cpp_handle;
+    }
+}
+
+
+
+// RespondFocusRange sync
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_range_feedback)
+{
+    auto wrapper = reinterpret_cast<mavsdk_camera_server_wrapper*>(camera_server);
+
+    auto ret_value = wrapper->cpp_plugin->respond_focus_range(        translate_camera_feedback_from_c(focus_range_feedback));
 
     return translate_result(ret_value);
 }

--- a/c/src/cmavsdk/plugins/camera_server/camera_server.h
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.h
@@ -37,6 +37,12 @@ typedef struct mavsdk_camera_server_zoom_in_start_handle_s *mavsdk_camera_server
 typedef struct mavsdk_camera_server_zoom_out_start_handle_s *mavsdk_camera_server_zoom_out_start_handle_t;
 typedef struct mavsdk_camera_server_zoom_stop_handle_s *mavsdk_camera_server_zoom_stop_handle_t;
 typedef struct mavsdk_camera_server_zoom_range_handle_s *mavsdk_camera_server_zoom_range_handle_t;
+typedef struct mavsdk_camera_server_focus_in_step_handle_s *mavsdk_camera_server_focus_in_step_handle_t;
+typedef struct mavsdk_camera_server_focus_out_step_handle_s *mavsdk_camera_server_focus_out_step_handle_t;
+typedef struct mavsdk_camera_server_focus_in_start_handle_s *mavsdk_camera_server_focus_in_start_handle_t;
+typedef struct mavsdk_camera_server_focus_out_start_handle_s *mavsdk_camera_server_focus_out_start_handle_t;
+typedef struct mavsdk_camera_server_focus_stop_handle_s *mavsdk_camera_server_focus_stop_handle_t;
+typedef struct mavsdk_camera_server_focus_range_handle_s *mavsdk_camera_server_focus_range_handle_t;
 typedef struct mavsdk_camera_server_tracking_point_command_handle_s *mavsdk_camera_server_tracking_point_command_handle_t;
 typedef struct mavsdk_camera_server_tracking_rectangle_command_handle_s *mavsdk_camera_server_tracking_rectangle_command_handle_t;
 typedef struct mavsdk_camera_server_tracking_off_command_handle_s *mavsdk_camera_server_tracking_off_command_handle_t;
@@ -665,6 +671,12 @@ typedef void (*mavsdk_camera_server_zoom_in_start_callback_t)(const int32_t rese
 typedef void (*mavsdk_camera_server_zoom_out_start_callback_t)(const int32_t reserved, void* user_data);
 typedef void (*mavsdk_camera_server_zoom_stop_callback_t)(const int32_t reserved, void* user_data);
 typedef void (*mavsdk_camera_server_zoom_range_callback_t)(const float factor, void* user_data);
+typedef void (*mavsdk_camera_server_focus_in_step_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_out_step_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_in_start_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_out_start_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_stop_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_range_callback_t)(const float focus_distance_m, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_point_command_callback_t)(const mavsdk_camera_server_track_point_t track_point, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_rectangle_command_callback_t)(const mavsdk_camera_server_track_rectangle_t track_rectangle, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_off_command_callback_t)(const int32_t dummy, void* user_data);
@@ -1309,6 +1321,258 @@ mavsdk_camera_server_result_t
 mavsdk_camera_server_respond_zoom_range(
     mavsdk_camera_server_t camera_server,
     mavsdk_camera_server_camera_feedback_t zoom_range_feedback);
+
+
+/**
+ * @brief Subscribe to focus in step command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_in_step() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_in_step_handle_t mavsdk_camera_server_subscribe_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_step_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_in_step' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_in_step().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_step_handle_t);
+
+
+/**
+ * @brief Get the current respond focus in step (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_in_step_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_in_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_in_step_feedback);
+
+
+/**
+ * @brief Subscribe to focus out step command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_out_step() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_out_step_handle_t mavsdk_camera_server_subscribe_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_step_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_out_step' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_out_step().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_step_handle_t);
+
+
+/**
+ * @brief Get the current respond focus out step (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_out_step_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_out_step(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_out_step_feedback);
+
+
+/**
+ * @brief Subscribe to focus in start command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_in_start() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_in_start_handle_t mavsdk_camera_server_subscribe_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_start_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_in_start' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_in_start().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_in_start_handle_t);
+
+
+/**
+ * @brief Get the current respond focus in start (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_in_start_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_in_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_in_start_feedback);
+
+
+/**
+ * @brief Subscribe to focus out start command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_out_start() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_out_start_handle_t mavsdk_camera_server_subscribe_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_start_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_out_start' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_out_start().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_out_start_handle_t);
+
+
+/**
+ * @brief Get the current respond focus out start (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_out_start_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_out_start(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_out_start_feedback);
+
+
+/**
+ * @brief Subscribe to focus stop command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_stop() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_stop_handle_t mavsdk_camera_server_subscribe_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_stop_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_stop' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_stop().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_stop_handle_t);
+
+
+/**
+ * @brief Get the current respond focus stop (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_stop_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_stop(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_stop_feedback);
+
+
+/**
+ * @brief Subscribe to focus range command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_range() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_range_handle_t mavsdk_camera_server_subscribe_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_range_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_range' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_range().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_range_handle_t);
+
+
+/**
+ * @brief Get the current respond focus range (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_range_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_range(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_range_feedback);
 
 
 /**

--- a/c/src/cmavsdk/plugins/camera_server/camera_server.h
+++ b/c/src/cmavsdk/plugins/camera_server/camera_server.h
@@ -43,6 +43,10 @@ typedef struct mavsdk_camera_server_focus_in_start_handle_s *mavsdk_camera_serve
 typedef struct mavsdk_camera_server_focus_out_start_handle_s *mavsdk_camera_server_focus_out_start_handle_t;
 typedef struct mavsdk_camera_server_focus_stop_handle_s *mavsdk_camera_server_focus_stop_handle_t;
 typedef struct mavsdk_camera_server_focus_range_handle_s *mavsdk_camera_server_focus_range_handle_t;
+typedef struct mavsdk_camera_server_focus_meters_handle_s *mavsdk_camera_server_focus_meters_handle_t;
+typedef struct mavsdk_camera_server_focus_auto_handle_s *mavsdk_camera_server_focus_auto_handle_t;
+typedef struct mavsdk_camera_server_focus_auto_single_handle_s *mavsdk_camera_server_focus_auto_single_handle_t;
+typedef struct mavsdk_camera_server_focus_auto_continuous_handle_s *mavsdk_camera_server_focus_auto_continuous_handle_t;
 typedef struct mavsdk_camera_server_tracking_point_command_handle_s *mavsdk_camera_server_tracking_point_command_handle_t;
 typedef struct mavsdk_camera_server_tracking_rectangle_command_handle_s *mavsdk_camera_server_tracking_rectangle_command_handle_t;
 typedef struct mavsdk_camera_server_tracking_off_command_handle_s *mavsdk_camera_server_tracking_off_command_handle_t;
@@ -677,6 +681,10 @@ typedef void (*mavsdk_camera_server_focus_in_start_callback_t)(const int32_t res
 typedef void (*mavsdk_camera_server_focus_out_start_callback_t)(const int32_t reserved, void* user_data);
 typedef void (*mavsdk_camera_server_focus_stop_callback_t)(const int32_t reserved, void* user_data);
 typedef void (*mavsdk_camera_server_focus_range_callback_t)(const float focus_distance_m, void* user_data);
+typedef void (*mavsdk_camera_server_focus_meters_callback_t)(const float focus_distance_m, void* user_data);
+typedef void (*mavsdk_camera_server_focus_auto_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_auto_single_callback_t)(const int32_t reserved, void* user_data);
+typedef void (*mavsdk_camera_server_focus_auto_continuous_callback_t)(const int32_t reserved, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_point_command_callback_t)(const mavsdk_camera_server_track_point_t track_point, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_rectangle_command_callback_t)(const mavsdk_camera_server_track_rectangle_t track_rectangle, void* user_data);
 typedef void (*mavsdk_camera_server_tracking_off_command_callback_t)(const int32_t dummy, void* user_data);
@@ -1573,6 +1581,174 @@ mavsdk_camera_server_result_t
 mavsdk_camera_server_respond_focus_range(
     mavsdk_camera_server_t camera_server,
     mavsdk_camera_server_camera_feedback_t focus_range_feedback);
+
+
+/**
+ * @brief Subscribe to focus meters command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_meters() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_meters_handle_t mavsdk_camera_server_subscribe_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_meters_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_meters' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_meters().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_meters_handle_t);
+
+
+/**
+ * @brief Get the current respond focus meters (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_meters_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_meters(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_meters_feedback);
+
+
+/**
+ * @brief Subscribe to focus auto command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_auto() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_auto_handle_t mavsdk_camera_server_subscribe_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_auto' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_auto().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_handle_t);
+
+
+/**
+ * @brief Get the current respond focus auto (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_auto_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_feedback);
+
+
+/**
+ * @brief Subscribe to focus auto single command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_auto_single() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_auto_single_handle_t mavsdk_camera_server_subscribe_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_single_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_auto_single' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_auto_single().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_single_handle_t);
+
+
+/**
+ * @brief Get the current respond focus auto single (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_auto_single_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto_single(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_single_feedback);
+
+
+/**
+ * @brief Subscribe to focus auto continuous command.
+ *
+ * @param camera_server The camera_server instance.
+ *
+ * @param callback Function to call when new data is available.
+ * @param user_data User data to pass to the callback.
+ * @return Handle for this subscription. Use mavsdk_camera_server_unsubscribe_focus_auto_continuous() to unsubscribe.
+ */
+CMAVSDK_EXPORT mavsdk_camera_server_focus_auto_continuous_handle_t mavsdk_camera_server_subscribe_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_continuous_callback_t callback,
+    void* user_data);
+
+/**
+ * @brief Unsubscribe from 'focus_auto_continuous' updates.
+ *
+ * Stops the subscription and frees resources associated with the handle.
+ *
+ * @param camera_server The camera_server instance.
+ * @param handle The subscription handle returned by mavsdk_camera_server_subscribe_focus_auto_continuous().
+ */
+CMAVSDK_EXPORT void mavsdk_camera_server_unsubscribe_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_focus_auto_continuous_handle_t);
+
+
+/**
+ * @brief Get the current respond focus auto continuous (blocking).
+ *
+ * This function blocks until a value is available.
+ *
+ * @param telemetry The telemetry instance.
+ * @param respond_focus_auto_continuous_out Pointer to store the result.
+ */
+CMAVSDK_EXPORT
+mavsdk_camera_server_result_t
+mavsdk_camera_server_respond_focus_auto_continuous(
+    mavsdk_camera_server_t camera_server,
+    mavsdk_camera_server_camera_feedback_t focus_auto_continuous_feedback);
 
 
 /**

--- a/cpp/examples/camera_server/camera_server.cpp
+++ b/cpp/examples/camera_server/camera_server.cpp
@@ -178,4 +178,54 @@ static void subscribe_camera_operation(mavsdk::CameraServer& camera_server)
         std::cout << "reset camera settings" << std::endl;
         camera_server.respond_reset_settings(mavsdk::CameraServer::CameraFeedback::Ok);
     });
+
+    camera_server.subscribe_zoom_in_start([&camera_server](int camera_id) {
+        std::cout << "Zoom in start" << std::endl;
+        camera_server.respond_zoom_in_start(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_zoom_out_start([&camera_server](int camera_id) {
+        std::cout << "Zoom out start" << std::endl;
+        camera_server.respond_zoom_out_start(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_zoom_stop([&camera_server](int camera_id) {
+        std::cout << "Zoom stop" << std::endl;
+        camera_server.respond_zoom_stop(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_zoom_range([&camera_server](float zoom_level) {
+        std::cout << "Zoom range requested: " << zoom_level << "%" << std::endl;
+        camera_server.respond_zoom_range(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_in_step([&camera_server](int camera_id) {
+        std::cout << "Focus in step" << std::endl;
+        camera_server.respond_focus_in_step(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_out_step([&camera_server](int camera_id) {
+        std::cout << "Focus out step" << std::endl;
+        camera_server.respond_focus_out_step(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_in_start([&camera_server](int camera_id) {
+        std::cout << "Focus in start" << std::endl;
+        camera_server.respond_focus_in_start(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_out_start([&camera_server](int camera_id) {
+        std::cout << "Focus out start" << std::endl;
+        camera_server.respond_focus_out_start(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_stop([&camera_server](int camera_id) {
+        std::cout << "Focus stop" << std::endl;
+        camera_server.respond_focus_stop(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_range([&camera_server](float focus_level) {
+        std::cout << "Focus range requested: " << focus_level << "%" << std::endl;
+        camera_server.respond_focus_range(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
 }

--- a/cpp/examples/camera_server/camera_server.cpp
+++ b/cpp/examples/camera_server/camera_server.cpp
@@ -228,4 +228,24 @@ static void subscribe_camera_operation(mavsdk::CameraServer& camera_server)
         std::cout << "Focus range requested: " << focus_level << "%" << std::endl;
         camera_server.respond_focus_range(mavsdk::CameraServer::CameraFeedback::Ok);
     });
+
+    camera_server.subscribe_focus_meters([&camera_server](float focus_distance_m) {
+        std::cout << "Focus meters requested: " << focus_distance_m << "m" << std::endl;
+        camera_server.respond_focus_meters(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_auto([&camera_server](int camera_id) {
+        std::cout << "Focus auto" << std::endl;
+        camera_server.respond_focus_auto(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_auto_single([&camera_server](int camera_id) {
+        std::cout << "Focus auto single" << std::endl;
+        camera_server.respond_focus_auto_single(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
+
+    camera_server.subscribe_focus_auto_continuous([&camera_server](int camera_id) {
+        std::cout << "Focus auto continuous" << std::endl;
+        camera_server.respond_focus_auto_continuous(mavsdk::CameraServer::CameraFeedback::Ok);
+    });
 }

--- a/cpp/src/mavsdk/plugins/camera/camera.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera.cpp
@@ -414,6 +414,47 @@ Camera::Result Camera::focus_range(int32_t component_id, float range) const
     return _impl->focus_range(component_id, range);
 }
 
+void Camera::focus_meters_async(
+    int32_t component_id, float distance_m, const ResultCallback callback)
+{
+    _impl->focus_meters_async(component_id, distance_m, callback);
+}
+
+Camera::Result Camera::focus_meters(int32_t component_id, float distance_m) const
+{
+    return _impl->focus_meters(component_id, distance_m);
+}
+
+void Camera::focus_auto_async(int32_t component_id, const ResultCallback callback)
+{
+    _impl->focus_auto_async(component_id, callback);
+}
+
+Camera::Result Camera::focus_auto(int32_t component_id) const
+{
+    return _impl->focus_auto(component_id);
+}
+
+void Camera::focus_auto_single_async(int32_t component_id, const ResultCallback callback)
+{
+    _impl->focus_auto_single_async(component_id, callback);
+}
+
+Camera::Result Camera::focus_auto_single(int32_t component_id) const
+{
+    return _impl->focus_auto_single(component_id);
+}
+
+void Camera::focus_auto_continuous_async(int32_t component_id, const ResultCallback callback)
+{
+    _impl->focus_auto_continuous_async(component_id, callback);
+}
+
+Camera::Result Camera::focus_auto_continuous(int32_t component_id) const
+{
+    return _impl->focus_auto_continuous(component_id);
+}
+
 MAVSDK_PUBLIC bool operator==(const Camera::Option& lhs, const Camera::Option& rhs)
 {
     return (rhs.option_id == lhs.option_id) && (rhs.option_description == lhs.option_description);

--- a/cpp/src/mavsdk/plugins/camera/camera.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera.cpp
@@ -354,6 +354,26 @@ Camera::Result Camera::track_stop(int32_t component_id) const
     return _impl->track_stop(component_id);
 }
 
+void Camera::focus_in_step_async(int32_t component_id, const ResultCallback callback)
+{
+    _impl->focus_in_step_async(component_id, callback);
+}
+
+Camera::Result Camera::focus_in_step(int32_t component_id) const
+{
+    return _impl->focus_in_step(component_id);
+}
+
+void Camera::focus_out_step_async(int32_t component_id, const ResultCallback callback)
+{
+    _impl->focus_out_step_async(component_id, callback);
+}
+
+Camera::Result Camera::focus_out_step(int32_t component_id) const
+{
+    return _impl->focus_out_step(component_id);
+}
+
 void Camera::focus_in_start_async(int32_t component_id, const ResultCallback callback)
 {
     _impl->focus_in_start_async(component_id, callback);

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -261,7 +261,29 @@ MavlinkCommandSender::CommandLong CameraImpl::make_command_track_stop(int32_t co
     return cmd;
 }
 
-MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_in(int32_t component_id)
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_in_step(int32_t component_id)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_STEP);
+    cmd.params.maybe_param2 = -1.f;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_out_step(int32_t component_id)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_STEP);
+    cmd.params.maybe_param2 = 1.f;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_in_start(int32_t component_id)
 {
     MavlinkCommandSender::CommandLong cmd{};
     cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
@@ -272,7 +294,7 @@ MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_in(int32_t comp
     return cmd;
 }
 
-MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_out(int32_t component_id)
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_out_start(int32_t component_id)
 {
     MavlinkCommandSender::CommandLong cmd{};
     cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
@@ -444,16 +466,30 @@ Camera::Result CameraImpl::track_stop(int32_t component_id)
     return camera_result_from_command_result(_system_impl->send_command(cmd));
 }
 
+Camera::Result CameraImpl::focus_in_step(int32_t component_id)
+{
+    auto cmd = make_command_focus_in_step(component_id);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
+Camera::Result CameraImpl::focus_out_step(int32_t component_id)
+{
+    auto cmd = make_command_focus_out_step(component_id);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
 Camera::Result CameraImpl::focus_in_start(int32_t component_id)
 {
-    auto cmd = make_command_focus_in(component_id);
+    auto cmd = make_command_focus_in_start(component_id);
 
     return camera_result_from_command_result(_system_impl->send_command(cmd));
 }
 
 Camera::Result CameraImpl::focus_out_start(int32_t component_id)
 {
-    auto cmd = make_command_focus_out(component_id);
+    auto cmd = make_command_focus_out_start(component_id);
 
     return camera_result_from_command_result(_system_impl->send_command(cmd));
 }
@@ -584,9 +620,29 @@ void CameraImpl::track_stop_async(int32_t component_id, const Camera::ResultCall
         });
 }
 
+void CameraImpl::focus_in_step_async(int32_t component_id, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_in_step(component_id);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
+void CameraImpl::focus_out_step_async(int32_t component_id, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_out_step(component_id);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
 void CameraImpl::focus_in_start_async(int32_t component_id, const Camera::ResultCallback& callback)
 {
-    auto cmd = make_command_focus_in(component_id);
+    auto cmd = make_command_focus_in_start(component_id);
 
     _system_impl->send_command_async(
         cmd, [this, callback](MavlinkCommandSender::Result result, float) {
@@ -596,7 +652,7 @@ void CameraImpl::focus_in_start_async(int32_t component_id, const Camera::Result
 
 void CameraImpl::focus_out_start_async(int32_t component_id, const Camera::ResultCallback& callback)
 {
-    auto cmd = make_command_focus_out(component_id);
+    auto cmd = make_command_focus_out_start(component_id);
 
     _system_impl->send_command_async(
         cmd, [this, callback](MavlinkCommandSender::Result result, float) {

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -331,6 +331,52 @@ CameraImpl::make_command_focus_range(int32_t component_id, float range)
     return cmd;
 }
 
+MavlinkCommandSender::CommandLong
+CameraImpl::make_command_focus_meters(int32_t component_id, float distance_m)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_METERS);
+    cmd.params.maybe_param2 = distance_m;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_auto(int32_t component_id)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_AUTO);
+    cmd.params.maybe_param2 = 0.f;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
+MavlinkCommandSender::CommandLong CameraImpl::make_command_focus_auto_single(int32_t component_id)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_AUTO_SINGLE);
+    cmd.params.maybe_param2 = 0.f;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
+MavlinkCommandSender::CommandLong
+CameraImpl::make_command_focus_auto_continuous(int32_t component_id)
+{
+    MavlinkCommandSender::CommandLong cmd{};
+    cmd.command = MAV_CMD_SET_CAMERA_FOCUS;
+    cmd.params.maybe_param1 = static_cast<float>(FOCUS_TYPE_AUTO_CONTINUOUS);
+    cmd.params.maybe_param2 = 0.f;
+    cmd.target_component_id = fixup_component_target(component_id);
+
+    return cmd;
+}
+
 MavlinkCommandSender::CommandLong CameraImpl::make_command_stop_photo(int32_t component_id)
 {
     MavlinkCommandSender::CommandLong cmd_stop_photo{};
@@ -508,6 +554,34 @@ Camera::Result CameraImpl::focus_range(int32_t component_id, float range)
     return camera_result_from_command_result(_system_impl->send_command(cmd));
 }
 
+Camera::Result CameraImpl::focus_meters(int32_t component_id, float distance_m)
+{
+    auto cmd = make_command_focus_meters(component_id, distance_m);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
+Camera::Result CameraImpl::focus_auto(int32_t component_id)
+{
+    auto cmd = make_command_focus_auto(component_id);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
+Camera::Result CameraImpl::focus_auto_single(int32_t component_id)
+{
+    auto cmd = make_command_focus_auto_single(component_id);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
+Camera::Result CameraImpl::focus_auto_continuous(int32_t component_id)
+{
+    auto cmd = make_command_focus_auto_continuous(component_id);
+
+    return camera_result_from_command_result(_system_impl->send_command(cmd));
+}
+
 Camera::Result CameraImpl::start_photo_interval(int32_t component_id, float interval_s)
 {
     auto cmd_take_photo_time_lapse = make_command_take_photo(component_id, interval_s, 0.f);
@@ -674,6 +748,49 @@ void CameraImpl::focus_range_async(
     int32_t component_id, float range, const Camera::ResultCallback& callback)
 {
     auto cmd = make_command_focus_range(component_id, range);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
+void CameraImpl::focus_meters_async(
+    int32_t component_id, float distance_m, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_meters(component_id, distance_m);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
+void CameraImpl::focus_auto_async(int32_t component_id, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_auto(component_id);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
+void CameraImpl::focus_auto_single_async(
+    int32_t component_id, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_auto_single(component_id);
+
+    _system_impl->send_command_async(
+        cmd, [this, callback](MavlinkCommandSender::Result result, float) {
+            receive_command_result(result, callback);
+        });
+}
+
+void CameraImpl::focus_auto_continuous_async(
+    int32_t component_id, const Camera::ResultCallback& callback)
+{
+    auto cmd = make_command_focus_auto_continuous(component_id);
 
     _system_impl->send_command_async(
         cmd, [this, callback](MavlinkCommandSender::Result result, float) {

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
@@ -55,6 +55,10 @@ public:
     Camera::Result focus_out_start(int32_t camera_id);
     Camera::Result focus_stop(int32_t camera_id);
     Camera::Result focus_range(int32_t camera_id, float range);
+    Camera::Result focus_meters(int32_t camera_id, float distance_m);
+    Camera::Result focus_auto(int32_t camera_id);
+    Camera::Result focus_auto_single(int32_t camera_id);
+    Camera::Result focus_auto_continuous(int32_t camera_id);
 
     void zoom_in_start_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void zoom_out_start_async(int32_t camera_id, const Camera::ResultCallback& callback);
@@ -82,6 +86,11 @@ public:
     void focus_out_start_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void focus_stop_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void focus_range_async(int32_t camera_id, float range, const Camera::ResultCallback& callback);
+    void focus_meters_async(
+        int32_t camera_id, float distance_m, const Camera::ResultCallback& callback);
+    void focus_auto_async(int32_t camera_id, const Camera::ResultCallback& callback);
+    void focus_auto_single_async(int32_t camera_id, const Camera::ResultCallback& callback);
+    void focus_auto_continuous_async(int32_t camera_id, const Camera::ResultCallback& callback);
 
     void take_photo_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void start_photo_interval_async(
@@ -349,6 +358,11 @@ private:
     MavlinkCommandSender::CommandLong make_command_focus_out_start(int32_t camera_id);
     MavlinkCommandSender::CommandLong make_command_focus_stop(int32_t camera_id);
     MavlinkCommandSender::CommandLong make_command_focus_range(int32_t camera_id, float range);
+    MavlinkCommandSender::CommandLong
+    make_command_focus_meters(int32_t camera_id, float distance_m);
+    MavlinkCommandSender::CommandLong make_command_focus_auto(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_auto_single(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_auto_continuous(int32_t camera_id);
 
     void request_slower();
     void request_faster();

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.hpp
@@ -49,6 +49,8 @@ public:
         float bottom_right_x,
         float bottom_right_y);
     Camera::Result track_stop(int32_t camera_id);
+    Camera::Result focus_in_step(int32_t camera_id);
+    Camera::Result focus_out_step(int32_t camera_id);
     Camera::Result focus_in_start(int32_t camera_id);
     Camera::Result focus_out_start(int32_t camera_id);
     Camera::Result focus_stop(int32_t camera_id);
@@ -73,7 +75,9 @@ public:
         float bottom_right_y,
         const Camera::ResultCallback& callback);
     void track_stop_async(int32_t camera_id, const Camera::ResultCallback& callback);
-
+    
+    void focus_in_step_async(int32_t camera_id, const Camera::ResultCallback& callback);
+    void focus_out_step_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void focus_in_start_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void focus_out_start_async(int32_t camera_id, const Camera::ResultCallback& callback);
     void focus_stop_async(int32_t camera_id, const Camera::ResultCallback& callback);
@@ -339,8 +343,10 @@ private:
         float bottom_right_x,
         float bottom_right_y);
     MavlinkCommandSender::CommandLong make_command_track_stop(int32_t camera_id);
-    MavlinkCommandSender::CommandLong make_command_focus_in(int32_t camera_id);
-    MavlinkCommandSender::CommandLong make_command_focus_out(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_in_step(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_out_step(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_in_start(int32_t camera_id);
+    MavlinkCommandSender::CommandLong make_command_focus_out_start(int32_t camera_id);
     MavlinkCommandSender::CommandLong make_command_focus_stop(int32_t camera_id);
     MavlinkCommandSender::CommandLong make_command_focus_range(int32_t camera_id, float range);
 

--- a/cpp/src/mavsdk/plugins/camera/include/plugins/camera/camera.hpp
+++ b/cpp/src/mavsdk/plugins/camera/include/plugins/camera/camera.hpp
@@ -1511,6 +1511,52 @@ public:
 
 
     /**
+     * @brief Step focus in.
+     *
+     * This function is non-blocking. See 'focus_in_step' for the blocking counterpart.
+     */
+    void focus_in_step_async(int32_t component_id, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Step focus in.
+     *
+     * This function is blocking. See 'focus_in_step_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_in_step(int32_t component_id) const;
+
+
+
+
+    /**
+     * @brief Step focus out.
+     *
+     * This function is non-blocking. See 'focus_out_step' for the blocking counterpart.
+     */
+    void focus_out_step_async(int32_t component_id, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Step focus out.
+     *
+     * This function is blocking. See 'focus_out_step_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_out_step(int32_t component_id) const;
+
+
+
+
+    /**
      * @brief Start focusing in.
      *
      * This function is non-blocking. See 'focus_in_start' for the blocking counterpart.

--- a/cpp/src/mavsdk/plugins/camera/include/plugins/camera/camera.hpp
+++ b/cpp/src/mavsdk/plugins/camera/include/plugins/camera/camera.hpp
@@ -1649,6 +1649,104 @@ public:
 
 
     /**
+     * @brief Focus at a distance in meters.
+     *
+     * Note that there is no message to get the valid focus range of the camera,
+     * so this can only be used for cameras where the range is known.
+     *
+     * This function is non-blocking. See 'focus_meters' for the blocking counterpart.
+     */
+    void focus_meters_async(int32_t component_id, float distance_m, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Focus at a distance in meters.
+     *
+     * Note that there is no message to get the valid focus range of the camera,
+     * so this can only be used for cameras where the range is known.
+     *
+     * This function is blocking. See 'focus_meters_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_meters(int32_t component_id, float distance_m) const;
+
+
+
+
+    /**
+     * @brief Focus automatically.
+     *
+     * This function is non-blocking. See 'focus_auto' for the blocking counterpart.
+     */
+    void focus_auto_async(int32_t component_id, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Focus automatically.
+     *
+     * This function is blocking. See 'focus_auto_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_auto(int32_t component_id) const;
+
+
+
+
+    /**
+     * @brief Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+     *
+     * This function is non-blocking. See 'focus_auto_single' for the blocking counterpart.
+     */
+    void focus_auto_single_async(int32_t component_id, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+     *
+     * This function is blocking. See 'focus_auto_single_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_auto_single(int32_t component_id) const;
+
+
+
+
+    /**
+     * @brief Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+     *
+     * This function is non-blocking. See 'focus_auto_continuous' for the blocking counterpart.
+     */
+    void focus_auto_continuous_async(int32_t component_id, const ResultCallback callback);
+
+
+
+    /**
+     * @brief Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+     *
+     * This function is blocking. See 'focus_auto_continuous_async' for the non-blocking counterpart.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result focus_auto_continuous(int32_t component_id) const;
+
+
+
+
+    /**
      * @brief Copy constructor.
      */
     Camera(const Camera& other);

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -271,6 +271,105 @@ CameraServer::Result CameraServer::respond_zoom_range(CameraFeedback zoom_range_
     return _impl->respond_zoom_range(zoom_range_feedback);
 }
 
+CameraServer::FocusInStepHandle
+CameraServer::subscribe_focus_in_step(const FocusInStepCallback& callback)
+{
+    return _impl->subscribe_focus_in_step(callback);
+}
+
+void CameraServer::unsubscribe_focus_in_step(FocusInStepHandle handle)
+{
+    _impl->unsubscribe_focus_in_step(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_in_step(CameraFeedback focus_in_step_feedback) const
+{
+    return _impl->respond_focus_in_step(focus_in_step_feedback);
+}
+
+CameraServer::FocusOutStepHandle
+CameraServer::subscribe_focus_out_step(const FocusOutStepCallback& callback)
+{
+    return _impl->subscribe_focus_out_step(callback);
+}
+
+void CameraServer::unsubscribe_focus_out_step(FocusOutStepHandle handle)
+{
+    _impl->unsubscribe_focus_out_step(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_out_step(CameraFeedback focus_out_step_feedback) const
+{
+    return _impl->respond_focus_out_step(focus_out_step_feedback);
+}
+
+CameraServer::FocusInStartHandle
+CameraServer::subscribe_focus_in_start(const FocusInStartCallback& callback)
+{
+    return _impl->subscribe_focus_in_start(callback);
+}
+
+void CameraServer::unsubscribe_focus_in_start(FocusInStartHandle handle)
+{
+    _impl->unsubscribe_focus_in_start(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_in_start(CameraFeedback focus_in_start_feedback) const
+{
+    return _impl->respond_focus_in_start(focus_in_start_feedback);
+}
+
+CameraServer::FocusOutStartHandle
+CameraServer::subscribe_focus_out_start(const FocusOutStartCallback& callback)
+{
+    return _impl->subscribe_focus_out_start(callback);
+}
+
+void CameraServer::unsubscribe_focus_out_start(FocusOutStartHandle handle)
+{
+    _impl->unsubscribe_focus_out_start(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_out_start(CameraFeedback focus_out_start_feedback) const
+{
+    return _impl->respond_focus_out_start(focus_out_start_feedback);
+}
+
+CameraServer::FocusStopHandle CameraServer::subscribe_focus_stop(const FocusStopCallback& callback)
+{
+    return _impl->subscribe_focus_stop(callback);
+}
+
+void CameraServer::unsubscribe_focus_stop(FocusStopHandle handle)
+{
+    _impl->unsubscribe_focus_stop(handle);
+}
+
+CameraServer::Result CameraServer::respond_focus_stop(CameraFeedback focus_stop_feedback) const
+{
+    return _impl->respond_focus_stop(focus_stop_feedback);
+}
+
+CameraServer::FocusRangeHandle
+CameraServer::subscribe_focus_range(const FocusRangeCallback& callback)
+{
+    return _impl->subscribe_focus_range(callback);
+}
+
+void CameraServer::unsubscribe_focus_range(FocusRangeHandle handle)
+{
+    _impl->unsubscribe_focus_range(handle);
+}
+
+CameraServer::Result CameraServer::respond_focus_range(CameraFeedback focus_range_feedback) const
+{
+    return _impl->respond_focus_range(focus_range_feedback);
+}
+
 void CameraServer::set_tracking_rectangle_status(TrackRectangle tracked_rectangle) const
 {
     _impl->set_tracking_rectangle_status(tracked_rectangle);

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server.cpp
@@ -370,6 +370,71 @@ CameraServer::Result CameraServer::respond_focus_range(CameraFeedback focus_rang
     return _impl->respond_focus_range(focus_range_feedback);
 }
 
+CameraServer::FocusMetersHandle
+CameraServer::subscribe_focus_meters(const FocusMetersCallback& callback)
+{
+    return _impl->subscribe_focus_meters(callback);
+}
+
+void CameraServer::unsubscribe_focus_meters(FocusMetersHandle handle)
+{
+    _impl->unsubscribe_focus_meters(handle);
+}
+
+CameraServer::Result CameraServer::respond_focus_meters(CameraFeedback focus_meters_feedback) const
+{
+    return _impl->respond_focus_meters(focus_meters_feedback);
+}
+
+CameraServer::FocusAutoHandle CameraServer::subscribe_focus_auto(const FocusAutoCallback& callback)
+{
+    return _impl->subscribe_focus_auto(callback);
+}
+
+void CameraServer::unsubscribe_focus_auto(FocusAutoHandle handle)
+{
+    _impl->unsubscribe_focus_auto(handle);
+}
+
+CameraServer::Result CameraServer::respond_focus_auto(CameraFeedback focus_auto_feedback) const
+{
+    return _impl->respond_focus_auto(focus_auto_feedback);
+}
+
+CameraServer::FocusAutoSingleHandle
+CameraServer::subscribe_focus_auto_single(const FocusAutoSingleCallback& callback)
+{
+    return _impl->subscribe_focus_auto_single(callback);
+}
+
+void CameraServer::unsubscribe_focus_auto_single(FocusAutoSingleHandle handle)
+{
+    _impl->unsubscribe_focus_auto_single(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_auto_single(CameraFeedback focus_auto_single_feedback) const
+{
+    return _impl->respond_focus_auto_single(focus_auto_single_feedback);
+}
+
+CameraServer::FocusAutoContinuousHandle
+CameraServer::subscribe_focus_auto_continuous(const FocusAutoContinuousCallback& callback)
+{
+    return _impl->subscribe_focus_auto_continuous(callback);
+}
+
+void CameraServer::unsubscribe_focus_auto_continuous(FocusAutoContinuousHandle handle)
+{
+    _impl->unsubscribe_focus_auto_continuous(handle);
+}
+
+CameraServer::Result
+CameraServer::respond_focus_auto_continuous(CameraFeedback focus_auto_continuous_feedback) const
+{
+    return _impl->respond_focus_auto_continuous(focus_auto_continuous_feedback);
+}
+
 void CameraServer::set_tracking_rectangle_status(TrackRectangle tracked_rectangle) const
 {
     _impl->set_tracking_rectangle_status(tracked_rectangle);

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1656,7 +1656,7 @@ CameraServerImpl::process_set_camera_zoom(const MavlinkCommandReceiver::CommandL
                 if (_zoom_out_start_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_zoom_out_start_command = command;
                     int dummy = 0;
@@ -1668,7 +1668,7 @@ CameraServerImpl::process_set_camera_zoom(const MavlinkCommandReceiver::CommandL
                 if (_zoom_in_start_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_zoom_in_start_command = command;
                     int dummy = 0;
@@ -1680,7 +1680,7 @@ CameraServerImpl::process_set_camera_zoom(const MavlinkCommandReceiver::CommandL
                 if (_zoom_stop_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_zoom_stop_command = command;
                     int dummy = 0;
@@ -1698,7 +1698,7 @@ CameraServerImpl::process_set_camera_zoom(const MavlinkCommandReceiver::CommandL
             if (_zoom_range_callbacks.empty()) {
                 unsupported();
                 return _server_component_impl->make_command_ack_message(
-                    command, MAV_RESULT::MAV_RESULT_DENIED);
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
 
             } else {
                 _last_zoom_range_command = command;

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1746,27 +1746,28 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
 
     switch (focus_type) {
         case FOCUS_TYPE_STEP:
+            // Negative: In, Positive: Out
             if (focus_value == -1.f) {
-                if (_focus_out_step_callbacks.empty()) {
-                    unsupported();
-                    return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
-                } else {
-                    _last_focus_out_step_command = command;
-                    int dummy = 0;
-                    _focus_out_step_callbacks.queue(dummy, [this](const auto& func) {
-                        _server_component_impl->call_user_callback(func);
-                    });
-                }
-            } else if (focus_value == 1.f) {
                 if (_focus_in_step_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_focus_in_step_command = command;
                     int dummy = 0;
                     _focus_in_step_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else if (focus_value == 1.f) {
+                if (_focus_out_step_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+                } else {
+                    _last_focus_out_step_command = command;
+                    int dummy = 0;
+                    _focus_out_step_callbacks.queue(dummy, [this](const auto& func) {
                         _server_component_impl->call_user_callback(func);
                     });
                 }
@@ -1777,23 +1778,12 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
             }
             break;
         case FOCUS_TYPE_CONTINUOUS:
+            // Negative: In, Positive: Out, 0: Stop
             if (focus_value == -1.f) {
-                if (_focus_out_start_callbacks.empty()) {
-                    unsupported();
-                    return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
-                } else {
-                    _last_focus_out_start_command = command;
-                    int dummy = 0;
-                    _focus_out_start_callbacks.queue(dummy, [this](const auto& func) {
-                        _server_component_impl->call_user_callback(func);
-                    });
-                }
-            } else if (focus_value == 1.f) {
                 if (_focus_in_start_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_focus_in_start_command = command;
                     int dummy = 0;
@@ -1801,11 +1791,23 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
                         _server_component_impl->call_user_callback(func);
                     });
                 }
+            } else if (focus_value == 1.f) {
+                if (_focus_out_start_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+                } else {
+                    _last_focus_out_start_command = command;
+                    int dummy = 0;
+                    _focus_out_start_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
             } else if (focus_value == 0.f) {
                 if (_focus_stop_callbacks.empty()) {
                     unsupported();
                     return _server_component_impl->make_command_ack_message(
-                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
                 } else {
                     _last_focus_stop_command = command;
                     int dummy = 0;
@@ -1823,7 +1825,7 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
             if (_focus_range_callbacks.empty()) {
                 unsupported();
                 return _server_component_impl->make_command_ack_message(
-                    command, MAV_RESULT::MAV_RESULT_DENIED);
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
 
             } else {
                 if (focus_value < 0.0f || focus_value > 100.0f) {
@@ -1839,25 +1841,20 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
             break;
         case FOCUS_TYPE_METERS:
             // Fallthrough
-            break;
         case FOCUS_TYPE_AUTO:
             // Fallthrough
-            break;
         case FOCUS_TYPE_AUTO_SINGLE:
             // Fallthrough
-            break;
         case FOCUS_TYPE_AUTO_CONTINUOUS:
             // Fallthrough
-            break;
         default:
             unsupported();
             return _server_component_impl->make_command_ack_message(
                 command, MAV_RESULT::MAV_RESULT_DENIED);
-            break;
     }
 
-    return _server_component_impl->make_command_ack_message(
-        command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+    // For any success so far, we don't ack yet, but later when the respond function is called.
+    return std::nullopt;
 }
 
 std::optional<mavlink_command_ack_t>

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -1826,6 +1826,11 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
                     command, MAV_RESULT::MAV_RESULT_DENIED);
 
             } else {
+                if (focus_value < 0.0f || focus_value > 100.0f) {
+                    LogWarn("Invalid focus range value: {}", focus_value);
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                }
                 _last_focus_range_command = command;
                 _focus_range_callbacks.queue(focus_value, [this](const auto& func) {
                     _server_component_impl->call_user_callback(func);

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -194,6 +194,12 @@ void CameraServerImpl::deinit()
     _zoom_out_start_callbacks.clear();
     _zoom_stop_callbacks.clear();
     _zoom_range_callbacks.clear();
+    _focus_in_step_callbacks.clear();
+    _focus_out_step_callbacks.clear();
+    _focus_in_start_callbacks.clear();
+    _focus_out_start_callbacks.clear();
+    _focus_stop_callbacks.clear();
+    _focus_range_callbacks.clear();
 }
 
 bool CameraServerImpl::is_command_sender_ok(const MavlinkCommandReceiver::CommandLong& command)
@@ -1213,6 +1219,12 @@ CameraServerImpl::send_camera_information(const MavlinkCommandReceiver::CommandL
         capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM;
     }
 
+    if (!_focus_in_step_callbacks.empty() || !_focus_out_step_callbacks.empty() ||
+        !_focus_in_start_callbacks.empty() || !_focus_out_start_callbacks.empty() ||
+        !_focus_stop_callbacks.empty() || !_focus_range_callbacks.empty()) {
+        capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;
+    }
+
     _information.vendor_name.resize(sizeof(mavlink_camera_information_t::vendor_name));
     _information.model_name.resize(sizeof(mavlink_camera_information_t::model_name));
     _information.definition_file_uri.resize(
@@ -1718,10 +1730,126 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
     auto focus_type = static_cast<SET_FOCUS_TYPE>(command.params.param1);
     auto focus_value = command.params.param2;
 
-    UNUSED(focus_type);
-    UNUSED(focus_value);
+    std::lock_guard<std::mutex> lg{_mutex};
 
-    LogDebug("Unsupported set camera focus request");
+    if (_focus_in_step_callbacks.empty() && _focus_out_step_callbacks.empty() &&
+        _focus_in_start_callbacks.empty() && _focus_out_start_callbacks.empty() &&
+        _focus_stop_callbacks.empty() && _focus_range_callbacks.empty()) {
+        LogWarn("No camera focus is supported");
+        return _server_component_impl->make_command_ack_message(
+            command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+    }
+
+    auto unsupported = [&]() {
+        LogWarn("Unsupported set camera focus type ({}) request", (int)focus_type);
+    };
+
+    switch (focus_type) {
+        case FOCUS_TYPE_STEP:
+            if (focus_value == -1.f) {
+                if (_focus_out_step_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                } else {
+                    _last_focus_out_step_command = command;
+                    int dummy = 0;
+                    _focus_out_step_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else if (focus_value == 1.f) {
+                if (_focus_in_step_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                } else {
+                    _last_focus_in_step_command = command;
+                    int dummy = 0;
+                    _focus_in_step_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else {
+                LogWarn("Invalid focus step value: {}", focus_value);
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_DENIED);
+            }
+            break;
+        case FOCUS_TYPE_CONTINUOUS:
+            if (focus_value == -1.f) {
+                if (_focus_out_start_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                } else {
+                    _last_focus_out_start_command = command;
+                    int dummy = 0;
+                    _focus_out_start_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else if (focus_value == 1.f) {
+                if (_focus_in_start_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                } else {
+                    _last_focus_in_start_command = command;
+                    int dummy = 0;
+                    _focus_in_start_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else if (focus_value == 0.f) {
+                if (_focus_stop_callbacks.empty()) {
+                    unsupported();
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                } else {
+                    _last_focus_stop_command = command;
+                    int dummy = 0;
+                    _focus_stop_callbacks.queue(dummy, [this](const auto& func) {
+                        _server_component_impl->call_user_callback(func);
+                    });
+                }
+            } else {
+                LogWarn("Invalid continuous focus value: {}", focus_value);
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_DENIED);
+            }
+            break;
+        case FOCUS_TYPE_RANGE:
+            if (_focus_range_callbacks.empty()) {
+                unsupported();
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_DENIED);
+
+            } else {
+                _last_focus_range_command = command;
+                _focus_range_callbacks.queue(focus_value, [this](const auto& func) {
+                    _server_component_impl->call_user_callback(func);
+                });
+            }
+            break;
+        case FOCUS_TYPE_METERS:
+            // Fallthrough
+            break;
+        case FOCUS_TYPE_AUTO:
+            // Fallthrough
+            break;
+        case FOCUS_TYPE_AUTO_SINGLE:
+            // Fallthrough
+            break;
+        case FOCUS_TYPE_AUTO_CONTINUOUS:
+            // Fallthrough
+            break;
+        default:
+            unsupported();
+            return _server_component_impl->make_command_ack_message(
+                command, MAV_RESULT::MAV_RESULT_DENIED);
+            break;
+    }
 
     return _server_component_impl->make_command_ack_message(
         command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
@@ -2158,6 +2286,264 @@ CameraServerImpl::respond_zoom_range(CameraServer::CameraFeedback zoom_range_fee
         case CameraServer::CameraFeedback::Failed: {
             auto command_ack = _server_component_impl->make_command_ack_message(
                 _last_zoom_range_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusInStepHandle
+CameraServerImpl::subscribe_focus_in_step(const CameraServer::FocusInStepCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_in_step_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_in_step(CameraServer::FocusInStepHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_in_step_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_in_step(CameraServer::CameraFeedback focus_in_step_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_in_step_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_step_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_step_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_step_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusOutStepHandle
+CameraServerImpl::subscribe_focus_out_step(const CameraServer::FocusOutStepCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_out_step_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_out_step(CameraServer::FocusOutStepHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_out_step_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_out_step(CameraServer::CameraFeedback focus_out_step_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_out_step_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_step_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_step_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_step_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusInStartHandle
+CameraServerImpl::subscribe_focus_in_start(const CameraServer::FocusInStartCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_in_start_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_in_start(CameraServer::FocusInStartHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_in_start_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_in_start(CameraServer::CameraFeedback focus_in_start_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_in_start_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_start_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_start_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_in_start_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusOutStartHandle
+CameraServerImpl::subscribe_focus_out_start(const CameraServer::FocusOutStartCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_out_start_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_out_start(CameraServer::FocusOutStartHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_out_start_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_out_start(CameraServer::CameraFeedback focus_out_start_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_out_start_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_start_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_start_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_out_start_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusStopHandle
+CameraServerImpl::subscribe_focus_stop(const CameraServer::FocusStopCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_stop_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_stop(CameraServer::FocusStopHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_stop_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_stop(CameraServer::CameraFeedback focus_stop_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_stop_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_stop_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_stop_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_stop_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusRangeHandle
+CameraServerImpl::subscribe_focus_range(const CameraServer::FocusRangeCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_range_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_range(CameraServer::FocusRangeHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_range_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_range(CameraServer::CameraFeedback focus_range_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_range_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_range_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_range_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_range_command, MAV_RESULT_FAILED);
             _server_component_impl->send_command_ack(command_ack);
             return CameraServer::Result::Success;
         }

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.cpp
@@ -200,6 +200,10 @@ void CameraServerImpl::deinit()
     _focus_out_start_callbacks.clear();
     _focus_stop_callbacks.clear();
     _focus_range_callbacks.clear();
+    _focus_meters_callbacks.clear();
+    _focus_auto_callbacks.clear();
+    _focus_auto_single_callbacks.clear();
+    _focus_auto_continuous_callbacks.clear();
 }
 
 bool CameraServerImpl::is_command_sender_ok(const MavlinkCommandReceiver::CommandLong& command)
@@ -1221,7 +1225,9 @@ CameraServerImpl::send_camera_information(const MavlinkCommandReceiver::CommandL
 
     if (!_focus_in_step_callbacks.empty() || !_focus_out_step_callbacks.empty() ||
         !_focus_in_start_callbacks.empty() || !_focus_out_start_callbacks.empty() ||
-        !_focus_stop_callbacks.empty() || !_focus_range_callbacks.empty()) {
+        !_focus_stop_callbacks.empty() || !_focus_range_callbacks.empty() ||
+        !_focus_meters_callbacks.empty() || !_focus_auto_callbacks.empty() ||
+        !_focus_auto_single_callbacks.empty() || !_focus_auto_continuous_callbacks.empty()) {
         capability_flags |= CAMERA_CAP_FLAGS::CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;
     }
 
@@ -1734,7 +1740,9 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
 
     if (_focus_in_step_callbacks.empty() && _focus_out_step_callbacks.empty() &&
         _focus_in_start_callbacks.empty() && _focus_out_start_callbacks.empty() &&
-        _focus_stop_callbacks.empty() && _focus_range_callbacks.empty()) {
+        _focus_stop_callbacks.empty() && _focus_range_callbacks.empty() &&
+        _focus_meters_callbacks.empty() && _focus_auto_callbacks.empty() &&
+        _focus_auto_single_callbacks.empty() && _focus_auto_continuous_callbacks.empty()) {
         LogWarn("No camera focus is supported");
         return _server_component_impl->make_command_ack_message(
             command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
@@ -1840,13 +1848,65 @@ CameraServerImpl::process_set_camera_focus(const MavlinkCommandReceiver::Command
             }
             break;
         case FOCUS_TYPE_METERS:
-            // Fallthrough
+            if (_focus_meters_callbacks.empty()) {
+                unsupported();
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+
+            } else {
+                if (focus_value < 0.0f) {
+                    LogWarn("Invalid focus meters value: {}", focus_value);
+                    return _server_component_impl->make_command_ack_message(
+                        command, MAV_RESULT::MAV_RESULT_DENIED);
+                }
+                _last_focus_meters_command = command;
+                _focus_meters_callbacks.queue(focus_value, [this](const auto& func) {
+                    _server_component_impl->call_user_callback(func);
+                });
+            }
+            break;
         case FOCUS_TYPE_AUTO:
-            // Fallthrough
+            if (_focus_auto_callbacks.empty()) {
+                unsupported();
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+
+            } else {
+                _last_focus_auto_command = command;
+                int dummy = 0;
+                _focus_auto_callbacks.queue(dummy, [this](const auto& func) {
+                    _server_component_impl->call_user_callback(func);
+                });
+            }
+            break;
         case FOCUS_TYPE_AUTO_SINGLE:
-            // Fallthrough
+            if (_focus_auto_single_callbacks.empty()) {
+                unsupported();
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+
+            } else {
+                _last_focus_auto_single_command = command;
+                int dummy = 0;
+                _focus_auto_single_callbacks.queue(dummy, [this](const auto& func) {
+                    _server_component_impl->call_user_callback(func);
+                });
+            }
+            break;
         case FOCUS_TYPE_AUTO_CONTINUOUS:
-            // Fallthrough
+            if (_focus_auto_continuous_callbacks.empty()) {
+                unsupported();
+                return _server_component_impl->make_command_ack_message(
+                    command, MAV_RESULT::MAV_RESULT_UNSUPPORTED);
+
+            } else {
+                _last_focus_auto_continuous_command = command;
+                int dummy = 0;
+                _focus_auto_continuous_callbacks.queue(dummy, [this](const auto& func) {
+                    _server_component_impl->call_user_callback(func);
+                });
+            }
+            break;
         default:
             unsupported();
             return _server_component_impl->make_command_ack_message(
@@ -2546,6 +2606,179 @@ CameraServerImpl::respond_focus_range(CameraServer::CameraFeedback focus_range_f
         case CameraServer::CameraFeedback::Failed: {
             auto command_ack = _server_component_impl->make_command_ack_message(
                 _last_focus_range_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusMetersHandle
+CameraServerImpl::subscribe_focus_meters(const CameraServer::FocusMetersCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_meters_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_meters(CameraServer::FocusMetersHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_meters_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_meters(CameraServer::CameraFeedback focus_meters_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_meters_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_meters_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_meters_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_meters_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusAutoHandle
+CameraServerImpl::subscribe_focus_auto(const CameraServer::FocusAutoCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_auto_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_auto(CameraServer::FocusAutoHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_auto_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_auto(CameraServer::CameraFeedback focus_auto_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_auto_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusAutoSingleHandle
+CameraServerImpl::subscribe_focus_auto_single(const CameraServer::FocusAutoSingleCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_auto_single_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_auto_single(CameraServer::FocusAutoSingleHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_auto_single_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result
+CameraServerImpl::respond_focus_auto_single(CameraServer::CameraFeedback focus_auto_single_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_auto_single_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_single_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_single_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_single_command, MAV_RESULT_FAILED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Unknown:
+            // Fallthrough
+        default:
+            return CameraServer::Result::Error;
+    }
+}
+
+CameraServer::FocusAutoContinuousHandle CameraServerImpl::subscribe_focus_auto_continuous(
+    const CameraServer::FocusAutoContinuousCallback& callback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    return _focus_auto_continuous_callbacks.subscribe(callback);
+}
+
+void CameraServerImpl::unsubscribe_focus_auto_continuous(
+    CameraServer::FocusAutoContinuousHandle handle)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    _focus_auto_continuous_callbacks.unsubscribe(handle);
+}
+
+CameraServer::Result CameraServerImpl::respond_focus_auto_continuous(
+    CameraServer::CameraFeedback focus_auto_continuous_feedback)
+{
+    std::lock_guard<std::mutex> lg{_mutex};
+    switch (focus_auto_continuous_feedback) {
+        case CameraServer::CameraFeedback::Ok: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_continuous_command, MAV_RESULT_ACCEPTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Busy: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_continuous_command, MAV_RESULT_TEMPORARILY_REJECTED);
+            _server_component_impl->send_command_ack(command_ack);
+            return CameraServer::Result::Success;
+        }
+        case CameraServer::CameraFeedback::Failed: {
+            auto command_ack = _server_component_impl->make_command_ack_message(
+                _last_focus_auto_continuous_command, MAV_RESULT_FAILED);
             _server_component_impl->send_command_ack(command_ack);
             return CameraServer::Result::Success;
         }

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
@@ -138,6 +138,26 @@ public:
     void unsubscribe_focus_range(CameraServer::FocusRangeHandle handle);
     CameraServer::Result respond_focus_range(CameraServer::CameraFeedback focus_range_feedback);
 
+    CameraServer::FocusMetersHandle
+    subscribe_focus_meters(const CameraServer::FocusMetersCallback& callback);
+    void unsubscribe_focus_meters(CameraServer::FocusMetersHandle handle);
+    CameraServer::Result respond_focus_meters(CameraServer::CameraFeedback focus_meters_feedback);
+
+    CameraServer::FocusAutoHandle
+    subscribe_focus_auto(const CameraServer::FocusAutoCallback& callback);
+    void unsubscribe_focus_auto(CameraServer::FocusAutoHandle handle);
+    CameraServer::Result respond_focus_auto(CameraServer::CameraFeedback focus_auto_feedback);
+
+    CameraServer::FocusAutoSingleHandle
+    subscribe_focus_auto_single(const CameraServer::FocusAutoSingleCallback& callback);
+    void unsubscribe_focus_auto_single(CameraServer::FocusAutoSingleHandle handle);
+    CameraServer::Result respond_focus_auto_single(CameraServer::CameraFeedback focus_auto_single_feedback);
+
+    CameraServer::FocusAutoContinuousHandle
+    subscribe_focus_auto_continuous(const CameraServer::FocusAutoContinuousCallback& callback);
+    void unsubscribe_focus_auto_continuous(CameraServer::FocusAutoContinuousHandle handle);
+    CameraServer::Result respond_focus_auto_continuous(CameraServer::CameraFeedback focus_auto_continuous_feedback);
+
     CameraServer::TrackingPointCommandHandle
     subscribe_tracking_point_command(const CameraServer::TrackingPointCommandCallback& callback);
     void unsubscribe_tracking_point_command(CameraServer::TrackingPointCommandHandle handle);
@@ -325,6 +345,10 @@ private:
     CallbackList<int32_t> _focus_out_start_callbacks{_server_component_impl->io_context()};
     CallbackList<int32_t> _focus_stop_callbacks{_server_component_impl->io_context()};
     CallbackList<float> _focus_range_callbacks{_server_component_impl->io_context()};
+    CallbackList<float> _focus_meters_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_auto_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_auto_single_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_auto_continuous_callbacks{_server_component_impl->io_context()};
     
     MavlinkCommandReceiver::CommandLong _last_focus_in_step_command;
     MavlinkCommandReceiver::CommandLong _last_focus_out_step_command;
@@ -332,6 +356,10 @@ private:
     MavlinkCommandReceiver::CommandLong _last_focus_out_start_command;
     MavlinkCommandReceiver::CommandLong _last_focus_stop_command;
     MavlinkCommandReceiver::CommandLong _last_focus_range_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_meters_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_auto_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_auto_single_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_auto_continuous_command;
 
     MavlinkCommandReceiver::CommandLong _last_zoom_in_start_command;
     MavlinkCommandReceiver::CommandLong _last_zoom_out_start_command;

--- a/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/camera_server_impl.hpp
@@ -104,6 +104,40 @@ public:
     subscribe_zoom_range(const CameraServer::ZoomRangeCallback& callback);
     void unsubscribe_zoom_range(CameraServer::ZoomRangeHandle handle);
     CameraServer::Result respond_zoom_range(CameraServer::CameraFeedback zoom_range_feedback);
+
+    CameraServer::FocusInStepHandle
+    subscribe_focus_in_step(const CameraServer::FocusInStepCallback& callback);
+    void unsubscribe_focus_in_step(CameraServer::FocusInStepHandle handle);
+    CameraServer::Result respond_focus_in_step(CameraServer::CameraFeedback focus_in_step_feedback);
+    
+    CameraServer::FocusOutStepHandle
+    subscribe_focus_out_step(const CameraServer::FocusOutStepCallback& callback);
+    void unsubscribe_focus_out_step(CameraServer::FocusOutStepHandle handle);
+    CameraServer::Result
+    respond_focus_out_step(CameraServer::CameraFeedback focus_out_step_feedback);
+
+    CameraServer::FocusInStartHandle
+    subscribe_focus_in_start(const CameraServer::FocusInStartCallback& callback);
+    void unsubscribe_focus_in_start(CameraServer::FocusInStartHandle handle);
+    CameraServer::Result
+    respond_focus_in_start(CameraServer::CameraFeedback focus_in_start_feedback);
+
+    CameraServer::FocusOutStartHandle
+    subscribe_focus_out_start(const CameraServer::FocusOutStartCallback& callback);
+    void unsubscribe_focus_out_start(CameraServer::FocusOutStartHandle handle);
+    CameraServer::Result
+    respond_focus_out_start(CameraServer::CameraFeedback focus_out_start_feedback);
+
+    CameraServer::FocusStopHandle
+    subscribe_focus_stop(const CameraServer::FocusStopCallback& callback);
+    void unsubscribe_focus_stop(CameraServer::FocusStopHandle handle);
+    CameraServer::Result respond_focus_stop(CameraServer::CameraFeedback focus_stop_feedback);
+
+    CameraServer::FocusRangeHandle
+    subscribe_focus_range(const CameraServer::FocusRangeCallback& callback);
+    void unsubscribe_focus_range(CameraServer::FocusRangeHandle handle);
+    CameraServer::Result respond_focus_range(CameraServer::CameraFeedback focus_range_feedback);
+
     CameraServer::TrackingPointCommandHandle
     subscribe_tracking_point_command(const CameraServer::TrackingPointCommandCallback& callback);
     void unsubscribe_tracking_point_command(CameraServer::TrackingPointCommandHandle handle);
@@ -284,6 +318,20 @@ private:
     CallbackList<int32_t> _zoom_out_start_callbacks{_server_component_impl->io_context()};
     CallbackList<int32_t> _zoom_stop_callbacks{_server_component_impl->io_context()};
     CallbackList<float> _zoom_range_callbacks{_server_component_impl->io_context()};
+    
+    CallbackList<int32_t> _focus_in_step_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_out_step_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_in_start_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_out_start_callbacks{_server_component_impl->io_context()};
+    CallbackList<int32_t> _focus_stop_callbacks{_server_component_impl->io_context()};
+    CallbackList<float> _focus_range_callbacks{_server_component_impl->io_context()};
+    
+    MavlinkCommandReceiver::CommandLong _last_focus_in_step_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_out_step_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_in_start_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_out_start_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_stop_command;
+    MavlinkCommandReceiver::CommandLong _last_focus_range_command;
 
     MavlinkCommandReceiver::CommandLong _last_zoom_in_start_command;
     MavlinkCommandReceiver::CommandLong _last_zoom_out_start_command;

--- a/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
@@ -1462,6 +1462,186 @@ public:
 
 
 
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_meters.
+     */
+    using FocusMetersCallback = std::function<void(float)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_meters.
+     */
+    using FocusMetersHandle = Handle<float>;
+
+    /**
+     * @brief Subscribe to focus meters command.
+     */
+    FocusMetersHandle subscribe_focus_meters(const FocusMetersCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_meters
+     */
+    void unsubscribe_focus_meters(FocusMetersHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus meters.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_meters(CameraFeedback focus_meters_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_auto.
+     */
+    using FocusAutoCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_auto.
+     */
+    using FocusAutoHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus auto command.
+     */
+    FocusAutoHandle subscribe_focus_auto(const FocusAutoCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_auto
+     */
+    void unsubscribe_focus_auto(FocusAutoHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus auto.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_auto(CameraFeedback focus_auto_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_auto_single.
+     */
+    using FocusAutoSingleCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_auto_single.
+     */
+    using FocusAutoSingleHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus auto single command.
+     */
+    FocusAutoSingleHandle subscribe_focus_auto_single(const FocusAutoSingleCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_auto_single
+     */
+    void unsubscribe_focus_auto_single(FocusAutoSingleHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus auto single.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_auto_single(CameraFeedback focus_auto_single_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_auto_continuous.
+     */
+    using FocusAutoContinuousCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_auto_continuous.
+     */
+    using FocusAutoContinuousHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus auto continuous command.
+     */
+    FocusAutoContinuousHandle subscribe_focus_auto_continuous(const FocusAutoContinuousCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_auto_continuous
+     */
+    void unsubscribe_focus_auto_continuous(FocusAutoContinuousHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus auto continuous.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_auto_continuous(CameraFeedback focus_auto_continuous_feedback) const;
+
+
+
+
 
 
     /**

--- a/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
+++ b/cpp/src/mavsdk/plugins/camera_server/include/plugins/camera_server/camera_server.hpp
@@ -1192,6 +1192,276 @@ public:
 
 
 
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_in_step.
+     */
+    using FocusInStepCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_in_step.
+     */
+    using FocusInStepHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus in step command.
+     */
+    FocusInStepHandle subscribe_focus_in_step(const FocusInStepCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_in_step
+     */
+    void unsubscribe_focus_in_step(FocusInStepHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus in step.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_in_step(CameraFeedback focus_in_step_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_out_step.
+     */
+    using FocusOutStepCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_out_step.
+     */
+    using FocusOutStepHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus out step command.
+     */
+    FocusOutStepHandle subscribe_focus_out_step(const FocusOutStepCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_out_step
+     */
+    void unsubscribe_focus_out_step(FocusOutStepHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus out step.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_out_step(CameraFeedback focus_out_step_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_in_start.
+     */
+    using FocusInStartCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_in_start.
+     */
+    using FocusInStartHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus in start command.
+     */
+    FocusInStartHandle subscribe_focus_in_start(const FocusInStartCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_in_start
+     */
+    void unsubscribe_focus_in_start(FocusInStartHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus in start.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_in_start(CameraFeedback focus_in_start_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_out_start.
+     */
+    using FocusOutStartCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_out_start.
+     */
+    using FocusOutStartHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus out start command.
+     */
+    FocusOutStartHandle subscribe_focus_out_start(const FocusOutStartCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_out_start
+     */
+    void unsubscribe_focus_out_start(FocusOutStartHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus out start.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_out_start(CameraFeedback focus_out_start_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_stop.
+     */
+    using FocusStopCallback = std::function<void(int32_t)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_stop.
+     */
+    using FocusStopHandle = Handle<int32_t>;
+
+    /**
+     * @brief Subscribe to focus stop command.
+     */
+    FocusStopHandle subscribe_focus_stop(const FocusStopCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_stop
+     */
+    void unsubscribe_focus_stop(FocusStopHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus stop.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_stop(CameraFeedback focus_stop_feedback) const;
+
+
+
+
+        
+
+    /**
+     * @brief Callback type for subscribe_focus_range.
+     */
+    using FocusRangeCallback = std::function<void(float)>;
+
+    /**
+     * @brief Handle type for subscribe_focus_range.
+     */
+    using FocusRangeHandle = Handle<float>;
+
+    /**
+     * @brief Subscribe to focus range command.
+     */
+    FocusRangeHandle subscribe_focus_range(const FocusRangeCallback& callback);
+
+    /**
+     * @brief Unsubscribe from subscribe_focus_range
+     */
+    void unsubscribe_focus_range(FocusRangeHandle handle);
+
+        
+
+
+
+
+
+
+
+
+    /**
+     * @brief Respond to focus range.
+     *
+     * This function is blocking.
+     *
+     
+     * @return Result of request.
+     
+     */
+    Result respond_focus_range(CameraFeedback focus_range_feedback) const;
+
+
+
+
 
 
     /**

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
@@ -62,6 +62,10 @@ static const char* CameraService_method_names[] = {
   "/mavsdk.rpc.camera.CameraService/FocusOutStart",
   "/mavsdk.rpc.camera.CameraService/FocusStop",
   "/mavsdk.rpc.camera.CameraService/FocusRange",
+  "/mavsdk.rpc.camera.CameraService/FocusMeters",
+  "/mavsdk.rpc.camera.CameraService/FocusAuto",
+  "/mavsdk.rpc.camera.CameraService/FocusAutoSingle",
+  "/mavsdk.rpc.camera.CameraService/FocusAutoContinuous",
 };
 
 std::unique_ptr< CameraService::Stub> CameraService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
@@ -109,6 +113,10 @@ CameraService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_FocusOutStart_(CameraService_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_FocusStop_(CameraService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_FocusRange_(CameraService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusMeters_(CameraService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusAuto_(CameraService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusAutoSingle_(CameraService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusAutoContinuous_(CameraService_method_names[41], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraService::Stub::TakePhoto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TakePhotoRequest& request, ::mavsdk::rpc::camera::TakePhotoResponse* response) {
@@ -936,6 +944,98 @@ void CameraService::Stub::async::FocusRange(::grpc::ClientContext* context, cons
   return result;
 }
 
+::grpc::Status CameraService::Stub::FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::mavsdk::rpc::camera::FocusMetersResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusMeters_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusMeters_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusMeters_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>* CameraService::Stub::PrepareAsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusMetersResponse, ::mavsdk::rpc::camera::FocusMetersRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusMeters_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>* CameraService::Stub::AsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusMetersRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraService::Stub::FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::mavsdk::rpc::camera::FocusAutoResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusAuto_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAuto_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAuto_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>* CameraService::Stub::PrepareAsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusAutoResponse, ::mavsdk::rpc::camera::FocusAutoRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusAuto_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>* CameraService::Stub::AsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusAutoRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraService::Stub::FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusAutoSingle_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAutoSingle_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAutoSingle_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* CameraService::Stub::PrepareAsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusAutoSingleResponse, ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusAutoSingle_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* CameraService::Stub::AsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusAutoSingleRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraService::Stub::FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusAutoContinuous_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAutoContinuous_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusAutoContinuous_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* CameraService::Stub::PrepareAsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusAutoContinuousResponse, ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusAutoContinuous_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* CameraService::Stub::AsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusAutoContinuousRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 CameraService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraService_method_names[0],
@@ -1317,6 +1417,46 @@ CameraService::Service::Service() {
              ::mavsdk::rpc::camera::FocusRangeResponse* resp) {
                return service->FocusRange(ctx, req, resp);
              }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[38],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusMetersRequest* req,
+             ::mavsdk::rpc::camera::FocusMetersResponse* resp) {
+               return service->FocusMeters(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[39],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusAutoRequest* req,
+             ::mavsdk::rpc::camera::FocusAutoResponse* resp) {
+               return service->FocusAuto(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[40],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusAutoSingleRequest* req,
+             ::mavsdk::rpc::camera::FocusAutoSingleResponse* resp) {
+               return service->FocusAutoSingle(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[41],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* req,
+             ::mavsdk::rpc::camera::FocusAutoContinuousResponse* resp) {
+               return service->FocusAutoContinuous(ctx, req, resp);
+             }, this)));
 }
 
 CameraService::Service::~Service() {
@@ -1582,6 +1722,34 @@ CameraService::Service::~Service() {
 }
 
 ::grpc::Status CameraService::Service::FocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.cc
@@ -56,6 +56,8 @@ static const char* CameraService_method_names[] = {
   "/mavsdk.rpc.camera.CameraService/TrackPoint",
   "/mavsdk.rpc.camera.CameraService/TrackRectangle",
   "/mavsdk.rpc.camera.CameraService/TrackStop",
+  "/mavsdk.rpc.camera.CameraService/FocusInStep",
+  "/mavsdk.rpc.camera.CameraService/FocusOutStep",
   "/mavsdk.rpc.camera.CameraService/FocusInStart",
   "/mavsdk.rpc.camera.CameraService/FocusOutStart",
   "/mavsdk.rpc.camera.CameraService/FocusStop",
@@ -101,10 +103,12 @@ CameraService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& chan
   , rpcmethod_TrackPoint_(CameraService_method_names[29], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_TrackRectangle_(CameraService_method_names[30], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_TrackStop_(CameraService_method_names[31], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_FocusInStart_(CameraService_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_FocusOutStart_(CameraService_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_FocusStop_(CameraService_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_FocusRange_(CameraService_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusInStep_(CameraService_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusOutStep_(CameraService_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusInStart_(CameraService_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusOutStart_(CameraService_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusStop_(CameraService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_FocusRange_(CameraService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraService::Stub::TakePhoto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TakePhotoRequest& request, ::mavsdk::rpc::camera::TakePhotoResponse* response) {
@@ -794,6 +798,52 @@ void CameraService::Stub::async::TrackStop(::grpc::ClientContext* context, const
   return result;
 }
 
+::grpc::Status CameraService::Stub::FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::mavsdk::rpc::camera::FocusInStepResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusInStep_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusInStep_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusInStep_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>* CameraService::Stub::PrepareAsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusInStepResponse, ::mavsdk::rpc::camera::FocusInStepRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusInStep_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>* CameraService::Stub::AsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusInStepRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status CameraService::Stub::FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::mavsdk::rpc::camera::FocusOutStepResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusOutStep_, context, request, response);
+}
+
+void CameraService::Stub::async::FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusOutStep_, context, request, response, std::move(f));
+}
+
+void CameraService::Stub::async::FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_FocusOutStep_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>* CameraService::Stub::PrepareAsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera::FocusOutStepResponse, ::mavsdk::rpc::camera::FocusOutStepRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_FocusOutStep_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>* CameraService::Stub::AsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncFocusOutStepRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ::grpc::Status CameraService::Stub::FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::mavsdk::rpc::camera::FocusInStartResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_FocusInStart_, context, request, response);
 }
@@ -1210,6 +1260,26 @@ CameraService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraService_method_names[32],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusInStepRequest* req,
+             ::mavsdk::rpc::camera::FocusInStepResponse* resp) {
+               return service->FocusInStep(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[33],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera::FocusOutStepRequest* req,
+             ::mavsdk::rpc::camera::FocusOutStepResponse* resp) {
+               return service->FocusOutStep(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraService_method_names[34],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
              ::grpc::ServerContext* ctx,
@@ -1218,7 +1288,7 @@ CameraService::Service::Service() {
                return service->FocusInStart(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[33],
+      CameraService_method_names[35],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusOutStartRequest, ::mavsdk::rpc::camera::FocusOutStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -1228,7 +1298,7 @@ CameraService::Service::Service() {
                return service->FocusOutStart(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[34],
+      CameraService_method_names[36],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusStopRequest, ::mavsdk::rpc::camera::FocusStopResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -1238,7 +1308,7 @@ CameraService::Service::Service() {
                return service->FocusStop(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraService_method_names[35],
+      CameraService_method_names[37],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraService::Service, ::mavsdk::rpc::camera::FocusRangeRequest, ::mavsdk::rpc::camera::FocusRangeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraService::Service* service,
@@ -1470,6 +1540,20 @@ CameraService::Service::~Service() {
 }
 
 ::grpc::Status CameraService::Service::TrackStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraService::Service::FocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
@@ -416,6 +416,45 @@ class CameraService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusRangeResponse>> PrepareAsyncFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusRangeResponse>>(PrepareAsyncFocusRangeRaw(context, request, cq));
     }
+    //
+    // Focus at a distance in meters.
+    //
+    // Note that there is no message to get the valid focus range of the camera,
+    // so this can only be used for cameras where the range is known.
+    virtual ::grpc::Status FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::mavsdk::rpc::camera::FocusMetersResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>> AsyncFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>>(AsyncFocusMetersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>> PrepareAsyncFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>>(PrepareAsyncFocusMetersRaw(context, request, cq));
+    }
+    //
+    // Focus automatically.
+    virtual ::grpc::Status FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::mavsdk::rpc::camera::FocusAutoResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>> AsyncFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>>(AsyncFocusAutoRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>> PrepareAsyncFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>>(PrepareAsyncFocusAutoRaw(context, request, cq));
+    }
+    //
+    // Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+    virtual ::grpc::Status FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>> AsyncFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>>(AsyncFocusAutoSingleRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>> PrepareAsyncFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>>(PrepareAsyncFocusAutoSingleRaw(context, request, cq));
+    }
+    //
+    // Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+    virtual ::grpc::Status FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>> AsyncFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>>(AsyncFocusAutoContinuousRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>> PrepareAsyncFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>>(PrepareAsyncFocusAutoContinuousRaw(context, request, cq));
+    }
     class async_interface {
      public:
       virtual ~async_interface() {}
@@ -579,6 +618,25 @@ class CameraService final {
       // Focus with range value of full range (value between 0.0 and 100.0).
       virtual void FocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void FocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Focus at a distance in meters.
+      //
+      // Note that there is no message to get the valid focus range of the camera,
+      // so this can only be used for cameras where the range is known.
+      virtual void FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Focus automatically.
+      virtual void FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+      virtual void FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+      virtual void FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
     };
     typedef class async_interface experimental_async_interface;
     virtual class async_interface* async() { return nullptr; }
@@ -667,6 +725,14 @@ class CameraService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusStopResponse>* PrepareAsyncFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusRangeResponse>* AsyncFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusRangeResponse>* PrepareAsyncFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>* AsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusMetersResponse>* PrepareAsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>* AsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoResponse>* PrepareAsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* AsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* PrepareAsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* AsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* PrepareAsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
@@ -951,6 +1017,34 @@ class CameraService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusRangeResponse>> PrepareAsyncFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusRangeResponse>>(PrepareAsyncFocusRangeRaw(context, request, cq));
     }
+    ::grpc::Status FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::mavsdk::rpc::camera::FocusMetersResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>> AsyncFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>>(AsyncFocusMetersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>> PrepareAsyncFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>>(PrepareAsyncFocusMetersRaw(context, request, cq));
+    }
+    ::grpc::Status FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::mavsdk::rpc::camera::FocusAutoResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>> AsyncFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>>(AsyncFocusAutoRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>> PrepareAsyncFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>>(PrepareAsyncFocusAutoRaw(context, request, cq));
+    }
+    ::grpc::Status FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>> AsyncFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>>(AsyncFocusAutoSingleRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>> PrepareAsyncFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>>(PrepareAsyncFocusAutoSingleRaw(context, request, cq));
+    }
+    ::grpc::Status FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>> AsyncFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>>(AsyncFocusAutoContinuousRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>> PrepareAsyncFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>>(PrepareAsyncFocusAutoContinuousRaw(context, request, cq));
+    }
     class async final :
       public StubInterface::async_interface {
      public:
@@ -1023,6 +1117,14 @@ class CameraService final {
       void FocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusStopRequest* request, ::mavsdk::rpc::camera::FocusStopResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void FocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response, std::function<void(::grpc::Status)>) override;
       void FocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
      private:
       friend class Stub;
       explicit async(Stub* stub): stub_(stub) { }
@@ -1117,6 +1219,14 @@ class CameraService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusStopResponse>* PrepareAsyncFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusStopRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusRangeResponse>* AsyncFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusRangeResponse>* PrepareAsyncFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>* AsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusMetersResponse>* PrepareAsyncFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>* AsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoResponse>* PrepareAsyncFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* AsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* PrepareAsyncFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* AsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* PrepareAsyncFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_TakePhoto_;
     const ::grpc::internal::RpcMethod rpcmethod_StartPhotoInterval_;
     const ::grpc::internal::RpcMethod rpcmethod_StopPhotoInterval_;
@@ -1155,6 +1265,10 @@ class CameraService final {
     const ::grpc::internal::RpcMethod rpcmethod_FocusOutStart_;
     const ::grpc::internal::RpcMethod rpcmethod_FocusStop_;
     const ::grpc::internal::RpcMethod rpcmethod_FocusRange_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusMeters_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusAuto_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusAutoSingle_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusAutoContinuous_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -1291,6 +1405,21 @@ class CameraService final {
     //
     // Focus with range value of full range (value between 0.0 and 100.0).
     virtual ::grpc::Status FocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response);
+    //
+    // Focus at a distance in meters.
+    //
+    // Note that there is no message to get the valid focus range of the camera,
+    // so this can only be used for cameras where the range is known.
+    virtual ::grpc::Status FocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response);
+    //
+    // Focus automatically.
+    virtual ::grpc::Status FocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response);
+    //
+    // Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+    virtual ::grpc::Status FocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response);
+    //
+    // Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+    virtual ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_TakePhoto : public BaseClass {
@@ -2052,7 +2181,87 @@ class CameraService final {
       ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_ListPhotos<WithAsyncMethod_SubscribeCameraList<WithAsyncMethod_SubscribeMode<WithAsyncMethod_GetMode<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_GetVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStorage<WithAsyncMethod_GetStorage<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_GetCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_GetPossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<WithAsyncMethod_ResetSettings<WithAsyncMethod_ZoomInStart<WithAsyncMethod_ZoomOutStart<WithAsyncMethod_ZoomStop<WithAsyncMethod_ZoomRange<WithAsyncMethod_TrackPoint<WithAsyncMethod_TrackRectangle<WithAsyncMethod_TrackStop<WithAsyncMethod_FocusInStep<WithAsyncMethod_FocusOutStep<WithAsyncMethod_FocusInStart<WithAsyncMethod_FocusOutStart<WithAsyncMethod_FocusStop<WithAsyncMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  template <class BaseClass>
+  class WithAsyncMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodAsync(38);
+    }
+    ~WithAsyncMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusMeters(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusMetersRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusMetersResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodAsync(39);
+    }
+    ~WithAsyncMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAuto(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusAutoRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusAutoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodAsync(40);
+    }
+    ~WithAsyncMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAutoSingle(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusAutoSingleResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodAsync(41);
+    }
+    ~WithAsyncMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAutoContinuous(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_ListPhotos<WithAsyncMethod_SubscribeCameraList<WithAsyncMethod_SubscribeMode<WithAsyncMethod_GetMode<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_GetVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStorage<WithAsyncMethod_GetStorage<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_GetCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_GetPossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<WithAsyncMethod_ResetSettings<WithAsyncMethod_ZoomInStart<WithAsyncMethod_ZoomOutStart<WithAsyncMethod_ZoomStop<WithAsyncMethod_ZoomRange<WithAsyncMethod_TrackPoint<WithAsyncMethod_TrackRectangle<WithAsyncMethod_TrackStop<WithAsyncMethod_FocusInStep<WithAsyncMethod_FocusOutStep<WithAsyncMethod_FocusInStart<WithAsyncMethod_FocusOutStart<WithAsyncMethod_FocusStop<WithAsyncMethod_FocusRange<WithAsyncMethod_FocusMeters<WithAsyncMethod_FocusAuto<WithAsyncMethod_FocusAutoSingle<WithAsyncMethod_FocusAutoContinuous<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_TakePhoto : public BaseClass {
    private:
@@ -3044,7 +3253,115 @@ class CameraService final {
     virtual ::grpc::ServerUnaryReactor* FocusRange(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusRangeRequest* /*request*/, ::mavsdk::rpc::camera::FocusRangeResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_TakePhoto<WithCallbackMethod_StartPhotoInterval<WithCallbackMethod_StopPhotoInterval<WithCallbackMethod_StartVideo<WithCallbackMethod_StopVideo<WithCallbackMethod_StartVideoStreaming<WithCallbackMethod_StopVideoStreaming<WithCallbackMethod_SetMode<WithCallbackMethod_ListPhotos<WithCallbackMethod_SubscribeCameraList<WithCallbackMethod_SubscribeMode<WithCallbackMethod_GetMode<WithCallbackMethod_SubscribeVideoStreamInfo<WithCallbackMethod_GetVideoStreamInfo<WithCallbackMethod_SubscribeCaptureInfo<WithCallbackMethod_SubscribeStorage<WithCallbackMethod_GetStorage<WithCallbackMethod_SubscribeCurrentSettings<WithCallbackMethod_GetCurrentSettings<WithCallbackMethod_SubscribePossibleSettingOptions<WithCallbackMethod_GetPossibleSettingOptions<WithCallbackMethod_SetSetting<WithCallbackMethod_GetSetting<WithCallbackMethod_FormatStorage<WithCallbackMethod_ResetSettings<WithCallbackMethod_ZoomInStart<WithCallbackMethod_ZoomOutStart<WithCallbackMethod_ZoomStop<WithCallbackMethod_ZoomRange<WithCallbackMethod_TrackPoint<WithCallbackMethod_TrackRectangle<WithCallbackMethod_TrackStop<WithCallbackMethod_FocusInStep<WithCallbackMethod_FocusOutStep<WithCallbackMethod_FocusInStart<WithCallbackMethod_FocusOutStart<WithCallbackMethod_FocusStop<WithCallbackMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  template <class BaseClass>
+  class WithCallbackMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodCallback(38,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusMetersRequest* request, ::mavsdk::rpc::camera::FocusMetersResponse* response) { return this->FocusMeters(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusMeters(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(38);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusAutoRequest* request, ::mavsdk::rpc::camera::FocusAutoResponse* response) { return this->FocusAuto(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusAuto(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* request, ::mavsdk::rpc::camera::FocusAutoSingleResponse* response) { return this->FocusAutoSingle(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusAutoSingle(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodCallback(41,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* request, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* response) { return this->FocusAutoContinuous(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusAutoContinuous(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(41);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/)  { return nullptr; }
+  };
+  typedef WithCallbackMethod_TakePhoto<WithCallbackMethod_StartPhotoInterval<WithCallbackMethod_StopPhotoInterval<WithCallbackMethod_StartVideo<WithCallbackMethod_StopVideo<WithCallbackMethod_StartVideoStreaming<WithCallbackMethod_StopVideoStreaming<WithCallbackMethod_SetMode<WithCallbackMethod_ListPhotos<WithCallbackMethod_SubscribeCameraList<WithCallbackMethod_SubscribeMode<WithCallbackMethod_GetMode<WithCallbackMethod_SubscribeVideoStreamInfo<WithCallbackMethod_GetVideoStreamInfo<WithCallbackMethod_SubscribeCaptureInfo<WithCallbackMethod_SubscribeStorage<WithCallbackMethod_GetStorage<WithCallbackMethod_SubscribeCurrentSettings<WithCallbackMethod_GetCurrentSettings<WithCallbackMethod_SubscribePossibleSettingOptions<WithCallbackMethod_GetPossibleSettingOptions<WithCallbackMethod_SetSetting<WithCallbackMethod_GetSetting<WithCallbackMethod_FormatStorage<WithCallbackMethod_ResetSettings<WithCallbackMethod_ZoomInStart<WithCallbackMethod_ZoomOutStart<WithCallbackMethod_ZoomStop<WithCallbackMethod_ZoomRange<WithCallbackMethod_TrackPoint<WithCallbackMethod_TrackRectangle<WithCallbackMethod_TrackStop<WithCallbackMethod_FocusInStep<WithCallbackMethod_FocusOutStep<WithCallbackMethod_FocusInStart<WithCallbackMethod_FocusOutStart<WithCallbackMethod_FocusStop<WithCallbackMethod_FocusRange<WithCallbackMethod_FocusMeters<WithCallbackMethod_FocusAuto<WithCallbackMethod_FocusAutoSingle<WithCallbackMethod_FocusAutoContinuous<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_TakePhoto : public BaseClass {
@@ -3688,6 +4005,74 @@ class CameraService final {
     }
     // disable synchronous version of this method
     ::grpc::Status FocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusRangeRequest* /*request*/, ::mavsdk::rpc::camera::FocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodGeneric(38);
+    }
+    ~WithGenericMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodGeneric(39);
+    }
+    ~WithGenericMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodGeneric(40);
+    }
+    ~WithGenericMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodGeneric(41);
+    }
+    ~WithGenericMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -4450,6 +4835,86 @@ class CameraService final {
     }
     void RequestFocusRange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodRaw(38);
+    }
+    ~WithRawMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusMeters(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodRaw(39);
+    }
+    ~WithRawMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAuto(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodRaw(40);
+    }
+    ~WithRawMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRaw(41);
+    }
+    ~WithRawMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5289,6 +5754,94 @@ class CameraService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodRawCallback(38,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusMeters(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodRawCallback(39,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusAuto(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodRawCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusAutoSingle(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRawCallback(41,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusAutoContinuous(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_TakePhoto : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -6125,7 +6678,115 @@ class CameraService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedFocusRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusRangeRequest,::mavsdk::rpc::camera::FocusRangeResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithStreamedUnaryMethod_GetMode<WithStreamedUnaryMethod_GetVideoStreamInfo<WithStreamedUnaryMethod_GetStorage<WithStreamedUnaryMethod_GetCurrentSettings<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusMeters() {
+      ::grpc::Service::MarkMethodStreamed(38,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusMetersRequest, ::mavsdk::rpc::camera::FocusMetersResponse>* streamer) {
+                       return this->StreamedFocusMeters(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusMetersRequest* /*request*/, ::mavsdk::rpc::camera::FocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusMeters(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusMetersRequest,::mavsdk::rpc::camera::FocusMetersResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusAuto() {
+      ::grpc::Service::MarkMethodStreamed(39,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusAutoRequest, ::mavsdk::rpc::camera::FocusAutoResponse>* streamer) {
+                       return this->StreamedFocusAuto(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusAuto(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusAutoRequest,::mavsdk::rpc::camera::FocusAutoResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusAutoSingle() {
+      ::grpc::Service::MarkMethodStreamed(40,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusAutoSingleRequest, ::mavsdk::rpc::camera::FocusAutoSingleResponse>* streamer) {
+                       return this->StreamedFocusAutoSingle(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusAutoSingleRequest,::mavsdk::rpc::camera::FocusAutoSingleResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusAutoContinuous() {
+      ::grpc::Service::MarkMethodStreamed(41,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusAutoContinuousRequest, ::mavsdk::rpc::camera::FocusAutoContinuousResponse>* streamer) {
+                       return this->StreamedFocusAutoContinuous(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera::FocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusAutoContinuousRequest,::mavsdk::rpc::camera::FocusAutoContinuousResponse>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithStreamedUnaryMethod_GetMode<WithStreamedUnaryMethod_GetVideoStreamInfo<WithStreamedUnaryMethod_GetStorage<WithStreamedUnaryMethod_GetCurrentSettings<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<WithStreamedUnaryMethod_FocusMeters<WithStreamedUnaryMethod_FocusAuto<WithStreamedUnaryMethod_FocusAutoSingle<WithStreamedUnaryMethod_FocusAutoContinuous<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeCameraList : public BaseClass {
    private:
@@ -6316,7 +6977,7 @@ class CameraService final {
     virtual ::grpc::Status StreamedSubscribePossibleSettingOptions(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest,::mavsdk::rpc::camera::PossibleSettingOptionsResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<Service > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithStreamedUnaryMethod_GetMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithStreamedUnaryMethod_GetVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithStreamedUnaryMethod_GetStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithStreamedUnaryMethod_GetCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithStreamedUnaryMethod_GetMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithStreamedUnaryMethod_GetVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithStreamedUnaryMethod_GetStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithStreamedUnaryMethod_GetCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<WithStreamedUnaryMethod_FocusMeters<WithStreamedUnaryMethod_FocusAuto<WithStreamedUnaryMethod_FocusAutoSingle<WithStreamedUnaryMethod_FocusAutoContinuous<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.grpc.pb.h
@@ -363,6 +363,24 @@ class CameraService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::TrackStopResponse>>(PrepareAsyncTrackStopRaw(context, request, cq));
     }
     //
+    // Step focus in.
+    virtual ::grpc::Status FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::mavsdk::rpc::camera::FocusInStepResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>> AsyncFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>>(AsyncFocusInStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>> PrepareAsyncFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>>(PrepareAsyncFocusInStepRaw(context, request, cq));
+    }
+    //
+    // Step focus out.
+    virtual ::grpc::Status FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::mavsdk::rpc::camera::FocusOutStepResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>> AsyncFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>>(AsyncFocusOutStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>> PrepareAsyncFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>>(PrepareAsyncFocusOutStepRaw(context, request, cq));
+    }
+    //
     // Start focusing in.
     virtual ::grpc::Status FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::mavsdk::rpc::camera::FocusInStartResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStartResponse>> AsyncFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
@@ -538,6 +556,14 @@ class CameraService final {
       virtual void TrackStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void TrackStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       //
+      // Step focus in.
+      virtual void FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
+      // Step focus out.
+      virtual void FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      //
       // Start focusing in.
       virtual void FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -629,6 +655,10 @@ class CameraService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::TrackRectangleResponse>* PrepareAsyncTrackRectangleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackRectangleRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::TrackStopResponse>* AsyncTrackStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::TrackStopResponse>* PrepareAsyncTrackStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>* AsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStepResponse>* PrepareAsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>* AsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStepResponse>* PrepareAsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStartResponse>* AsyncFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusInStartResponse>* PrepareAsyncFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera::FocusOutStartResponse>* AsyncFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -879,6 +909,20 @@ class CameraService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::TrackStopResponse>> PrepareAsyncTrackStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::TrackStopResponse>>(PrepareAsyncTrackStopRaw(context, request, cq));
     }
+    ::grpc::Status FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::mavsdk::rpc::camera::FocusInStepResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>> AsyncFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>>(AsyncFocusInStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>> PrepareAsyncFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>>(PrepareAsyncFocusInStepRaw(context, request, cq));
+    }
+    ::grpc::Status FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::mavsdk::rpc::camera::FocusOutStepResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>> AsyncFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>>(AsyncFocusOutStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>> PrepareAsyncFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>>(PrepareAsyncFocusOutStepRaw(context, request, cq));
+    }
     ::grpc::Status FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::mavsdk::rpc::camera::FocusInStartResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStartResponse>> AsyncFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStartResponse>>(AsyncFocusInStartRaw(context, request, cq));
@@ -967,6 +1011,10 @@ class CameraService final {
       void TrackRectangle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackRectangleRequest* request, ::mavsdk::rpc::camera::TrackRectangleResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void TrackStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response, std::function<void(::grpc::Status)>) override;
       void TrackStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, std::function<void(::grpc::Status)>) override;
+      void FocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response, std::function<void(::grpc::Status)>) override;
       void FocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void FocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStartRequest* request, ::mavsdk::rpc::camera::FocusOutStartResponse* response, std::function<void(::grpc::Status)>) override;
@@ -1057,6 +1105,10 @@ class CameraService final {
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::TrackRectangleResponse>* PrepareAsyncTrackRectangleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackRectangleRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::TrackStopResponse>* AsyncTrackStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::TrackStopResponse>* PrepareAsyncTrackStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::TrackStopRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>* AsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStepResponse>* PrepareAsyncFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>* AsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStepResponse>* PrepareAsyncFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStartResponse>* AsyncFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusInStartResponse>* PrepareAsyncFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera::FocusOutStartResponse>* AsyncFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera::FocusOutStartRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -1097,6 +1149,8 @@ class CameraService final {
     const ::grpc::internal::RpcMethod rpcmethod_TrackPoint_;
     const ::grpc::internal::RpcMethod rpcmethod_TrackRectangle_;
     const ::grpc::internal::RpcMethod rpcmethod_TrackStop_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusInStep_;
+    const ::grpc::internal::RpcMethod rpcmethod_FocusOutStep_;
     const ::grpc::internal::RpcMethod rpcmethod_FocusInStart_;
     const ::grpc::internal::RpcMethod rpcmethod_FocusOutStart_;
     const ::grpc::internal::RpcMethod rpcmethod_FocusStop_;
@@ -1219,6 +1273,12 @@ class CameraService final {
     //
     // Stop tracking.
     virtual ::grpc::Status TrackStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::TrackStopRequest* request, ::mavsdk::rpc::camera::TrackStopResponse* response);
+    //
+    // Step focus in.
+    virtual ::grpc::Status FocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response);
+    //
+    // Step focus out.
+    virtual ::grpc::Status FocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response);
     //
     // Start focusing in.
     virtual ::grpc::Status FocusInStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response);
@@ -1873,12 +1933,52 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodAsync(32);
+    }
+    ~WithAsyncMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusInStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusInStepRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusInStepResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodAsync(33);
+    }
+    ~WithAsyncMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusOutStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusOutStepResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodAsync(32);
+      ::grpc::Service::MarkMethodAsync(34);
     }
     ~WithAsyncMethod_FocusInStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1889,7 +1989,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusInStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusInStartRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusInStartResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1898,7 +1998,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodAsync(33);
+      ::grpc::Service::MarkMethodAsync(35);
     }
     ~WithAsyncMethod_FocusOutStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1909,7 +2009,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusOutStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusOutStartRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusOutStartResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1918,7 +2018,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_FocusStop() {
-      ::grpc::Service::MarkMethodAsync(34);
+      ::grpc::Service::MarkMethodAsync(36);
     }
     ~WithAsyncMethod_FocusStop() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1929,7 +2029,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusStop(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusStopRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusStopResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1938,7 +2038,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_FocusRange() {
-      ::grpc::Service::MarkMethodAsync(35);
+      ::grpc::Service::MarkMethodAsync(37);
     }
     ~WithAsyncMethod_FocusRange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1949,10 +2049,10 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusRange(::grpc::ServerContext* context, ::mavsdk::rpc::camera::FocusRangeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera::FocusRangeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_ListPhotos<WithAsyncMethod_SubscribeCameraList<WithAsyncMethod_SubscribeMode<WithAsyncMethod_GetMode<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_GetVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStorage<WithAsyncMethod_GetStorage<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_GetCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_GetPossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<WithAsyncMethod_ResetSettings<WithAsyncMethod_ZoomInStart<WithAsyncMethod_ZoomOutStart<WithAsyncMethod_ZoomStop<WithAsyncMethod_ZoomRange<WithAsyncMethod_TrackPoint<WithAsyncMethod_TrackRectangle<WithAsyncMethod_TrackStop<WithAsyncMethod_FocusInStart<WithAsyncMethod_FocusOutStart<WithAsyncMethod_FocusStop<WithAsyncMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_TakePhoto<WithAsyncMethod_StartPhotoInterval<WithAsyncMethod_StopPhotoInterval<WithAsyncMethod_StartVideo<WithAsyncMethod_StopVideo<WithAsyncMethod_StartVideoStreaming<WithAsyncMethod_StopVideoStreaming<WithAsyncMethod_SetMode<WithAsyncMethod_ListPhotos<WithAsyncMethod_SubscribeCameraList<WithAsyncMethod_SubscribeMode<WithAsyncMethod_GetMode<WithAsyncMethod_SubscribeVideoStreamInfo<WithAsyncMethod_GetVideoStreamInfo<WithAsyncMethod_SubscribeCaptureInfo<WithAsyncMethod_SubscribeStorage<WithAsyncMethod_GetStorage<WithAsyncMethod_SubscribeCurrentSettings<WithAsyncMethod_GetCurrentSettings<WithAsyncMethod_SubscribePossibleSettingOptions<WithAsyncMethod_GetPossibleSettingOptions<WithAsyncMethod_SetSetting<WithAsyncMethod_GetSetting<WithAsyncMethod_FormatStorage<WithAsyncMethod_ResetSettings<WithAsyncMethod_ZoomInStart<WithAsyncMethod_ZoomOutStart<WithAsyncMethod_ZoomStop<WithAsyncMethod_ZoomRange<WithAsyncMethod_TrackPoint<WithAsyncMethod_TrackRectangle<WithAsyncMethod_TrackStop<WithAsyncMethod_FocusInStep<WithAsyncMethod_FocusOutStep<WithAsyncMethod_FocusInStart<WithAsyncMethod_FocusOutStart<WithAsyncMethod_FocusStop<WithAsyncMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_TakePhoto : public BaseClass {
    private:
@@ -2783,18 +2883,72 @@ class CameraService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::TrackStopRequest* /*request*/, ::mavsdk::rpc::camera::TrackStopResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodCallback(32,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusInStepRequest* request, ::mavsdk::rpc::camera::FocusInStepResponse* response) { return this->FocusInStep(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusInStep(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodCallback(33,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusOutStepRequest* request, ::mavsdk::rpc::camera::FocusOutStepResponse* response) { return this->FocusOutStep(context, request, response); }));}
+    void SetMessageAllocatorFor_FocusOutStep(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodCallback(32,
+      ::grpc::Service::MarkMethodCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusInStartRequest* request, ::mavsdk::rpc::camera::FocusInStartResponse* response) { return this->FocusInStart(context, request, response); }));}
     void SetMessageAllocatorFor_FocusInStart(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2815,13 +2969,13 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodCallback(33,
+      ::grpc::Service::MarkMethodCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusOutStartRequest, ::mavsdk::rpc::camera::FocusOutStartResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusOutStartRequest* request, ::mavsdk::rpc::camera::FocusOutStartResponse* response) { return this->FocusOutStart(context, request, response); }));}
     void SetMessageAllocatorFor_FocusOutStart(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusOutStartRequest, ::mavsdk::rpc::camera::FocusOutStartResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusOutStartRequest, ::mavsdk::rpc::camera::FocusOutStartResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2842,13 +2996,13 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_FocusStop() {
-      ::grpc::Service::MarkMethodCallback(34,
+      ::grpc::Service::MarkMethodCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusStopRequest, ::mavsdk::rpc::camera::FocusStopResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusStopRequest* request, ::mavsdk::rpc::camera::FocusStopResponse* response) { return this->FocusStop(context, request, response); }));}
     void SetMessageAllocatorFor_FocusStop(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusStopRequest, ::mavsdk::rpc::camera::FocusStopResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusStopRequest, ::mavsdk::rpc::camera::FocusStopResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2869,13 +3023,13 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_FocusRange() {
-      ::grpc::Service::MarkMethodCallback(35,
+      ::grpc::Service::MarkMethodCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusRangeRequest, ::mavsdk::rpc::camera::FocusRangeResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera::FocusRangeRequest* request, ::mavsdk::rpc::camera::FocusRangeResponse* response) { return this->FocusRange(context, request, response); }));}
     void SetMessageAllocatorFor_FocusRange(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera::FocusRangeRequest, ::mavsdk::rpc::camera::FocusRangeResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(37);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera::FocusRangeRequest, ::mavsdk::rpc::camera::FocusRangeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2890,7 +3044,7 @@ class CameraService final {
     virtual ::grpc::ServerUnaryReactor* FocusRange(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusRangeRequest* /*request*/, ::mavsdk::rpc::camera::FocusRangeResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_TakePhoto<WithCallbackMethod_StartPhotoInterval<WithCallbackMethod_StopPhotoInterval<WithCallbackMethod_StartVideo<WithCallbackMethod_StopVideo<WithCallbackMethod_StartVideoStreaming<WithCallbackMethod_StopVideoStreaming<WithCallbackMethod_SetMode<WithCallbackMethod_ListPhotos<WithCallbackMethod_SubscribeCameraList<WithCallbackMethod_SubscribeMode<WithCallbackMethod_GetMode<WithCallbackMethod_SubscribeVideoStreamInfo<WithCallbackMethod_GetVideoStreamInfo<WithCallbackMethod_SubscribeCaptureInfo<WithCallbackMethod_SubscribeStorage<WithCallbackMethod_GetStorage<WithCallbackMethod_SubscribeCurrentSettings<WithCallbackMethod_GetCurrentSettings<WithCallbackMethod_SubscribePossibleSettingOptions<WithCallbackMethod_GetPossibleSettingOptions<WithCallbackMethod_SetSetting<WithCallbackMethod_GetSetting<WithCallbackMethod_FormatStorage<WithCallbackMethod_ResetSettings<WithCallbackMethod_ZoomInStart<WithCallbackMethod_ZoomOutStart<WithCallbackMethod_ZoomStop<WithCallbackMethod_ZoomRange<WithCallbackMethod_TrackPoint<WithCallbackMethod_TrackRectangle<WithCallbackMethod_TrackStop<WithCallbackMethod_FocusInStart<WithCallbackMethod_FocusOutStart<WithCallbackMethod_FocusStop<WithCallbackMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_TakePhoto<WithCallbackMethod_StartPhotoInterval<WithCallbackMethod_StopPhotoInterval<WithCallbackMethod_StartVideo<WithCallbackMethod_StopVideo<WithCallbackMethod_StartVideoStreaming<WithCallbackMethod_StopVideoStreaming<WithCallbackMethod_SetMode<WithCallbackMethod_ListPhotos<WithCallbackMethod_SubscribeCameraList<WithCallbackMethod_SubscribeMode<WithCallbackMethod_GetMode<WithCallbackMethod_SubscribeVideoStreamInfo<WithCallbackMethod_GetVideoStreamInfo<WithCallbackMethod_SubscribeCaptureInfo<WithCallbackMethod_SubscribeStorage<WithCallbackMethod_GetStorage<WithCallbackMethod_SubscribeCurrentSettings<WithCallbackMethod_GetCurrentSettings<WithCallbackMethod_SubscribePossibleSettingOptions<WithCallbackMethod_GetPossibleSettingOptions<WithCallbackMethod_SetSetting<WithCallbackMethod_GetSetting<WithCallbackMethod_FormatStorage<WithCallbackMethod_ResetSettings<WithCallbackMethod_ZoomInStart<WithCallbackMethod_ZoomOutStart<WithCallbackMethod_ZoomStop<WithCallbackMethod_ZoomRange<WithCallbackMethod_TrackPoint<WithCallbackMethod_TrackRectangle<WithCallbackMethod_TrackStop<WithCallbackMethod_FocusInStep<WithCallbackMethod_FocusOutStep<WithCallbackMethod_FocusInStart<WithCallbackMethod_FocusOutStart<WithCallbackMethod_FocusStop<WithCallbackMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_TakePhoto : public BaseClass {
@@ -3437,12 +3591,46 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodGeneric(32);
+    }
+    ~WithGenericMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodGeneric(33);
+    }
+    ~WithGenericMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodGeneric(32);
+      ::grpc::Service::MarkMethodGeneric(34);
     }
     ~WithGenericMethod_FocusInStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3459,7 +3647,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodGeneric(33);
+      ::grpc::Service::MarkMethodGeneric(35);
     }
     ~WithGenericMethod_FocusOutStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3476,7 +3664,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_FocusStop() {
-      ::grpc::Service::MarkMethodGeneric(34);
+      ::grpc::Service::MarkMethodGeneric(36);
     }
     ~WithGenericMethod_FocusStop() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3493,7 +3681,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_FocusRange() {
-      ::grpc::Service::MarkMethodGeneric(35);
+      ::grpc::Service::MarkMethodGeneric(37);
     }
     ~WithGenericMethod_FocusRange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4145,12 +4333,52 @@ class CameraService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodRaw(32);
+    }
+    ~WithRawMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusInStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodRaw(33);
+    }
+    ~WithRawMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestFocusOutStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodRaw(32);
+      ::grpc::Service::MarkMethodRaw(34);
     }
     ~WithRawMethod_FocusInStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4161,7 +4389,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusInStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4170,7 +4398,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodRaw(33);
+      ::grpc::Service::MarkMethodRaw(35);
     }
     ~WithRawMethod_FocusOutStart() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4181,7 +4409,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusOutStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4190,7 +4418,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_FocusStop() {
-      ::grpc::Service::MarkMethodRaw(34);
+      ::grpc::Service::MarkMethodRaw(36);
     }
     ~WithRawMethod_FocusStop() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4201,7 +4429,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusStop(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4210,7 +4438,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_FocusRange() {
-      ::grpc::Service::MarkMethodRaw(35);
+      ::grpc::Service::MarkMethodRaw(37);
     }
     ~WithRawMethod_FocusRange() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4221,7 +4449,7 @@ class CameraService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestFocusRange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4929,12 +5157,56 @@ class CameraService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodRawCallback(32,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusInStep(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodRawCallback(33,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusOutStep(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* FocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodRawCallback(32,
+      ::grpc::Service::MarkMethodRawCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusInStart(context, request, response); }));
@@ -4956,7 +5228,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodRawCallback(33,
+      ::grpc::Service::MarkMethodRawCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusOutStart(context, request, response); }));
@@ -4978,7 +5250,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_FocusStop() {
-      ::grpc::Service::MarkMethodRawCallback(34,
+      ::grpc::Service::MarkMethodRawCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusStop(context, request, response); }));
@@ -5000,7 +5272,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_FocusRange() {
-      ::grpc::Service::MarkMethodRawCallback(35,
+      ::grpc::Service::MarkMethodRawCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->FocusRange(context, request, response); }));
@@ -5692,12 +5964,66 @@ class CameraService final {
     virtual ::grpc::Status StreamedTrackStop(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::TrackStopRequest,::mavsdk::rpc::camera::TrackStopResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusInStep() {
+      ::grpc::Service::MarkMethodStreamed(32,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusInStepRequest, ::mavsdk::rpc::camera::FocusInStepResponse>* streamer) {
+                       return this->StreamedFocusInStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusInStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusInStep(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusInStepRequest,::mavsdk::rpc::camera::FocusInStepResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_FocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_FocusOutStep() {
+      ::grpc::Service::MarkMethodStreamed(33,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera::FocusOutStepRequest, ::mavsdk::rpc::camera::FocusOutStepResponse>* streamer) {
+                       return this->StreamedFocusOutStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_FocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status FocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera::FocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera::FocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedFocusOutStep(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusOutStepRequest,::mavsdk::rpc::camera::FocusOutStepResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_FocusInStart : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_FocusInStart() {
-      ::grpc::Service::MarkMethodStreamed(32,
+      ::grpc::Service::MarkMethodStreamed(34,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::FocusInStartRequest, ::mavsdk::rpc::camera::FocusInStartResponse>(
             [this](::grpc::ServerContext* context,
@@ -5724,7 +6050,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_FocusOutStart() {
-      ::grpc::Service::MarkMethodStreamed(33,
+      ::grpc::Service::MarkMethodStreamed(35,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::FocusOutStartRequest, ::mavsdk::rpc::camera::FocusOutStartResponse>(
             [this](::grpc::ServerContext* context,
@@ -5751,7 +6077,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_FocusStop() {
-      ::grpc::Service::MarkMethodStreamed(34,
+      ::grpc::Service::MarkMethodStreamed(36,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::FocusStopRequest, ::mavsdk::rpc::camera::FocusStopResponse>(
             [this](::grpc::ServerContext* context,
@@ -5778,7 +6104,7 @@ class CameraService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_FocusRange() {
-      ::grpc::Service::MarkMethodStreamed(35,
+      ::grpc::Service::MarkMethodStreamed(37,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera::FocusRangeRequest, ::mavsdk::rpc::camera::FocusRangeResponse>(
             [this](::grpc::ServerContext* context,
@@ -5799,7 +6125,7 @@ class CameraService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedFocusRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera::FocusRangeRequest,::mavsdk::rpc::camera::FocusRangeResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithStreamedUnaryMethod_GetMode<WithStreamedUnaryMethod_GetVideoStreamInfo<WithStreamedUnaryMethod_GetStorage<WithStreamedUnaryMethod_GetCurrentSettings<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithStreamedUnaryMethod_GetMode<WithStreamedUnaryMethod_GetVideoStreamInfo<WithStreamedUnaryMethod_GetStorage<WithStreamedUnaryMethod_GetCurrentSettings<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeCameraList : public BaseClass {
    private:
@@ -5990,7 +6316,7 @@ class CameraService final {
     virtual ::grpc::Status StreamedSubscribePossibleSettingOptions(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera::SubscribePossibleSettingOptionsRequest,::mavsdk::rpc::camera::PossibleSettingOptionsResponse>* server_split_streamer) = 0;
   };
   typedef WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<Service > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithStreamedUnaryMethod_GetMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithStreamedUnaryMethod_GetVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithStreamedUnaryMethod_GetStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithStreamedUnaryMethod_GetCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_TakePhoto<WithStreamedUnaryMethod_StartPhotoInterval<WithStreamedUnaryMethod_StopPhotoInterval<WithStreamedUnaryMethod_StartVideo<WithStreamedUnaryMethod_StopVideo<WithStreamedUnaryMethod_StartVideoStreaming<WithStreamedUnaryMethod_StopVideoStreaming<WithStreamedUnaryMethod_SetMode<WithStreamedUnaryMethod_ListPhotos<WithSplitStreamingMethod_SubscribeCameraList<WithSplitStreamingMethod_SubscribeMode<WithStreamedUnaryMethod_GetMode<WithSplitStreamingMethod_SubscribeVideoStreamInfo<WithStreamedUnaryMethod_GetVideoStreamInfo<WithSplitStreamingMethod_SubscribeCaptureInfo<WithSplitStreamingMethod_SubscribeStorage<WithStreamedUnaryMethod_GetStorage<WithSplitStreamingMethod_SubscribeCurrentSettings<WithStreamedUnaryMethod_GetCurrentSettings<WithSplitStreamingMethod_SubscribePossibleSettingOptions<WithStreamedUnaryMethod_GetPossibleSettingOptions<WithStreamedUnaryMethod_SetSetting<WithStreamedUnaryMethod_GetSetting<WithStreamedUnaryMethod_FormatStorage<WithStreamedUnaryMethod_ResetSettings<WithStreamedUnaryMethod_ZoomInStart<WithStreamedUnaryMethod_ZoomOutStart<WithStreamedUnaryMethod_ZoomStop<WithStreamedUnaryMethod_ZoomRange<WithStreamedUnaryMethod_TrackPoint<WithStreamedUnaryMethod_TrackRectangle<WithStreamedUnaryMethod_TrackStop<WithStreamedUnaryMethod_FocusInStep<WithStreamedUnaryMethod_FocusOutStep<WithStreamedUnaryMethod_FocusInStart<WithStreamedUnaryMethod_FocusOutStart<WithStreamedUnaryMethod_FocusStop<WithStreamedUnaryMethod_FocusRange<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.pb.cc
@@ -1062,6 +1062,32 @@ struct FocusOutStartRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartRequestDefaultTypeInternal _FocusOutStartRequest_default_instance_;
 
+inline constexpr FocusMetersRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        distance_m_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusMetersRequest::FocusMetersRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusMetersRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusMetersRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusMetersRequestDefaultTypeInternal() {}
+  union {
+    FocusMetersRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusMetersRequestDefaultTypeInternal _FocusMetersRequest_default_instance_;
+
 inline constexpr FocusInStepRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : component_id_{0},
@@ -1111,6 +1137,81 @@ struct FocusInStartRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStartRequestDefaultTypeInternal _FocusInStartRequest_default_instance_;
+
+inline constexpr FocusAutoSingleRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoSingleRequest::FocusAutoSingleRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoSingleRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoSingleRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoSingleRequestDefaultTypeInternal() {}
+  union {
+    FocusAutoSingleRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoSingleRequestDefaultTypeInternal _FocusAutoSingleRequest_default_instance_;
+
+inline constexpr FocusAutoRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoRequest::FocusAutoRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoRequestDefaultTypeInternal() {}
+  union {
+    FocusAutoRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoRequestDefaultTypeInternal _FocusAutoRequest_default_instance_;
+
+inline constexpr FocusAutoContinuousRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoContinuousRequest::FocusAutoContinuousRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoContinuousRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoContinuousRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoContinuousRequestDefaultTypeInternal() {}
+  union {
+    FocusAutoContinuousRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoContinuousRequestDefaultTypeInternal _FocusAutoContinuousRequest_default_instance_;
 
 inline constexpr EulerAngle::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1913,6 +2014,31 @@ struct FocusOutStartResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
 
+inline constexpr FocusMetersResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusMetersResponse::FocusMetersResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusMetersResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusMetersResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusMetersResponseDefaultTypeInternal() {}
+  union {
+    FocusMetersResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusMetersResponseDefaultTypeInternal _FocusMetersResponse_default_instance_;
+
 inline constexpr FocusInStepResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1962,6 +2088,81 @@ struct FocusInStartResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
+
+inline constexpr FocusAutoSingleResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoSingleResponse::FocusAutoSingleResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoSingleResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoSingleResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoSingleResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoSingleResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoSingleResponseDefaultTypeInternal _FocusAutoSingleResponse_default_instance_;
+
+inline constexpr FocusAutoResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoResponse::FocusAutoResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoResponseDefaultTypeInternal _FocusAutoResponse_default_instance_;
+
+inline constexpr FocusAutoContinuousResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoContinuousResponse::FocusAutoContinuousResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoContinuousResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoContinuousResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoContinuousResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoContinuousResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoContinuousResponseDefaultTypeInternal _FocusAutoContinuousResponse_default_instance_;
 
 inline constexpr CaptureInfo::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -3334,6 +3535,83 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusRangeResponse, _impl_.camera_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersRequest, _impl_.distance_m_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusMetersResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoSingleRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoSingleRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoSingleResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoSingleResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoSingleResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoContinuousRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoContinuousRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoContinuousResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoContinuousResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusAutoContinuousResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::CameraResult, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -3518,13 +3796,21 @@ static const ::_pbi::MigrationSchema
         {863, 872, -1, sizeof(::mavsdk::rpc::camera::FocusStopResponse)},
         {873, -1, -1, sizeof(::mavsdk::rpc::camera::FocusRangeRequest)},
         {883, 892, -1, sizeof(::mavsdk::rpc::camera::FocusRangeResponse)},
-        {893, -1, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
-        {903, -1, -1, sizeof(::mavsdk::rpc::camera::Position)},
-        {915, -1, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
-        {927, -1, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
-        {938, 954, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
-        {962, -1, -1, sizeof(::mavsdk::rpc::camera::Information)},
-        {978, -1, -1, sizeof(::mavsdk::rpc::camera::CameraList)},
+        {893, -1, -1, sizeof(::mavsdk::rpc::camera::FocusMetersRequest)},
+        {903, 912, -1, sizeof(::mavsdk::rpc::camera::FocusMetersResponse)},
+        {913, -1, -1, sizeof(::mavsdk::rpc::camera::FocusAutoRequest)},
+        {922, 931, -1, sizeof(::mavsdk::rpc::camera::FocusAutoResponse)},
+        {932, -1, -1, sizeof(::mavsdk::rpc::camera::FocusAutoSingleRequest)},
+        {941, 950, -1, sizeof(::mavsdk::rpc::camera::FocusAutoSingleResponse)},
+        {951, -1, -1, sizeof(::mavsdk::rpc::camera::FocusAutoContinuousRequest)},
+        {960, 969, -1, sizeof(::mavsdk::rpc::camera::FocusAutoContinuousResponse)},
+        {970, -1, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
+        {980, -1, -1, sizeof(::mavsdk::rpc::camera::Position)},
+        {992, -1, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
+        {1004, -1, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
+        {1015, 1031, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
+        {1039, -1, -1, sizeof(::mavsdk::rpc::camera::Information)},
+        {1055, -1, -1, sizeof(::mavsdk::rpc::camera::CameraList)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera::_Option_default_instance_._instance,
@@ -3614,6 +3900,14 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera::_FocusStopResponse_default_instance_._instance,
     &::mavsdk::rpc::camera::_FocusRangeRequest_default_instance_._instance,
     &::mavsdk::rpc::camera::_FocusRangeResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusMetersRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusMetersResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoSingleRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoSingleResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoContinuousRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusAutoContinuousResponse_default_instance_._instance,
     &::mavsdk::rpc::camera::_CameraResult_default_instance_._instance,
     &::mavsdk::rpc::camera::_Position_default_instance_._instance,
     &::mavsdk::rpc::camera::_Quaternion_default_instance_._instance,
@@ -3816,142 +4110,165 @@ const char descriptor_table_protodef_camera_2fcamera_2eproto[] ABSL_ATTRIBUTE_SE
     "uest\022\024\n\014component_id\030\001 \001(\005\022\r\n\005range\030\002 \001("
     "\002\"L\n\022FocusRangeResponse\0226\n\rcamera_result"
     "\030\001 \001(\0132\037.mavsdk.rpc.camera.CameraResult\""
-    "\226\003\n\014CameraResult\0226\n\006result\030\001 \001(\0162&.mavsd"
-    "k.rpc.camera.CameraResult.Result\022\022\n\nresu"
-    "lt_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNKNOW"
-    "N\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PRO"
-    "GRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rRESULT_DENIE"
-    "D\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RESULT_TIMEOUT\020"
-    "\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007\022\024\n\020RESULT_N"
-    "O_SYSTEM\020\010\022\037\n\033RESULT_PROTOCOL_UNSUPPORTE"
-    "D\020\t\022\026\n\022RESULT_UNAVAILABLE\020\n\022\034\n\030RESULT_CA"
-    "MERA_ID_INVALID\020\013\022\035\n\031RESULT_ACTION_UNSUP"
-    "PORTED\020\014\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001"
-    "(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_al"
-    "titude_m\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 "
-    "\001(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022"
-    "\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"B\n\nEulerAngle\022\020\n\010r"
-    "oll_deg\030\001 \001(\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_"
-    "deg\030\003 \001(\002\"\225\002\n\013CaptureInfo\022\024\n\014component_i"
-    "d\030\001 \001(\005\022-\n\010position\030\002 \001(\0132\033.mavsdk.rpc.c"
-    "amera.Position\022:\n\023attitude_quaternion\030\003 "
-    "\001(\0132\035.mavsdk.rpc.camera.Quaternion\022;\n\024at"
-    "titude_euler_angle\030\004 \001(\0132\035.mavsdk.rpc.ca"
-    "mera.EulerAngle\022\023\n\013time_utc_us\030\005 \001(\004\022\022\n\n"
-    "is_success\030\006 \001(\010\022\r\n\005index\030\007 \001(\005\022\020\n\010file_"
-    "url\030\010 \001(\t\"\353\001\n\013Information\022\024\n\014component_i"
-    "d\030\001 \001(\005\022\023\n\013vendor_name\030\002 \001(\t\022\022\n\nmodel_na"
-    "me\030\003 \001(\t\022\027\n\017focal_length_mm\030\004 \001(\002\022!\n\031hor"
-    "izontal_sensor_size_mm\030\005 \001(\002\022\037\n\027vertical"
-    "_sensor_size_mm\030\006 \001(\002\022 \n\030horizontal_reso"
-    "lution_px\030\007 \001(\r\022\036\n\026vertical_resolution_p"
-    "x\030\010 \001(\r\"=\n\nCameraList\022/\n\007cameras\030\001 \003(\0132\036"
-    ".mavsdk.rpc.camera.Information*8\n\004Mode\022\020"
-    "\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE"
-    "_VIDEO\020\002*F\n\013PhotosRange\022\024\n\020PHOTOS_RANGE_"
-    "ALL\020\000\022!\n\035PHOTOS_RANGE_SINCE_CONNECTION\020\001"
-    "2\240\037\n\rCameraService\022X\n\tTakePhoto\022#.mavsdk"
-    ".rpc.camera.TakePhotoRequest\032$.mavsdk.rp"
-    "c.camera.TakePhotoResponse\"\000\022s\n\022StartPho"
-    "toInterval\022,.mavsdk.rpc.camera.StartPhot"
-    "oIntervalRequest\032-.mavsdk.rpc.camera.Sta"
-    "rtPhotoIntervalResponse\"\000\022p\n\021StopPhotoIn"
-    "terval\022+.mavsdk.rpc.camera.StopPhotoInte"
-    "rvalRequest\032,.mavsdk.rpc.camera.StopPhot"
-    "oIntervalResponse\"\000\022[\n\nStartVideo\022$.mavs"
-    "dk.rpc.camera.StartVideoRequest\032%.mavsdk"
-    ".rpc.camera.StartVideoResponse\"\000\022X\n\tStop"
-    "Video\022#.mavsdk.rpc.camera.StopVideoReque"
-    "st\032$.mavsdk.rpc.camera.StopVideoResponse"
-    "\"\000\022z\n\023StartVideoStreaming\022-.mavsdk.rpc.c"
-    "amera.StartVideoStreamingRequest\032..mavsd"
-    "k.rpc.camera.StartVideoStreamingResponse"
-    "\"\004\200\265\030\001\022w\n\022StopVideoStreaming\022,.mavsdk.rp"
-    "c.camera.StopVideoStreamingRequest\032-.mav"
-    "sdk.rpc.camera.StopVideoStreamingRespons"
-    "e\"\004\200\265\030\001\022R\n\007SetMode\022!.mavsdk.rpc.camera.S"
-    "etModeRequest\032\".mavsdk.rpc.camera.SetMod"
-    "eResponse\"\000\022[\n\nListPhotos\022$.mavsdk.rpc.c"
-    "amera.ListPhotosRequest\032%.mavsdk.rpc.cam"
-    "era.ListPhotosResponse\"\000\022o\n\023SubscribeCam"
-    "eraList\022-.mavsdk.rpc.camera.SubscribeCam"
-    "eraListRequest\032%.mavsdk.rpc.camera.Camer"
-    "aListResponse\"\0000\001\022a\n\rSubscribeMode\022\'.mav"
-    "sdk.rpc.camera.SubscribeModeRequest\032\037.ma"
-    "vsdk.rpc.camera.ModeResponse\"\004\200\265\030\0000\001\022V\n\007"
-    "GetMode\022!.mavsdk.rpc.camera.GetModeReque"
-    "st\032\".mavsdk.rpc.camera.GetModeResponse\"\004"
-    "\200\265\030\001\022\202\001\n\030SubscribeVideoStreamInfo\0222.mavs"
-    "dk.rpc.camera.SubscribeVideoStreamInfoRe"
-    "quest\032*.mavsdk.rpc.camera.VideoStreamInf"
-    "oResponse\"\004\200\265\030\0000\001\022w\n\022GetVideoStreamInfo\022"
-    ",.mavsdk.rpc.camera.GetVideoStreamInfoRe"
-    "quest\032-.mavsdk.rpc.camera.GetVideoStream"
-    "InfoResponse\"\004\200\265\030\001\022v\n\024SubscribeCaptureIn"
-    "fo\022..mavsdk.rpc.camera.SubscribeCaptureI"
-    "nfoRequest\032&.mavsdk.rpc.camera.CaptureIn"
-    "foResponse\"\004\200\265\030\0000\001\022j\n\020SubscribeStorage\022*"
-    ".mavsdk.rpc.camera.SubscribeStorageReque"
-    "st\032\".mavsdk.rpc.camera.StorageResponse\"\004"
-    "\200\265\030\0000\001\022_\n\nGetStorage\022$.mavsdk.rpc.camera"
-    ".GetStorageRequest\032%.mavsdk.rpc.camera.G"
-    "etStorageResponse\"\004\200\265\030\001\022\202\001\n\030SubscribeCur"
-    "rentSettings\0222.mavsdk.rpc.camera.Subscri"
-    "beCurrentSettingsRequest\032*.mavsdk.rpc.ca"
-    "mera.CurrentSettingsResponse\"\004\200\265\030\0000\001\022w\n\022"
-    "GetCurrentSettings\022,.mavsdk.rpc.camera.G"
-    "etCurrentSettingsRequest\032-.mavsdk.rpc.ca"
-    "mera.GetCurrentSettingsResponse\"\004\200\265\030\001\022\227\001"
-    "\n\037SubscribePossibleSettingOptions\0229.mavs"
-    "dk.rpc.camera.SubscribePossibleSettingOp"
-    "tionsRequest\0321.mavsdk.rpc.camera.Possibl"
-    "eSettingOptionsResponse\"\004\200\265\030\0000\001\022\214\001\n\031GetP"
-    "ossibleSettingOptions\0223.mavsdk.rpc.camer"
-    "a.GetPossibleSettingOptionsRequest\0324.mav"
-    "sdk.rpc.camera.GetPossibleSettingOptions"
-    "Response\"\004\200\265\030\001\022[\n\nSetSetting\022$.mavsdk.rp"
-    "c.camera.SetSettingRequest\032%.mavsdk.rpc."
-    "camera.SetSettingResponse\"\000\022[\n\nGetSettin"
-    "g\022$.mavsdk.rpc.camera.GetSettingRequest\032"
-    "%.mavsdk.rpc.camera.GetSettingResponse\"\000"
-    "\022d\n\rFormatStorage\022\'.mavsdk.rpc.camera.Fo"
-    "rmatStorageRequest\032(.mavsdk.rpc.camera.F"
-    "ormatStorageResponse\"\000\022d\n\rResetSettings\022"
-    "\'.mavsdk.rpc.camera.ResetSettingsRequest"
-    "\032(.mavsdk.rpc.camera.ResetSettingsRespon"
-    "se\"\000\022^\n\013ZoomInStart\022%.mavsdk.rpc.camera."
-    "ZoomInStartRequest\032&.mavsdk.rpc.camera.Z"
-    "oomInStartResponse\"\000\022a\n\014ZoomOutStart\022&.m"
-    "avsdk.rpc.camera.ZoomOutStartRequest\032\'.m"
-    "avsdk.rpc.camera.ZoomOutStartResponse\"\000\022"
-    "U\n\010ZoomStop\022\".mavsdk.rpc.camera.ZoomStop"
-    "Request\032#.mavsdk.rpc.camera.ZoomStopResp"
-    "onse\"\000\022X\n\tZoomRange\022#.mavsdk.rpc.camera."
-    "ZoomRangeRequest\032$.mavsdk.rpc.camera.Zoo"
-    "mRangeResponse\"\000\022[\n\nTrackPoint\022$.mavsdk."
-    "rpc.camera.TrackPointRequest\032%.mavsdk.rp"
-    "c.camera.TrackPointResponse\"\000\022g\n\016TrackRe"
-    "ctangle\022(.mavsdk.rpc.camera.TrackRectang"
-    "leRequest\032).mavsdk.rpc.camera.TrackRecta"
-    "ngleResponse\"\000\022X\n\tTrackStop\022#.mavsdk.rpc"
-    ".camera.TrackStopRequest\032$.mavsdk.rpc.ca"
-    "mera.TrackStopResponse\"\000\022^\n\013FocusInStep\022"
-    "%.mavsdk.rpc.camera.FocusInStepRequest\032&"
-    ".mavsdk.rpc.camera.FocusInStepResponse\"\000"
-    "\022a\n\014FocusOutStep\022&.mavsdk.rpc.camera.Foc"
-    "usOutStepRequest\032\'.mavsdk.rpc.camera.Foc"
-    "usOutStepResponse\"\000\022a\n\014FocusInStart\022&.ma"
-    "vsdk.rpc.camera.FocusInStartRequest\032\'.ma"
-    "vsdk.rpc.camera.FocusInStartResponse\"\000\022d"
-    "\n\rFocusOutStart\022\'.mavsdk.rpc.camera.Focu"
-    "sOutStartRequest\032(.mavsdk.rpc.camera.Foc"
-    "usOutStartResponse\"\000\022X\n\tFocusStop\022#.mavs"
-    "dk.rpc.camera.FocusStopRequest\032$.mavsdk."
-    "rpc.camera.FocusStopResponse\"\000\022[\n\nFocusR"
-    "ange\022$.mavsdk.rpc.camera.FocusRangeReque"
-    "st\032%.mavsdk.rpc.camera.FocusRangeRespons"
-    "e\"\000B\037\n\020io.mavsdk.cameraB\013CameraProtob\006pr"
-    "oto3"
+    ">\n\022FocusMetersRequest\022\024\n\014component_id\030\001 "
+    "\001(\005\022\022\n\ndistance_m\030\002 \001(\002\"M\n\023FocusMetersRe"
+    "sponse\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.r"
+    "pc.camera.CameraResult\"(\n\020FocusAutoReque"
+    "st\022\024\n\014component_id\030\001 \001(\005\"K\n\021FocusAutoRes"
+    "ponse\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rp"
+    "c.camera.CameraResult\".\n\026FocusAutoSingle"
+    "Request\022\024\n\014component_id\030\001 \001(\005\"Q\n\027FocusAu"
+    "toSingleResponse\0226\n\rcamera_result\030\001 \001(\0132"
+    "\037.mavsdk.rpc.camera.CameraResult\"2\n\032Focu"
+    "sAutoContinuousRequest\022\024\n\014component_id\030\001"
+    " \001(\005\"U\n\033FocusAutoContinuousResponse\0226\n\rc"
+    "amera_result\030\001 \001(\0132\037.mavsdk.rpc.camera.C"
+    "ameraResult\"\226\003\n\014CameraResult\0226\n\006result\030\001"
+    " \001(\0162&.mavsdk.rpc.camera.CameraResult.Re"
+    "sult\022\022\n\nresult_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016R"
+    "ESULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022R"
+    "ESULT_IN_PROGRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\r"
+    "RESULT_DENIED\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RES"
+    "ULT_TIMEOUT\020\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007"
+    "\022\024\n\020RESULT_NO_SYSTEM\020\010\022\037\n\033RESULT_PROTOCO"
+    "L_UNSUPPORTED\020\t\022\026\n\022RESULT_UNAVAILABLE\020\n\022"
+    "\034\n\030RESULT_CAMERA_ID_INVALID\020\013\022\035\n\031RESULT_"
+    "ACTION_UNSUPPORTED\020\014\"q\n\010Position\022\024\n\014lati"
+    "tude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n"
+    "\023absolute_altitude_m\030\003 \001(\002\022\033\n\023relative_a"
+    "ltitude_m\030\004 \001(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002"
+    "\022\t\n\001x\030\002 \001(\002\022\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"B\n\nEul"
+    "erAngle\022\020\n\010roll_deg\030\001 \001(\002\022\021\n\tpitch_deg\030\002"
+    " \001(\002\022\017\n\007yaw_deg\030\003 \001(\002\"\225\002\n\013CaptureInfo\022\024\n"
+    "\014component_id\030\001 \001(\005\022-\n\010position\030\002 \001(\0132\033."
+    "mavsdk.rpc.camera.Position\022:\n\023attitude_q"
+    "uaternion\030\003 \001(\0132\035.mavsdk.rpc.camera.Quat"
+    "ernion\022;\n\024attitude_euler_angle\030\004 \001(\0132\035.m"
+    "avsdk.rpc.camera.EulerAngle\022\023\n\013time_utc_"
+    "us\030\005 \001(\004\022\022\n\nis_success\030\006 \001(\010\022\r\n\005index\030\007 "
+    "\001(\005\022\020\n\010file_url\030\010 \001(\t\"\353\001\n\013Information\022\024\n"
+    "\014component_id\030\001 \001(\005\022\023\n\013vendor_name\030\002 \001(\t"
+    "\022\022\n\nmodel_name\030\003 \001(\t\022\027\n\017focal_length_mm\030"
+    "\004 \001(\002\022!\n\031horizontal_sensor_size_mm\030\005 \001(\002"
+    "\022\037\n\027vertical_sensor_size_mm\030\006 \001(\002\022 \n\030hor"
+    "izontal_resolution_px\030\007 \001(\r\022\036\n\026vertical_"
+    "resolution_px\030\010 \001(\r\"=\n\nCameraList\022/\n\007cam"
+    "eras\030\001 \003(\0132\036.mavsdk.rpc.camera.Informati"
+    "on*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHO"
+    "TO\020\001\022\016\n\nMODE_VIDEO\020\002*F\n\013PhotosRange\022\024\n\020P"
+    "HOTOS_RANGE_ALL\020\000\022!\n\035PHOTOS_RANGE_SINCE_"
+    "CONNECTION\020\0012\276\"\n\rCameraService\022X\n\tTakePh"
+    "oto\022#.mavsdk.rpc.camera.TakePhotoRequest"
+    "\032$.mavsdk.rpc.camera.TakePhotoResponse\"\000"
+    "\022s\n\022StartPhotoInterval\022,.mavsdk.rpc.came"
+    "ra.StartPhotoIntervalRequest\032-.mavsdk.rp"
+    "c.camera.StartPhotoIntervalResponse\"\000\022p\n"
+    "\021StopPhotoInterval\022+.mavsdk.rpc.camera.S"
+    "topPhotoIntervalRequest\032,.mavsdk.rpc.cam"
+    "era.StopPhotoIntervalResponse\"\000\022[\n\nStart"
+    "Video\022$.mavsdk.rpc.camera.StartVideoRequ"
+    "est\032%.mavsdk.rpc.camera.StartVideoRespon"
+    "se\"\000\022X\n\tStopVideo\022#.mavsdk.rpc.camera.St"
+    "opVideoRequest\032$.mavsdk.rpc.camera.StopV"
+    "ideoResponse\"\000\022z\n\023StartVideoStreaming\022-."
+    "mavsdk.rpc.camera.StartVideoStreamingReq"
+    "uest\032..mavsdk.rpc.camera.StartVideoStrea"
+    "mingResponse\"\004\200\265\030\001\022w\n\022StopVideoStreaming"
+    "\022,.mavsdk.rpc.camera.StopVideoStreamingR"
+    "equest\032-.mavsdk.rpc.camera.StopVideoStre"
+    "amingResponse\"\004\200\265\030\001\022R\n\007SetMode\022!.mavsdk."
+    "rpc.camera.SetModeRequest\032\".mavsdk.rpc.c"
+    "amera.SetModeResponse\"\000\022[\n\nListPhotos\022$."
+    "mavsdk.rpc.camera.ListPhotosRequest\032%.ma"
+    "vsdk.rpc.camera.ListPhotosResponse\"\000\022o\n\023"
+    "SubscribeCameraList\022-.mavsdk.rpc.camera."
+    "SubscribeCameraListRequest\032%.mavsdk.rpc."
+    "camera.CameraListResponse\"\0000\001\022a\n\rSubscri"
+    "beMode\022\'.mavsdk.rpc.camera.SubscribeMode"
+    "Request\032\037.mavsdk.rpc.camera.ModeResponse"
+    "\"\004\200\265\030\0000\001\022V\n\007GetMode\022!.mavsdk.rpc.camera."
+    "GetModeRequest\032\".mavsdk.rpc.camera.GetMo"
+    "deResponse\"\004\200\265\030\001\022\202\001\n\030SubscribeVideoStrea"
+    "mInfo\0222.mavsdk.rpc.camera.SubscribeVideo"
+    "StreamInfoRequest\032*.mavsdk.rpc.camera.Vi"
+    "deoStreamInfoResponse\"\004\200\265\030\0000\001\022w\n\022GetVide"
+    "oStreamInfo\022,.mavsdk.rpc.camera.GetVideo"
+    "StreamInfoRequest\032-.mavsdk.rpc.camera.Ge"
+    "tVideoStreamInfoResponse\"\004\200\265\030\001\022v\n\024Subscr"
+    "ibeCaptureInfo\022..mavsdk.rpc.camera.Subsc"
+    "ribeCaptureInfoRequest\032&.mavsdk.rpc.came"
+    "ra.CaptureInfoResponse\"\004\200\265\030\0000\001\022j\n\020Subscr"
+    "ibeStorage\022*.mavsdk.rpc.camera.Subscribe"
+    "StorageRequest\032\".mavsdk.rpc.camera.Stora"
+    "geResponse\"\004\200\265\030\0000\001\022_\n\nGetStorage\022$.mavsd"
+    "k.rpc.camera.GetStorageRequest\032%.mavsdk."
+    "rpc.camera.GetStorageResponse\"\004\200\265\030\001\022\202\001\n\030"
+    "SubscribeCurrentSettings\0222.mavsdk.rpc.ca"
+    "mera.SubscribeCurrentSettingsRequest\032*.m"
+    "avsdk.rpc.camera.CurrentSettingsResponse"
+    "\"\004\200\265\030\0000\001\022w\n\022GetCurrentSettings\022,.mavsdk."
+    "rpc.camera.GetCurrentSettingsRequest\032-.m"
+    "avsdk.rpc.camera.GetCurrentSettingsRespo"
+    "nse\"\004\200\265\030\001\022\227\001\n\037SubscribePossibleSettingOp"
+    "tions\0229.mavsdk.rpc.camera.SubscribePossi"
+    "bleSettingOptionsRequest\0321.mavsdk.rpc.ca"
+    "mera.PossibleSettingOptionsResponse\"\004\200\265\030"
+    "\0000\001\022\214\001\n\031GetPossibleSettingOptions\0223.mavs"
+    "dk.rpc.camera.GetPossibleSettingOptionsR"
+    "equest\0324.mavsdk.rpc.camera.GetPossibleSe"
+    "ttingOptionsResponse\"\004\200\265\030\001\022[\n\nSetSetting"
+    "\022$.mavsdk.rpc.camera.SetSettingRequest\032%"
+    ".mavsdk.rpc.camera.SetSettingResponse\"\000\022"
+    "[\n\nGetSetting\022$.mavsdk.rpc.camera.GetSet"
+    "tingRequest\032%.mavsdk.rpc.camera.GetSetti"
+    "ngResponse\"\000\022d\n\rFormatStorage\022\'.mavsdk.r"
+    "pc.camera.FormatStorageRequest\032(.mavsdk."
+    "rpc.camera.FormatStorageResponse\"\000\022d\n\rRe"
+    "setSettings\022\'.mavsdk.rpc.camera.ResetSet"
+    "tingsRequest\032(.mavsdk.rpc.camera.ResetSe"
+    "ttingsResponse\"\000\022^\n\013ZoomInStart\022%.mavsdk"
+    ".rpc.camera.ZoomInStartRequest\032&.mavsdk."
+    "rpc.camera.ZoomInStartResponse\"\000\022a\n\014Zoom"
+    "OutStart\022&.mavsdk.rpc.camera.ZoomOutStar"
+    "tRequest\032\'.mavsdk.rpc.camera.ZoomOutStar"
+    "tResponse\"\000\022U\n\010ZoomStop\022\".mavsdk.rpc.cam"
+    "era.ZoomStopRequest\032#.mavsdk.rpc.camera."
+    "ZoomStopResponse\"\000\022X\n\tZoomRange\022#.mavsdk"
+    ".rpc.camera.ZoomRangeRequest\032$.mavsdk.rp"
+    "c.camera.ZoomRangeResponse\"\000\022[\n\nTrackPoi"
+    "nt\022$.mavsdk.rpc.camera.TrackPointRequest"
+    "\032%.mavsdk.rpc.camera.TrackPointResponse\""
+    "\000\022g\n\016TrackRectangle\022(.mavsdk.rpc.camera."
+    "TrackRectangleRequest\032).mavsdk.rpc.camer"
+    "a.TrackRectangleResponse\"\000\022X\n\tTrackStop\022"
+    "#.mavsdk.rpc.camera.TrackStopRequest\032$.m"
+    "avsdk.rpc.camera.TrackStopResponse\"\000\022^\n\013"
+    "FocusInStep\022%.mavsdk.rpc.camera.FocusInS"
+    "tepRequest\032&.mavsdk.rpc.camera.FocusInSt"
+    "epResponse\"\000\022a\n\014FocusOutStep\022&.mavsdk.rp"
+    "c.camera.FocusOutStepRequest\032\'.mavsdk.rp"
+    "c.camera.FocusOutStepResponse\"\000\022a\n\014Focus"
+    "InStart\022&.mavsdk.rpc.camera.FocusInStart"
+    "Request\032\'.mavsdk.rpc.camera.FocusInStart"
+    "Response\"\000\022d\n\rFocusOutStart\022\'.mavsdk.rpc"
+    ".camera.FocusOutStartRequest\032(.mavsdk.rp"
+    "c.camera.FocusOutStartResponse\"\000\022X\n\tFocu"
+    "sStop\022#.mavsdk.rpc.camera.FocusStopReque"
+    "st\032$.mavsdk.rpc.camera.FocusStopResponse"
+    "\"\000\022[\n\nFocusRange\022$.mavsdk.rpc.camera.Foc"
+    "usRangeRequest\032%.mavsdk.rpc.camera.Focus"
+    "RangeResponse\"\000\022^\n\013FocusMeters\022%.mavsdk."
+    "rpc.camera.FocusMetersRequest\032&.mavsdk.r"
+    "pc.camera.FocusMetersResponse\"\000\022X\n\tFocus"
+    "Auto\022#.mavsdk.rpc.camera.FocusAutoReques"
+    "t\032$.mavsdk.rpc.camera.FocusAutoResponse\""
+    "\000\022j\n\017FocusAutoSingle\022).mavsdk.rpc.camera"
+    ".FocusAutoSingleRequest\032*.mavsdk.rpc.cam"
+    "era.FocusAutoSingleResponse\"\000\022v\n\023FocusAu"
+    "toContinuous\022-.mavsdk.rpc.camera.FocusAu"
+    "toContinuousRequest\032..mavsdk.rpc.camera."
+    "FocusAutoContinuousResponse\"\000B\037\n\020io.mavs"
+    "dk.cameraB\013CameraProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_2fcamera_2eproto_deps[1] =
     {
@@ -3961,13 +4278,13 @@ static ::absl::once_flag descriptor_table_camera_2fcamera_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_2fcamera_2eproto = {
     false,
     false,
-    13084,
+    14030,
     descriptor_table_protodef_camera_2fcamera_2eproto,
     "camera/camera.proto",
     &descriptor_table_camera_2fcamera_2eproto_once,
     descriptor_table_camera_2fcamera_2eproto_deps,
     1,
-    94,
+    102,
     schemas,
     file_default_instances,
     TableStruct_camera_2fcamera_2eproto::offsets,
@@ -25178,6 +25495,1867 @@ void FocusRangeResponse::InternalSwap(FocusRangeResponse* PROTOBUF_RESTRICT othe
 }
 
 ::google::protobuf::Metadata FocusRangeResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusMetersRequest::_Internal {
+ public:
+};
+
+FocusMetersRequest::FocusMetersRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusMetersRequest)
+}
+FocusMetersRequest::FocusMetersRequest(
+    ::google::protobuf::Arena* arena, const FocusMetersRequest& from)
+    : FocusMetersRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusMetersRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusMetersRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, component_id_),
+           0,
+           offsetof(Impl_, distance_m_) -
+               offsetof(Impl_, component_id_) +
+               sizeof(Impl_::distance_m_));
+}
+FocusMetersRequest::~FocusMetersRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusMetersRequest)
+  SharedDtor(*this);
+}
+inline void FocusMetersRequest::SharedDtor(MessageLite& self) {
+  FocusMetersRequest& this_ = static_cast<FocusMetersRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusMetersRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusMetersRequest(arena);
+}
+constexpr auto FocusMetersRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusMetersRequest),
+                                            alignof(FocusMetersRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusMetersRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusMetersRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusMetersRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusMetersRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusMetersRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusMetersRequest>(), &FocusMetersRequest::ByteSizeLong,
+            &FocusMetersRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusMetersRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusMetersRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 0, 2> FocusMetersRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusMetersRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float distance_m = 2;
+    {::_pbi::TcParser::FastF32S1,
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.distance_m_)}},
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusMetersRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+    // float distance_m = 2;
+    {PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.distance_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusMetersRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusMetersRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.component_id_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.distance_m_) -
+      reinterpret_cast<char*>(&_impl_.component_id_)) + sizeof(_impl_.distance_m_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusMetersRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusMetersRequest& this_ = static_cast<const FocusMetersRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusMetersRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusMetersRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusMetersRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          // float distance_m = 2;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_distance_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_distance_m(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusMetersRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusMetersRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusMetersRequest& this_ = static_cast<const FocusMetersRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusMetersRequest::ByteSizeLong() const {
+          const FocusMetersRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusMetersRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+            // float distance_m = 2;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_distance_m()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusMetersRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusMetersRequest*>(&to_msg);
+  auto& from = static_cast<const FocusMetersRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusMetersRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_distance_m()) != 0) {
+    _this->_impl_.distance_m_ = from._impl_.distance_m_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusMetersRequest::CopyFrom(const FocusMetersRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusMetersRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusMetersRequest::InternalSwap(FocusMetersRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.distance_m_)
+      + sizeof(FocusMetersRequest::_impl_.distance_m_)
+      - PROTOBUF_FIELD_OFFSET(FocusMetersRequest, _impl_.component_id_)>(
+          reinterpret_cast<char*>(&_impl_.component_id_),
+          reinterpret_cast<char*>(&other->_impl_.component_id_));
+}
+
+::google::protobuf::Metadata FocusMetersRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusMetersResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusMetersResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_._has_bits_);
+};
+
+FocusMetersResponse::FocusMetersResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusMetersResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusMetersResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusMetersResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusMetersResponse::FocusMetersResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusMetersResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusMetersResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusMetersResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusMetersResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusMetersResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusMetersResponse::~FocusMetersResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusMetersResponse)
+  SharedDtor(*this);
+}
+inline void FocusMetersResponse::SharedDtor(MessageLite& self) {
+  FocusMetersResponse& this_ = static_cast<FocusMetersResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusMetersResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusMetersResponse(arena);
+}
+constexpr auto FocusMetersResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusMetersResponse),
+                                            alignof(FocusMetersResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusMetersResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusMetersResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusMetersResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusMetersResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusMetersResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusMetersResponse>(), &FocusMetersResponse::ByteSizeLong,
+            &FocusMetersResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusMetersResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusMetersResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusMetersResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusMetersResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusMetersResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusMetersResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusMetersResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusMetersResponse& this_ = static_cast<const FocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusMetersResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusMetersResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusMetersResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusMetersResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusMetersResponse& this_ = static_cast<const FocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusMetersResponse::ByteSizeLong() const {
+          const FocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusMetersResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusMetersResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusMetersResponse*>(&to_msg);
+  auto& from = static_cast<const FocusMetersResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusMetersResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusMetersResponse::CopyFrom(const FocusMetersResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusMetersResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusMetersResponse::InternalSwap(FocusMetersResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusMetersResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoRequest::_Internal {
+ public:
+};
+
+FocusAutoRequest::FocusAutoRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoRequest)
+}
+FocusAutoRequest::FocusAutoRequest(
+    ::google::protobuf::Arena* arena, const FocusAutoRequest& from)
+    : FocusAutoRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.component_id_ = {};
+}
+FocusAutoRequest::~FocusAutoRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoRequest)
+  SharedDtor(*this);
+}
+inline void FocusAutoRequest::SharedDtor(MessageLite& self) {
+  FocusAutoRequest& this_ = static_cast<FocusAutoRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoRequest(arena);
+}
+constexpr auto FocusAutoRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoRequest),
+                                            alignof(FocusAutoRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoRequest>(), &FocusAutoRequest::ByteSizeLong,
+            &FocusAutoRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.component_id_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoRequest& this_ = static_cast<const FocusAutoRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoRequest& this_ = static_cast<const FocusAutoRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoRequest::ByteSizeLong() const {
+          const FocusAutoRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoRequest*>(&to_msg);
+  auto& from = static_cast<const FocusAutoRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoRequest::CopyFrom(const FocusAutoRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoRequest::InternalSwap(FocusAutoRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.component_id_, other->_impl_.component_id_);
+}
+
+::google::protobuf::Metadata FocusAutoRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusAutoResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_._has_bits_);
+};
+
+FocusAutoResponse::FocusAutoResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusAutoResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusAutoResponse::FocusAutoResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusAutoResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusAutoResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusAutoResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusAutoResponse::~FocusAutoResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoResponse::SharedDtor(MessageLite& self) {
+  FocusAutoResponse& this_ = static_cast<FocusAutoResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoResponse(arena);
+}
+constexpr auto FocusAutoResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoResponse),
+                                            alignof(FocusAutoResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoResponse>(), &FocusAutoResponse::ByteSizeLong,
+            &FocusAutoResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusAutoResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoResponse& this_ = static_cast<const FocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoResponse& this_ = static_cast<const FocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoResponse::ByteSizeLong() const {
+          const FocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoResponse::CopyFrom(const FocusAutoResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoResponse::InternalSwap(FocusAutoResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusAutoResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoSingleRequest::_Internal {
+ public:
+};
+
+FocusAutoSingleRequest::FocusAutoSingleRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoSingleRequest)
+}
+FocusAutoSingleRequest::FocusAutoSingleRequest(
+    ::google::protobuf::Arena* arena, const FocusAutoSingleRequest& from)
+    : FocusAutoSingleRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoSingleRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoSingleRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.component_id_ = {};
+}
+FocusAutoSingleRequest::~FocusAutoSingleRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoSingleRequest)
+  SharedDtor(*this);
+}
+inline void FocusAutoSingleRequest::SharedDtor(MessageLite& self) {
+  FocusAutoSingleRequest& this_ = static_cast<FocusAutoSingleRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoSingleRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoSingleRequest(arena);
+}
+constexpr auto FocusAutoSingleRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoSingleRequest),
+                                            alignof(FocusAutoSingleRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoSingleRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoSingleRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoSingleRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoSingleRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoSingleRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoSingleRequest>(), &FocusAutoSingleRequest::ByteSizeLong,
+            &FocusAutoSingleRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoSingleRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoSingleRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoSingleRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoSingleRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoSingleRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoSingleRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoSingleRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoSingleRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoSingleRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoSingleRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.component_id_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoSingleRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoSingleRequest& this_ = static_cast<const FocusAutoSingleRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoSingleRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoSingleRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoSingleRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoSingleRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoSingleRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoSingleRequest& this_ = static_cast<const FocusAutoSingleRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoSingleRequest::ByteSizeLong() const {
+          const FocusAutoSingleRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoSingleRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoSingleRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoSingleRequest*>(&to_msg);
+  auto& from = static_cast<const FocusAutoSingleRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoSingleRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoSingleRequest::CopyFrom(const FocusAutoSingleRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoSingleRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoSingleRequest::InternalSwap(FocusAutoSingleRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.component_id_, other->_impl_.component_id_);
+}
+
+::google::protobuf::Metadata FocusAutoSingleRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoSingleResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusAutoSingleResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_._has_bits_);
+};
+
+FocusAutoSingleResponse::FocusAutoSingleResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoSingleResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoSingleResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusAutoSingleResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusAutoSingleResponse::FocusAutoSingleResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusAutoSingleResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusAutoSingleResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusAutoSingleResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoSingleResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoSingleResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusAutoSingleResponse::~FocusAutoSingleResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoSingleResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoSingleResponse::SharedDtor(MessageLite& self) {
+  FocusAutoSingleResponse& this_ = static_cast<FocusAutoSingleResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoSingleResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoSingleResponse(arena);
+}
+constexpr auto FocusAutoSingleResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoSingleResponse),
+                                            alignof(FocusAutoSingleResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoSingleResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoSingleResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoSingleResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoSingleResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoSingleResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoSingleResponse>(), &FocusAutoSingleResponse::ByteSizeLong,
+            &FocusAutoSingleResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoSingleResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoSingleResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusAutoSingleResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoSingleResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoSingleResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoSingleResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoSingleResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoSingleResponse& this_ = static_cast<const FocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoSingleResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoSingleResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoSingleResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoSingleResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoSingleResponse& this_ = static_cast<const FocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoSingleResponse::ByteSizeLong() const {
+          const FocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoSingleResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoSingleResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoSingleResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoSingleResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoSingleResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoSingleResponse::CopyFrom(const FocusAutoSingleResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoSingleResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoSingleResponse::InternalSwap(FocusAutoSingleResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusAutoSingleResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoContinuousRequest::_Internal {
+ public:
+};
+
+FocusAutoContinuousRequest::FocusAutoContinuousRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+}
+FocusAutoContinuousRequest::FocusAutoContinuousRequest(
+    ::google::protobuf::Arena* arena, const FocusAutoContinuousRequest& from)
+    : FocusAutoContinuousRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoContinuousRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoContinuousRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.component_id_ = {};
+}
+FocusAutoContinuousRequest::~FocusAutoContinuousRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+  SharedDtor(*this);
+}
+inline void FocusAutoContinuousRequest::SharedDtor(MessageLite& self) {
+  FocusAutoContinuousRequest& this_ = static_cast<FocusAutoContinuousRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoContinuousRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoContinuousRequest(arena);
+}
+constexpr auto FocusAutoContinuousRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoContinuousRequest),
+                                            alignof(FocusAutoContinuousRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoContinuousRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoContinuousRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoContinuousRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoContinuousRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoContinuousRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoContinuousRequest>(), &FocusAutoContinuousRequest::ByteSizeLong,
+            &FocusAutoContinuousRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoContinuousRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoContinuousRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoContinuousRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoContinuousRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoContinuousRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoContinuousRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoContinuousRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoContinuousRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoContinuousRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.component_id_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoContinuousRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoContinuousRequest& this_ = static_cast<const FocusAutoContinuousRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoContinuousRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoContinuousRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoContinuousRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoContinuousRequest& this_ = static_cast<const FocusAutoContinuousRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoContinuousRequest::ByteSizeLong() const {
+          const FocusAutoContinuousRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoContinuousRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoContinuousRequest*>(&to_msg);
+  auto& from = static_cast<const FocusAutoContinuousRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoContinuousRequest::CopyFrom(const FocusAutoContinuousRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoContinuousRequest::InternalSwap(FocusAutoContinuousRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.component_id_, other->_impl_.component_id_);
+}
+
+::google::protobuf::Metadata FocusAutoContinuousRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoContinuousResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusAutoContinuousResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_._has_bits_);
+};
+
+FocusAutoContinuousResponse::FocusAutoContinuousResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoContinuousResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusAutoContinuousResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusAutoContinuousResponse::FocusAutoContinuousResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusAutoContinuousResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusAutoContinuousResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoContinuousResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoContinuousResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusAutoContinuousResponse::~FocusAutoContinuousResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoContinuousResponse::SharedDtor(MessageLite& self) {
+  FocusAutoContinuousResponse& this_ = static_cast<FocusAutoContinuousResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoContinuousResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoContinuousResponse(arena);
+}
+constexpr auto FocusAutoContinuousResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoContinuousResponse),
+                                            alignof(FocusAutoContinuousResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoContinuousResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoContinuousResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoContinuousResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoContinuousResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoContinuousResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoContinuousResponse>(), &FocusAutoContinuousResponse::ByteSizeLong,
+            &FocusAutoContinuousResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoContinuousResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoContinuousResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusAutoContinuousResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusAutoContinuousResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoContinuousResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoContinuousResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoContinuousResponse& this_ = static_cast<const FocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoContinuousResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoContinuousResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoContinuousResponse& this_ = static_cast<const FocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoContinuousResponse::ByteSizeLong() const {
+          const FocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoContinuousResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoContinuousResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoContinuousResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoContinuousResponse::CopyFrom(const FocusAutoContinuousResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoContinuousResponse::InternalSwap(FocusAutoContinuousResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusAutoContinuousResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.pb.cc
@@ -1012,6 +1012,31 @@ struct FocusRangeRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusRangeRequestDefaultTypeInternal _FocusRangeRequest_default_instance_;
 
+inline constexpr FocusOutStepRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusOutStepRequest::FocusOutStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusOutStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusOutStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusOutStepRequestDefaultTypeInternal() {}
+  union {
+    FocusOutStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStepRequestDefaultTypeInternal _FocusOutStepRequest_default_instance_;
+
 inline constexpr FocusOutStartRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : component_id_{0},
@@ -1036,6 +1061,31 @@ struct FocusOutStartRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartRequestDefaultTypeInternal _FocusOutStartRequest_default_instance_;
+
+inline constexpr FocusInStepRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : component_id_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusInStepRequest::FocusInStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusInStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusInStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusInStepRequestDefaultTypeInternal() {}
+  union {
+    FocusInStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStepRequestDefaultTypeInternal _FocusInStepRequest_default_instance_;
 
 inline constexpr FocusInStartRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1813,6 +1863,31 @@ struct FocusRangeResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusRangeResponseDefaultTypeInternal _FocusRangeResponse_default_instance_;
 
+inline constexpr FocusOutStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusOutStepResponse::FocusOutStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusOutStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusOutStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusOutStepResponseDefaultTypeInternal() {}
+  union {
+    FocusOutStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStepResponseDefaultTypeInternal _FocusOutStepResponse_default_instance_;
+
 inline constexpr FocusOutStartResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1837,6 +1912,31 @@ struct FocusOutStartResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
+
+inline constexpr FocusInStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusInStepResponse::FocusInStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusInStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusInStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusInStepResponseDefaultTypeInternal() {}
+  union {
+    FocusInStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
 
 inline constexpr FocusInStartResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -3119,6 +3219,44 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::TrackStopResponse, _impl_.camera_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStepRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStepResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStepResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusOutStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusOutStepRequest, _impl_.component_id_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusOutStepResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusOutStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusOutStepResponse, _impl_.camera_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera::FocusInStartRequest, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -3368,21 +3506,25 @@ static const ::_pbi::MigrationSchema
         {749, 758, -1, sizeof(::mavsdk::rpc::camera::TrackRectangleResponse)},
         {759, -1, -1, sizeof(::mavsdk::rpc::camera::TrackStopRequest)},
         {768, 777, -1, sizeof(::mavsdk::rpc::camera::TrackStopResponse)},
-        {778, -1, -1, sizeof(::mavsdk::rpc::camera::FocusInStartRequest)},
-        {787, 796, -1, sizeof(::mavsdk::rpc::camera::FocusInStartResponse)},
-        {797, -1, -1, sizeof(::mavsdk::rpc::camera::FocusOutStartRequest)},
-        {806, 815, -1, sizeof(::mavsdk::rpc::camera::FocusOutStartResponse)},
-        {816, -1, -1, sizeof(::mavsdk::rpc::camera::FocusStopRequest)},
-        {825, 834, -1, sizeof(::mavsdk::rpc::camera::FocusStopResponse)},
-        {835, -1, -1, sizeof(::mavsdk::rpc::camera::FocusRangeRequest)},
-        {845, 854, -1, sizeof(::mavsdk::rpc::camera::FocusRangeResponse)},
-        {855, -1, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
-        {865, -1, -1, sizeof(::mavsdk::rpc::camera::Position)},
-        {877, -1, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
-        {889, -1, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
-        {900, 916, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
-        {924, -1, -1, sizeof(::mavsdk::rpc::camera::Information)},
-        {940, -1, -1, sizeof(::mavsdk::rpc::camera::CameraList)},
+        {778, -1, -1, sizeof(::mavsdk::rpc::camera::FocusInStepRequest)},
+        {787, 796, -1, sizeof(::mavsdk::rpc::camera::FocusInStepResponse)},
+        {797, -1, -1, sizeof(::mavsdk::rpc::camera::FocusOutStepRequest)},
+        {806, 815, -1, sizeof(::mavsdk::rpc::camera::FocusOutStepResponse)},
+        {816, -1, -1, sizeof(::mavsdk::rpc::camera::FocusInStartRequest)},
+        {825, 834, -1, sizeof(::mavsdk::rpc::camera::FocusInStartResponse)},
+        {835, -1, -1, sizeof(::mavsdk::rpc::camera::FocusOutStartRequest)},
+        {844, 853, -1, sizeof(::mavsdk::rpc::camera::FocusOutStartResponse)},
+        {854, -1, -1, sizeof(::mavsdk::rpc::camera::FocusStopRequest)},
+        {863, 872, -1, sizeof(::mavsdk::rpc::camera::FocusStopResponse)},
+        {873, -1, -1, sizeof(::mavsdk::rpc::camera::FocusRangeRequest)},
+        {883, 892, -1, sizeof(::mavsdk::rpc::camera::FocusRangeResponse)},
+        {893, -1, -1, sizeof(::mavsdk::rpc::camera::CameraResult)},
+        {903, -1, -1, sizeof(::mavsdk::rpc::camera::Position)},
+        {915, -1, -1, sizeof(::mavsdk::rpc::camera::Quaternion)},
+        {927, -1, -1, sizeof(::mavsdk::rpc::camera::EulerAngle)},
+        {938, 954, -1, sizeof(::mavsdk::rpc::camera::CaptureInfo)},
+        {962, -1, -1, sizeof(::mavsdk::rpc::camera::Information)},
+        {978, -1, -1, sizeof(::mavsdk::rpc::camera::CameraList)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera::_Option_default_instance_._instance,
@@ -3460,6 +3602,10 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera::_TrackRectangleResponse_default_instance_._instance,
     &::mavsdk::rpc::camera::_TrackStopRequest_default_instance_._instance,
     &::mavsdk::rpc::camera::_TrackStopResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusInStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusInStepResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusOutStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera::_FocusOutStepResponse_default_instance_._instance,
     &::mavsdk::rpc::camera::_FocusInStartRequest_default_instance_._instance,
     &::mavsdk::rpc::camera::_FocusInStartResponse_default_instance_._instance,
     &::mavsdk::rpc::camera::_FocusOutStartRequest_default_instance_._instance,
@@ -3651,150 +3797,161 @@ const char descriptor_table_protodef_camera_2fcamera_2eproto[] ABSL_ATTRIBUTE_SE
     "esult\"(\n\020TrackStopRequest\022\024\n\014component_i"
     "d\030\001 \001(\005\"K\n\021TrackStopResponse\0226\n\rcamera_r"
     "esult\030\001 \001(\0132\037.mavsdk.rpc.camera.CameraRe"
-    "sult\"+\n\023FocusInStartRequest\022\024\n\014component"
-    "_id\030\001 \001(\005\"N\n\024FocusInStartResponse\0226\n\rcam"
-    "era_result\030\001 \001(\0132\037.mavsdk.rpc.camera.Cam"
-    "eraResult\",\n\024FocusOutStartRequest\022\024\n\014com"
-    "ponent_id\030\001 \001(\005\"O\n\025FocusOutStartResponse"
-    "\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rpc.cam"
-    "era.CameraResult\"(\n\020FocusStopRequest\022\024\n\014"
-    "component_id\030\001 \001(\005\"K\n\021FocusStopResponse\022"
-    "6\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rpc.came"
-    "ra.CameraResult\"8\n\021FocusRangeRequest\022\024\n\014"
-    "component_id\030\001 \001(\005\022\r\n\005range\030\002 \001(\002\"L\n\022Foc"
-    "usRangeResponse\0226\n\rcamera_result\030\001 \001(\0132\037"
-    ".mavsdk.rpc.camera.CameraResult\"\226\003\n\014Came"
-    "raResult\0226\n\006result\030\001 \001(\0162&.mavsdk.rpc.ca"
-    "mera.CameraResult.Result\022\022\n\nresult_str\030\002"
-    " \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016R"
-    "ESULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PROGRESS\020\002\022"
-    "\017\n\013RESULT_BUSY\020\003\022\021\n\rRESULT_DENIED\020\004\022\020\n\014R"
-    "ESULT_ERROR\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\031\n\025RES"
-    "ULT_WRONG_ARGUMENT\020\007\022\024\n\020RESULT_NO_SYSTEM"
-    "\020\010\022\037\n\033RESULT_PROTOCOL_UNSUPPORTED\020\t\022\026\n\022R"
-    "ESULT_UNAVAILABLE\020\n\022\034\n\030RESULT_CAMERA_ID_"
-    "INVALID\020\013\022\035\n\031RESULT_ACTION_UNSUPPORTED\020\014"
-    "\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlo"
-    "ngitude_deg\030\002 \001(\001\022\033\n\023absolute_altitude_m"
-    "\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 \001(\002\"8\n\nQ"
-    "uaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t\n\001y\030\003 \001"
-    "(\002\022\t\n\001z\030\004 \001(\002\"B\n\nEulerAngle\022\020\n\010roll_deg\030"
-    "\001 \001(\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_deg\030\003 \001("
-    "\002\"\225\002\n\013CaptureInfo\022\024\n\014component_id\030\001 \001(\005\022"
-    "-\n\010position\030\002 \001(\0132\033.mavsdk.rpc.camera.Po"
-    "sition\022:\n\023attitude_quaternion\030\003 \001(\0132\035.ma"
-    "vsdk.rpc.camera.Quaternion\022;\n\024attitude_e"
-    "uler_angle\030\004 \001(\0132\035.mavsdk.rpc.camera.Eul"
-    "erAngle\022\023\n\013time_utc_us\030\005 \001(\004\022\022\n\nis_succe"
-    "ss\030\006 \001(\010\022\r\n\005index\030\007 \001(\005\022\020\n\010file_url\030\010 \001("
-    "\t\"\353\001\n\013Information\022\024\n\014component_id\030\001 \001(\005\022"
-    "\023\n\013vendor_name\030\002 \001(\t\022\022\n\nmodel_name\030\003 \001(\t"
-    "\022\027\n\017focal_length_mm\030\004 \001(\002\022!\n\031horizontal_"
-    "sensor_size_mm\030\005 \001(\002\022\037\n\027vertical_sensor_"
-    "size_mm\030\006 \001(\002\022 \n\030horizontal_resolution_p"
-    "x\030\007 \001(\r\022\036\n\026vertical_resolution_px\030\010 \001(\r\""
-    "=\n\nCameraList\022/\n\007cameras\030\001 \003(\0132\036.mavsdk."
-    "rpc.camera.Information*8\n\004Mode\022\020\n\014MODE_U"
-    "NKNOWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\002"
-    "*F\n\013PhotosRange\022\024\n\020PHOTOS_RANGE_ALL\020\000\022!\n"
-    "\035PHOTOS_RANGE_SINCE_CONNECTION\020\0012\335\035\n\rCam"
-    "eraService\022X\n\tTakePhoto\022#.mavsdk.rpc.cam"
-    "era.TakePhotoRequest\032$.mavsdk.rpc.camera"
-    ".TakePhotoResponse\"\000\022s\n\022StartPhotoInterv"
-    "al\022,.mavsdk.rpc.camera.StartPhotoInterva"
-    "lRequest\032-.mavsdk.rpc.camera.StartPhotoI"
-    "ntervalResponse\"\000\022p\n\021StopPhotoInterval\022+"
-    ".mavsdk.rpc.camera.StopPhotoIntervalRequ"
-    "est\032,.mavsdk.rpc.camera.StopPhotoInterva"
-    "lResponse\"\000\022[\n\nStartVideo\022$.mavsdk.rpc.c"
-    "amera.StartVideoRequest\032%.mavsdk.rpc.cam"
-    "era.StartVideoResponse\"\000\022X\n\tStopVideo\022#."
-    "mavsdk.rpc.camera.StopVideoRequest\032$.mav"
-    "sdk.rpc.camera.StopVideoResponse\"\000\022z\n\023St"
-    "artVideoStreaming\022-.mavsdk.rpc.camera.St"
-    "artVideoStreamingRequest\032..mavsdk.rpc.ca"
-    "mera.StartVideoStreamingResponse\"\004\200\265\030\001\022w"
-    "\n\022StopVideoStreaming\022,.mavsdk.rpc.camera"
-    ".StopVideoStreamingRequest\032-.mavsdk.rpc."
-    "camera.StopVideoStreamingResponse\"\004\200\265\030\001\022"
-    "R\n\007SetMode\022!.mavsdk.rpc.camera.SetModeRe"
-    "quest\032\".mavsdk.rpc.camera.SetModeRespons"
-    "e\"\000\022[\n\nListPhotos\022$.mavsdk.rpc.camera.Li"
-    "stPhotosRequest\032%.mavsdk.rpc.camera.List"
-    "PhotosResponse\"\000\022o\n\023SubscribeCameraList\022"
-    "-.mavsdk.rpc.camera.SubscribeCameraListR"
-    "equest\032%.mavsdk.rpc.camera.CameraListRes"
-    "ponse\"\0000\001\022a\n\rSubscribeMode\022\'.mavsdk.rpc."
-    "camera.SubscribeModeRequest\032\037.mavsdk.rpc"
-    ".camera.ModeResponse\"\004\200\265\030\0000\001\022V\n\007GetMode\022"
-    "!.mavsdk.rpc.camera.GetModeRequest\032\".mav"
-    "sdk.rpc.camera.GetModeResponse\"\004\200\265\030\001\022\202\001\n"
-    "\030SubscribeVideoStreamInfo\0222.mavsdk.rpc.c"
-    "amera.SubscribeVideoStreamInfoRequest\032*."
-    "mavsdk.rpc.camera.VideoStreamInfoRespons"
-    "e\"\004\200\265\030\0000\001\022w\n\022GetVideoStreamInfo\022,.mavsdk"
-    ".rpc.camera.GetVideoStreamInfoRequest\032-."
-    "mavsdk.rpc.camera.GetVideoStreamInfoResp"
-    "onse\"\004\200\265\030\001\022v\n\024SubscribeCaptureInfo\022..mav"
-    "sdk.rpc.camera.SubscribeCaptureInfoReque"
-    "st\032&.mavsdk.rpc.camera.CaptureInfoRespon"
-    "se\"\004\200\265\030\0000\001\022j\n\020SubscribeStorage\022*.mavsdk."
-    "rpc.camera.SubscribeStorageRequest\032\".mav"
-    "sdk.rpc.camera.StorageResponse\"\004\200\265\030\0000\001\022_"
-    "\n\nGetStorage\022$.mavsdk.rpc.camera.GetStor"
-    "ageRequest\032%.mavsdk.rpc.camera.GetStorag"
-    "eResponse\"\004\200\265\030\001\022\202\001\n\030SubscribeCurrentSett"
-    "ings\0222.mavsdk.rpc.camera.SubscribeCurren"
-    "tSettingsRequest\032*.mavsdk.rpc.camera.Cur"
-    "rentSettingsResponse\"\004\200\265\030\0000\001\022w\n\022GetCurre"
-    "ntSettings\022,.mavsdk.rpc.camera.GetCurren"
-    "tSettingsRequest\032-.mavsdk.rpc.camera.Get"
-    "CurrentSettingsResponse\"\004\200\265\030\001\022\227\001\n\037Subscr"
-    "ibePossibleSettingOptions\0229.mavsdk.rpc.c"
-    "amera.SubscribePossibleSettingOptionsReq"
-    "uest\0321.mavsdk.rpc.camera.PossibleSetting"
-    "OptionsResponse\"\004\200\265\030\0000\001\022\214\001\n\031GetPossibleS"
-    "ettingOptions\0223.mavsdk.rpc.camera.GetPos"
-    "sibleSettingOptionsRequest\0324.mavsdk.rpc."
-    "camera.GetPossibleSettingOptionsResponse"
-    "\"\004\200\265\030\001\022[\n\nSetSetting\022$.mavsdk.rpc.camera"
-    ".SetSettingRequest\032%.mavsdk.rpc.camera.S"
-    "etSettingResponse\"\000\022[\n\nGetSetting\022$.mavs"
-    "dk.rpc.camera.GetSettingRequest\032%.mavsdk"
-    ".rpc.camera.GetSettingResponse\"\000\022d\n\rForm"
-    "atStorage\022\'.mavsdk.rpc.camera.FormatStor"
-    "ageRequest\032(.mavsdk.rpc.camera.FormatSto"
-    "rageResponse\"\000\022d\n\rResetSettings\022\'.mavsdk"
-    ".rpc.camera.ResetSettingsRequest\032(.mavsd"
-    "k.rpc.camera.ResetSettingsResponse\"\000\022^\n\013"
-    "ZoomInStart\022%.mavsdk.rpc.camera.ZoomInSt"
-    "artRequest\032&.mavsdk.rpc.camera.ZoomInSta"
-    "rtResponse\"\000\022a\n\014ZoomOutStart\022&.mavsdk.rp"
-    "c.camera.ZoomOutStartRequest\032\'.mavsdk.rp"
-    "c.camera.ZoomOutStartResponse\"\000\022U\n\010ZoomS"
-    "top\022\".mavsdk.rpc.camera.ZoomStopRequest\032"
-    "#.mavsdk.rpc.camera.ZoomStopResponse\"\000\022X"
-    "\n\tZoomRange\022#.mavsdk.rpc.camera.ZoomRang"
-    "eRequest\032$.mavsdk.rpc.camera.ZoomRangeRe"
-    "sponse\"\000\022[\n\nTrackPoint\022$.mavsdk.rpc.came"
-    "ra.TrackPointRequest\032%.mavsdk.rpc.camera"
-    ".TrackPointResponse\"\000\022g\n\016TrackRectangle\022"
-    "(.mavsdk.rpc.camera.TrackRectangleReques"
-    "t\032).mavsdk.rpc.camera.TrackRectangleResp"
-    "onse\"\000\022X\n\tTrackStop\022#.mavsdk.rpc.camera."
-    "TrackStopRequest\032$.mavsdk.rpc.camera.Tra"
-    "ckStopResponse\"\000\022a\n\014FocusInStart\022&.mavsd"
-    "k.rpc.camera.FocusInStartRequest\032\'.mavsd"
-    "k.rpc.camera.FocusInStartResponse\"\000\022d\n\rF"
-    "ocusOutStart\022\'.mavsdk.rpc.camera.FocusOu"
-    "tStartRequest\032(.mavsdk.rpc.camera.FocusO"
-    "utStartResponse\"\000\022X\n\tFocusStop\022#.mavsdk."
-    "rpc.camera.FocusStopRequest\032$.mavsdk.rpc"
-    ".camera.FocusStopResponse\"\000\022[\n\nFocusRang"
-    "e\022$.mavsdk.rpc.camera.FocusRangeRequest\032"
-    "%.mavsdk.rpc.camera.FocusRangeResponse\"\000"
-    "B\037\n\020io.mavsdk.cameraB\013CameraProtob\006proto"
-    "3"
+    "sult\"*\n\022FocusInStepRequest\022\024\n\014component_"
+    "id\030\001 \001(\005\"M\n\023FocusInStepResponse\0226\n\rcamer"
+    "a_result\030\001 \001(\0132\037.mavsdk.rpc.camera.Camer"
+    "aResult\"+\n\023FocusOutStepRequest\022\024\n\014compon"
+    "ent_id\030\001 \001(\005\"N\n\024FocusOutStepResponse\0226\n\r"
+    "camera_result\030\001 \001(\0132\037.mavsdk.rpc.camera."
+    "CameraResult\"+\n\023FocusInStartRequest\022\024\n\014c"
+    "omponent_id\030\001 \001(\005\"N\n\024FocusInStartRespons"
+    "e\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk.rpc.ca"
+    "mera.CameraResult\",\n\024FocusOutStartReques"
+    "t\022\024\n\014component_id\030\001 \001(\005\"O\n\025FocusOutStart"
+    "Response\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk"
+    ".rpc.camera.CameraResult\"(\n\020FocusStopReq"
+    "uest\022\024\n\014component_id\030\001 \001(\005\"K\n\021FocusStopR"
+    "esponse\0226\n\rcamera_result\030\001 \001(\0132\037.mavsdk."
+    "rpc.camera.CameraResult\"8\n\021FocusRangeReq"
+    "uest\022\024\n\014component_id\030\001 \001(\005\022\r\n\005range\030\002 \001("
+    "\002\"L\n\022FocusRangeResponse\0226\n\rcamera_result"
+    "\030\001 \001(\0132\037.mavsdk.rpc.camera.CameraResult\""
+    "\226\003\n\014CameraResult\0226\n\006result\030\001 \001(\0162&.mavsd"
+    "k.rpc.camera.CameraResult.Result\022\022\n\nresu"
+    "lt_str\030\002 \001(\t\"\271\002\n\006Result\022\022\n\016RESULT_UNKNOW"
+    "N\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PRO"
+    "GRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rRESULT_DENIE"
+    "D\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RESULT_TIMEOUT\020"
+    "\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007\022\024\n\020RESULT_N"
+    "O_SYSTEM\020\010\022\037\n\033RESULT_PROTOCOL_UNSUPPORTE"
+    "D\020\t\022\026\n\022RESULT_UNAVAILABLE\020\n\022\034\n\030RESULT_CA"
+    "MERA_ID_INVALID\020\013\022\035\n\031RESULT_ACTION_UNSUP"
+    "PORTED\020\014\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001"
+    "(\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_al"
+    "titude_m\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 "
+    "\001(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022"
+    "\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"B\n\nEulerAngle\022\020\n\010r"
+    "oll_deg\030\001 \001(\002\022\021\n\tpitch_deg\030\002 \001(\002\022\017\n\007yaw_"
+    "deg\030\003 \001(\002\"\225\002\n\013CaptureInfo\022\024\n\014component_i"
+    "d\030\001 \001(\005\022-\n\010position\030\002 \001(\0132\033.mavsdk.rpc.c"
+    "amera.Position\022:\n\023attitude_quaternion\030\003 "
+    "\001(\0132\035.mavsdk.rpc.camera.Quaternion\022;\n\024at"
+    "titude_euler_angle\030\004 \001(\0132\035.mavsdk.rpc.ca"
+    "mera.EulerAngle\022\023\n\013time_utc_us\030\005 \001(\004\022\022\n\n"
+    "is_success\030\006 \001(\010\022\r\n\005index\030\007 \001(\005\022\020\n\010file_"
+    "url\030\010 \001(\t\"\353\001\n\013Information\022\024\n\014component_i"
+    "d\030\001 \001(\005\022\023\n\013vendor_name\030\002 \001(\t\022\022\n\nmodel_na"
+    "me\030\003 \001(\t\022\027\n\017focal_length_mm\030\004 \001(\002\022!\n\031hor"
+    "izontal_sensor_size_mm\030\005 \001(\002\022\037\n\027vertical"
+    "_sensor_size_mm\030\006 \001(\002\022 \n\030horizontal_reso"
+    "lution_px\030\007 \001(\r\022\036\n\026vertical_resolution_p"
+    "x\030\010 \001(\r\"=\n\nCameraList\022/\n\007cameras\030\001 \003(\0132\036"
+    ".mavsdk.rpc.camera.Information*8\n\004Mode\022\020"
+    "\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE"
+    "_VIDEO\020\002*F\n\013PhotosRange\022\024\n\020PHOTOS_RANGE_"
+    "ALL\020\000\022!\n\035PHOTOS_RANGE_SINCE_CONNECTION\020\001"
+    "2\240\037\n\rCameraService\022X\n\tTakePhoto\022#.mavsdk"
+    ".rpc.camera.TakePhotoRequest\032$.mavsdk.rp"
+    "c.camera.TakePhotoResponse\"\000\022s\n\022StartPho"
+    "toInterval\022,.mavsdk.rpc.camera.StartPhot"
+    "oIntervalRequest\032-.mavsdk.rpc.camera.Sta"
+    "rtPhotoIntervalResponse\"\000\022p\n\021StopPhotoIn"
+    "terval\022+.mavsdk.rpc.camera.StopPhotoInte"
+    "rvalRequest\032,.mavsdk.rpc.camera.StopPhot"
+    "oIntervalResponse\"\000\022[\n\nStartVideo\022$.mavs"
+    "dk.rpc.camera.StartVideoRequest\032%.mavsdk"
+    ".rpc.camera.StartVideoResponse\"\000\022X\n\tStop"
+    "Video\022#.mavsdk.rpc.camera.StopVideoReque"
+    "st\032$.mavsdk.rpc.camera.StopVideoResponse"
+    "\"\000\022z\n\023StartVideoStreaming\022-.mavsdk.rpc.c"
+    "amera.StartVideoStreamingRequest\032..mavsd"
+    "k.rpc.camera.StartVideoStreamingResponse"
+    "\"\004\200\265\030\001\022w\n\022StopVideoStreaming\022,.mavsdk.rp"
+    "c.camera.StopVideoStreamingRequest\032-.mav"
+    "sdk.rpc.camera.StopVideoStreamingRespons"
+    "e\"\004\200\265\030\001\022R\n\007SetMode\022!.mavsdk.rpc.camera.S"
+    "etModeRequest\032\".mavsdk.rpc.camera.SetMod"
+    "eResponse\"\000\022[\n\nListPhotos\022$.mavsdk.rpc.c"
+    "amera.ListPhotosRequest\032%.mavsdk.rpc.cam"
+    "era.ListPhotosResponse\"\000\022o\n\023SubscribeCam"
+    "eraList\022-.mavsdk.rpc.camera.SubscribeCam"
+    "eraListRequest\032%.mavsdk.rpc.camera.Camer"
+    "aListResponse\"\0000\001\022a\n\rSubscribeMode\022\'.mav"
+    "sdk.rpc.camera.SubscribeModeRequest\032\037.ma"
+    "vsdk.rpc.camera.ModeResponse\"\004\200\265\030\0000\001\022V\n\007"
+    "GetMode\022!.mavsdk.rpc.camera.GetModeReque"
+    "st\032\".mavsdk.rpc.camera.GetModeResponse\"\004"
+    "\200\265\030\001\022\202\001\n\030SubscribeVideoStreamInfo\0222.mavs"
+    "dk.rpc.camera.SubscribeVideoStreamInfoRe"
+    "quest\032*.mavsdk.rpc.camera.VideoStreamInf"
+    "oResponse\"\004\200\265\030\0000\001\022w\n\022GetVideoStreamInfo\022"
+    ",.mavsdk.rpc.camera.GetVideoStreamInfoRe"
+    "quest\032-.mavsdk.rpc.camera.GetVideoStream"
+    "InfoResponse\"\004\200\265\030\001\022v\n\024SubscribeCaptureIn"
+    "fo\022..mavsdk.rpc.camera.SubscribeCaptureI"
+    "nfoRequest\032&.mavsdk.rpc.camera.CaptureIn"
+    "foResponse\"\004\200\265\030\0000\001\022j\n\020SubscribeStorage\022*"
+    ".mavsdk.rpc.camera.SubscribeStorageReque"
+    "st\032\".mavsdk.rpc.camera.StorageResponse\"\004"
+    "\200\265\030\0000\001\022_\n\nGetStorage\022$.mavsdk.rpc.camera"
+    ".GetStorageRequest\032%.mavsdk.rpc.camera.G"
+    "etStorageResponse\"\004\200\265\030\001\022\202\001\n\030SubscribeCur"
+    "rentSettings\0222.mavsdk.rpc.camera.Subscri"
+    "beCurrentSettingsRequest\032*.mavsdk.rpc.ca"
+    "mera.CurrentSettingsResponse\"\004\200\265\030\0000\001\022w\n\022"
+    "GetCurrentSettings\022,.mavsdk.rpc.camera.G"
+    "etCurrentSettingsRequest\032-.mavsdk.rpc.ca"
+    "mera.GetCurrentSettingsResponse\"\004\200\265\030\001\022\227\001"
+    "\n\037SubscribePossibleSettingOptions\0229.mavs"
+    "dk.rpc.camera.SubscribePossibleSettingOp"
+    "tionsRequest\0321.mavsdk.rpc.camera.Possibl"
+    "eSettingOptionsResponse\"\004\200\265\030\0000\001\022\214\001\n\031GetP"
+    "ossibleSettingOptions\0223.mavsdk.rpc.camer"
+    "a.GetPossibleSettingOptionsRequest\0324.mav"
+    "sdk.rpc.camera.GetPossibleSettingOptions"
+    "Response\"\004\200\265\030\001\022[\n\nSetSetting\022$.mavsdk.rp"
+    "c.camera.SetSettingRequest\032%.mavsdk.rpc."
+    "camera.SetSettingResponse\"\000\022[\n\nGetSettin"
+    "g\022$.mavsdk.rpc.camera.GetSettingRequest\032"
+    "%.mavsdk.rpc.camera.GetSettingResponse\"\000"
+    "\022d\n\rFormatStorage\022\'.mavsdk.rpc.camera.Fo"
+    "rmatStorageRequest\032(.mavsdk.rpc.camera.F"
+    "ormatStorageResponse\"\000\022d\n\rResetSettings\022"
+    "\'.mavsdk.rpc.camera.ResetSettingsRequest"
+    "\032(.mavsdk.rpc.camera.ResetSettingsRespon"
+    "se\"\000\022^\n\013ZoomInStart\022%.mavsdk.rpc.camera."
+    "ZoomInStartRequest\032&.mavsdk.rpc.camera.Z"
+    "oomInStartResponse\"\000\022a\n\014ZoomOutStart\022&.m"
+    "avsdk.rpc.camera.ZoomOutStartRequest\032\'.m"
+    "avsdk.rpc.camera.ZoomOutStartResponse\"\000\022"
+    "U\n\010ZoomStop\022\".mavsdk.rpc.camera.ZoomStop"
+    "Request\032#.mavsdk.rpc.camera.ZoomStopResp"
+    "onse\"\000\022X\n\tZoomRange\022#.mavsdk.rpc.camera."
+    "ZoomRangeRequest\032$.mavsdk.rpc.camera.Zoo"
+    "mRangeResponse\"\000\022[\n\nTrackPoint\022$.mavsdk."
+    "rpc.camera.TrackPointRequest\032%.mavsdk.rp"
+    "c.camera.TrackPointResponse\"\000\022g\n\016TrackRe"
+    "ctangle\022(.mavsdk.rpc.camera.TrackRectang"
+    "leRequest\032).mavsdk.rpc.camera.TrackRecta"
+    "ngleResponse\"\000\022X\n\tTrackStop\022#.mavsdk.rpc"
+    ".camera.TrackStopRequest\032$.mavsdk.rpc.ca"
+    "mera.TrackStopResponse\"\000\022^\n\013FocusInStep\022"
+    "%.mavsdk.rpc.camera.FocusInStepRequest\032&"
+    ".mavsdk.rpc.camera.FocusInStepResponse\"\000"
+    "\022a\n\014FocusOutStep\022&.mavsdk.rpc.camera.Foc"
+    "usOutStepRequest\032\'.mavsdk.rpc.camera.Foc"
+    "usOutStepResponse\"\000\022a\n\014FocusInStart\022&.ma"
+    "vsdk.rpc.camera.FocusInStartRequest\032\'.ma"
+    "vsdk.rpc.camera.FocusInStartResponse\"\000\022d"
+    "\n\rFocusOutStart\022\'.mavsdk.rpc.camera.Focu"
+    "sOutStartRequest\032(.mavsdk.rpc.camera.Foc"
+    "usOutStartResponse\"\000\022X\n\tFocusStop\022#.mavs"
+    "dk.rpc.camera.FocusStopRequest\032$.mavsdk."
+    "rpc.camera.FocusStopResponse\"\000\022[\n\nFocusR"
+    "ange\022$.mavsdk.rpc.camera.FocusRangeReque"
+    "st\032%.mavsdk.rpc.camera.FocusRangeRespons"
+    "e\"\000B\037\n\020io.mavsdk.cameraB\013CameraProtob\006pr"
+    "oto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_2fcamera_2eproto_deps[1] =
     {
@@ -3804,13 +3961,13 @@ static ::absl::once_flag descriptor_table_camera_2fcamera_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_2fcamera_2eproto = {
     false,
     false,
-    12641,
+    13084,
     descriptor_table_protodef_camera_2fcamera_2eproto,
     "camera/camera.proto",
     &descriptor_table_camera_2fcamera_2eproto_once,
     descriptor_table_camera_2fcamera_2eproto_deps,
     1,
-    90,
+    94,
     schemas,
     file_default_instances,
     TableStruct_camera_2fcamera_2eproto::offsets,
@@ -22246,6 +22403,920 @@ void TrackStopResponse::InternalSwap(TrackStopResponse* PROTOBUF_RESTRICT other)
 }
 
 ::google::protobuf::Metadata TrackStopResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusInStepRequest::_Internal {
+ public:
+};
+
+FocusInStepRequest::FocusInStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusInStepRequest)
+}
+FocusInStepRequest::FocusInStepRequest(
+    ::google::protobuf::Arena* arena, const FocusInStepRequest& from)
+    : FocusInStepRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusInStepRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusInStepRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.component_id_ = {};
+}
+FocusInStepRequest::~FocusInStepRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusInStepRequest)
+  SharedDtor(*this);
+}
+inline void FocusInStepRequest::SharedDtor(MessageLite& self) {
+  FocusInStepRequest& this_ = static_cast<FocusInStepRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusInStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusInStepRequest(arena);
+}
+constexpr auto FocusInStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusInStepRequest),
+                                            alignof(FocusInStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusInStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusInStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusInStepRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusInStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusInStepRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusInStepRequest>(), &FocusInStepRequest::ByteSizeLong,
+            &FocusInStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusInStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusInStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusInStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusInStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusInStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusInStepRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusInStepRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusInStepRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusInStepRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusInStepRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.component_id_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusInStepRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusInStepRequest& this_ = static_cast<const FocusInStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusInStepRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusInStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusInStepRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusInStepRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusInStepRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusInStepRequest& this_ = static_cast<const FocusInStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusInStepRequest::ByteSizeLong() const {
+          const FocusInStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusInStepRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusInStepRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusInStepRequest*>(&to_msg);
+  auto& from = static_cast<const FocusInStepRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusInStepRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusInStepRequest::CopyFrom(const FocusInStepRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusInStepRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusInStepRequest::InternalSwap(FocusInStepRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.component_id_, other->_impl_.component_id_);
+}
+
+::google::protobuf::Metadata FocusInStepRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusInStepResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusInStepResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_._has_bits_);
+};
+
+FocusInStepResponse::FocusInStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusInStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusInStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusInStepResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusInStepResponse::FocusInStepResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusInStepResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusInStepResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusInStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusInStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusInStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusInStepResponse::~FocusInStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusInStepResponse)
+  SharedDtor(*this);
+}
+inline void FocusInStepResponse::SharedDtor(MessageLite& self) {
+  FocusInStepResponse& this_ = static_cast<FocusInStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusInStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusInStepResponse(arena);
+}
+constexpr auto FocusInStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusInStepResponse),
+                                            alignof(FocusInStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusInStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusInStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusInStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusInStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusInStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusInStepResponse>(), &FocusInStepResponse::ByteSizeLong,
+            &FocusInStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusInStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusInStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusInStepResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusInStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusInStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusInStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusInStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusInStepResponse& this_ = static_cast<const FocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusInStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusInStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusInStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusInStepResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusInStepResponse& this_ = static_cast<const FocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusInStepResponse::ByteSizeLong() const {
+          const FocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusInStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusInStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusInStepResponse*>(&to_msg);
+  auto& from = static_cast<const FocusInStepResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusInStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusInStepResponse::CopyFrom(const FocusInStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusInStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusInStepResponse::InternalSwap(FocusInStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusInStepResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusOutStepRequest::_Internal {
+ public:
+};
+
+FocusOutStepRequest::FocusOutStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusOutStepRequest)
+}
+FocusOutStepRequest::FocusOutStepRequest(
+    ::google::protobuf::Arena* arena, const FocusOutStepRequest& from)
+    : FocusOutStepRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusOutStepRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusOutStepRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.component_id_ = {};
+}
+FocusOutStepRequest::~FocusOutStepRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusOutStepRequest)
+  SharedDtor(*this);
+}
+inline void FocusOutStepRequest::SharedDtor(MessageLite& self) {
+  FocusOutStepRequest& this_ = static_cast<FocusOutStepRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusOutStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusOutStepRequest(arena);
+}
+constexpr auto FocusOutStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusOutStepRequest),
+                                            alignof(FocusOutStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusOutStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusOutStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusOutStepRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusOutStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusOutStepRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusOutStepRequest>(), &FocusOutStepRequest::ByteSizeLong,
+            &FocusOutStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusOutStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &FocusOutStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusOutStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusOutStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusOutStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 component_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusOutStepRequest, _impl_.component_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusOutStepRequest, _impl_.component_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 component_id = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusOutStepRequest, _impl_.component_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusOutStepRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusOutStepRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.component_id_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusOutStepRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusOutStepRequest& this_ = static_cast<const FocusOutStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusOutStepRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusOutStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusOutStepRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 component_id = 1;
+          if (this_._internal_component_id() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_component_id(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusOutStepRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusOutStepRequest::ByteSizeLong(const MessageLite& base) {
+          const FocusOutStepRequest& this_ = static_cast<const FocusOutStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusOutStepRequest::ByteSizeLong() const {
+          const FocusOutStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusOutStepRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 component_id = 1;
+            if (this_._internal_component_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_component_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusOutStepRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusOutStepRequest*>(&to_msg);
+  auto& from = static_cast<const FocusOutStepRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusOutStepRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_component_id() != 0) {
+    _this->_impl_.component_id_ = from._impl_.component_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusOutStepRequest::CopyFrom(const FocusOutStepRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusOutStepRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusOutStepRequest::InternalSwap(FocusOutStepRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.component_id_, other->_impl_.component_id_);
+}
+
+::google::protobuf::Metadata FocusOutStepRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusOutStepResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<FocusOutStepResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_._has_bits_);
+};
+
+FocusOutStepResponse::FocusOutStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera.FocusOutStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusOutStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera::FocusOutStepResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+FocusOutStepResponse::FocusOutStepResponse(
+    ::google::protobuf::Arena* arena,
+    const FocusOutStepResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  FocusOutStepResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(
+                              arena, *from._impl_.camera_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera.FocusOutStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE FocusOutStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusOutStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_result_ = {};
+}
+FocusOutStepResponse::~FocusOutStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera.FocusOutStepResponse)
+  SharedDtor(*this);
+}
+inline void FocusOutStepResponse::SharedDtor(MessageLite& self) {
+  FocusOutStepResponse& this_ = static_cast<FocusOutStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusOutStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusOutStepResponse(arena);
+}
+constexpr auto FocusOutStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusOutStepResponse),
+                                            alignof(FocusOutStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusOutStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusOutStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusOutStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusOutStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusOutStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusOutStepResponse>(), &FocusOutStepResponse::ByteSizeLong,
+            &FocusOutStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusOutStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_2fcamera_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusOutStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> FocusOutStepResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::FocusOutStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_.camera_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_.camera_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera::CameraResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusOutStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera.FocusOutStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_result_ != nullptr);
+    _impl_.camera_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusOutStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusOutStepResponse& this_ = static_cast<const FocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusOutStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera.FocusOutStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_result_, this_._impl_.camera_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera.FocusOutStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusOutStepResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusOutStepResponse& this_ = static_cast<const FocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusOutStepResponse::ByteSizeLong() const {
+          const FocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera.FocusOutStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusOutStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusOutStepResponse*>(&to_msg);
+  auto& from = static_cast<const FocusOutStepResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera.FocusOutStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_result_ != nullptr);
+    if (_this->_impl_.camera_result_ == nullptr) {
+      _this->_impl_.camera_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera::CameraResult>(arena, *from._impl_.camera_result_);
+    } else {
+      _this->_impl_.camera_result_->MergeFrom(*from._impl_.camera_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusOutStepResponse::CopyFrom(const FocusOutStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera.FocusOutStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusOutStepResponse::InternalSwap(FocusOutStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_result_, other->_impl_.camera_result_);
+}
+
+::google::protobuf::Metadata FocusOutStepResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.pb.h
@@ -81,6 +81,24 @@ extern CurrentSettingsUpdateDefaultTypeInternal _CurrentSettingsUpdate_default_i
 class EulerAngle;
 struct EulerAngleDefaultTypeInternal;
 extern EulerAngleDefaultTypeInternal _EulerAngle_default_instance_;
+class FocusAutoContinuousRequest;
+struct FocusAutoContinuousRequestDefaultTypeInternal;
+extern FocusAutoContinuousRequestDefaultTypeInternal _FocusAutoContinuousRequest_default_instance_;
+class FocusAutoContinuousResponse;
+struct FocusAutoContinuousResponseDefaultTypeInternal;
+extern FocusAutoContinuousResponseDefaultTypeInternal _FocusAutoContinuousResponse_default_instance_;
+class FocusAutoRequest;
+struct FocusAutoRequestDefaultTypeInternal;
+extern FocusAutoRequestDefaultTypeInternal _FocusAutoRequest_default_instance_;
+class FocusAutoResponse;
+struct FocusAutoResponseDefaultTypeInternal;
+extern FocusAutoResponseDefaultTypeInternal _FocusAutoResponse_default_instance_;
+class FocusAutoSingleRequest;
+struct FocusAutoSingleRequestDefaultTypeInternal;
+extern FocusAutoSingleRequestDefaultTypeInternal _FocusAutoSingleRequest_default_instance_;
+class FocusAutoSingleResponse;
+struct FocusAutoSingleResponseDefaultTypeInternal;
+extern FocusAutoSingleResponseDefaultTypeInternal _FocusAutoSingleResponse_default_instance_;
 class FocusInStartRequest;
 struct FocusInStartRequestDefaultTypeInternal;
 extern FocusInStartRequestDefaultTypeInternal _FocusInStartRequest_default_instance_;
@@ -93,6 +111,12 @@ extern FocusInStepRequestDefaultTypeInternal _FocusInStepRequest_default_instanc
 class FocusInStepResponse;
 struct FocusInStepResponseDefaultTypeInternal;
 extern FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
+class FocusMetersRequest;
+struct FocusMetersRequestDefaultTypeInternal;
+extern FocusMetersRequestDefaultTypeInternal _FocusMetersRequest_default_instance_;
+class FocusMetersResponse;
+struct FocusMetersResponseDefaultTypeInternal;
+extern FocusMetersResponseDefaultTypeInternal _FocusMetersResponse_default_instance_;
 class FocusOutStartRequest;
 struct FocusOutStartRequestDefaultTypeInternal;
 extern FocusOutStartRequestDefaultTypeInternal _FocusOutStartRequest_default_instance_;
@@ -5512,7 +5536,7 @@ class Quaternion final
     return reinterpret_cast<const Quaternion*>(
         &_Quaternion_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 97;
   friend void swap(Quaternion& a, Quaternion& b) { a.Swap(&b); }
   inline void Swap(Quaternion* other) {
     if (other == this) return;
@@ -5739,7 +5763,7 @@ class Position final
     return reinterpret_cast<const Position*>(
         &_Position_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 96;
   friend void swap(Position& a, Position& b) { a.Swap(&b); }
   inline void Swap(Position* other) {
     if (other == this) return;
@@ -6587,7 +6611,7 @@ class Information final
     return reinterpret_cast<const Information*>(
         &_Information_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 92;
+  static constexpr int kIndexInFileMessages = 100;
   friend void swap(Information& a, Information& b) { a.Swap(&b); }
   inline void Swap(Information* other) {
     if (other == this) return;
@@ -8748,6 +8772,209 @@ class FocusOutStartRequest final
 };
 // -------------------------------------------------------------------
 
+class FocusMetersRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusMetersRequest) */ {
+ public:
+  inline FocusMetersRequest() : FocusMetersRequest(nullptr) {}
+  ~FocusMetersRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusMetersRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusMetersRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusMetersRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusMetersRequest(const FocusMetersRequest& from) : FocusMetersRequest(nullptr, from) {}
+  inline FocusMetersRequest(FocusMetersRequest&& from) noexcept
+      : FocusMetersRequest(nullptr, std::move(from)) {}
+  inline FocusMetersRequest& operator=(const FocusMetersRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusMetersRequest& operator=(FocusMetersRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusMetersRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusMetersRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusMetersRequest*>(
+        &_FocusMetersRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 87;
+  friend void swap(FocusMetersRequest& a, FocusMetersRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusMetersRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusMetersRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusMetersRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusMetersRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusMetersRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusMetersRequest& from) { FocusMetersRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusMetersRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusMetersRequest"; }
+
+ protected:
+  explicit FocusMetersRequest(::google::protobuf::Arena* arena);
+  FocusMetersRequest(::google::protobuf::Arena* arena, const FocusMetersRequest& from);
+  FocusMetersRequest(::google::protobuf::Arena* arena, FocusMetersRequest&& from) noexcept
+      : FocusMetersRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+    kDistanceMFieldNumber = 2,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // float distance_m = 2;
+  void clear_distance_m() ;
+  float distance_m() const;
+  void set_distance_m(float value);
+
+  private:
+  float _internal_distance_m() const;
+  void _internal_set_distance_m(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusMetersRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusMetersRequest& from_msg);
+    ::int32_t component_id_;
+    float distance_m_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusInStepRequest final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStepRequest) */ {
@@ -9130,6 +9357,579 @@ class FocusInStartRequest final
 };
 // -------------------------------------------------------------------
 
+class FocusAutoSingleRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoSingleRequest) */ {
+ public:
+  inline FocusAutoSingleRequest() : FocusAutoSingleRequest(nullptr) {}
+  ~FocusAutoSingleRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoSingleRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoSingleRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoSingleRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoSingleRequest(const FocusAutoSingleRequest& from) : FocusAutoSingleRequest(nullptr, from) {}
+  inline FocusAutoSingleRequest(FocusAutoSingleRequest&& from) noexcept
+      : FocusAutoSingleRequest(nullptr, std::move(from)) {}
+  inline FocusAutoSingleRequest& operator=(const FocusAutoSingleRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoSingleRequest& operator=(FocusAutoSingleRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoSingleRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoSingleRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoSingleRequest*>(
+        &_FocusAutoSingleRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 91;
+  friend void swap(FocusAutoSingleRequest& a, FocusAutoSingleRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoSingleRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoSingleRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoSingleRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoSingleRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoSingleRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoSingleRequest& from) { FocusAutoSingleRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoSingleRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoSingleRequest"; }
+
+ protected:
+  explicit FocusAutoSingleRequest(::google::protobuf::Arena* arena);
+  FocusAutoSingleRequest(::google::protobuf::Arena* arena, const FocusAutoSingleRequest& from);
+  FocusAutoSingleRequest(::google::protobuf::Arena* arena, FocusAutoSingleRequest&& from) noexcept
+      : FocusAutoSingleRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoSingleRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoSingleRequest& from_msg);
+    ::int32_t component_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoRequest) */ {
+ public:
+  inline FocusAutoRequest() : FocusAutoRequest(nullptr) {}
+  ~FocusAutoRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoRequest(const FocusAutoRequest& from) : FocusAutoRequest(nullptr, from) {}
+  inline FocusAutoRequest(FocusAutoRequest&& from) noexcept
+      : FocusAutoRequest(nullptr, std::move(from)) {}
+  inline FocusAutoRequest& operator=(const FocusAutoRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoRequest& operator=(FocusAutoRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoRequest*>(
+        &_FocusAutoRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 89;
+  friend void swap(FocusAutoRequest& a, FocusAutoRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoRequest& from) { FocusAutoRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoRequest"; }
+
+ protected:
+  explicit FocusAutoRequest(::google::protobuf::Arena* arena);
+  FocusAutoRequest(::google::protobuf::Arena* arena, const FocusAutoRequest& from);
+  FocusAutoRequest(::google::protobuf::Arena* arena, FocusAutoRequest&& from) noexcept
+      : FocusAutoRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoRequest& from_msg);
+    ::int32_t component_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoContinuousRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoContinuousRequest) */ {
+ public:
+  inline FocusAutoContinuousRequest() : FocusAutoContinuousRequest(nullptr) {}
+  ~FocusAutoContinuousRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoContinuousRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoContinuousRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoContinuousRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoContinuousRequest(const FocusAutoContinuousRequest& from) : FocusAutoContinuousRequest(nullptr, from) {}
+  inline FocusAutoContinuousRequest(FocusAutoContinuousRequest&& from) noexcept
+      : FocusAutoContinuousRequest(nullptr, std::move(from)) {}
+  inline FocusAutoContinuousRequest& operator=(const FocusAutoContinuousRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoContinuousRequest& operator=(FocusAutoContinuousRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoContinuousRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoContinuousRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoContinuousRequest*>(
+        &_FocusAutoContinuousRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 93;
+  friend void swap(FocusAutoContinuousRequest& a, FocusAutoContinuousRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoContinuousRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoContinuousRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoContinuousRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoContinuousRequest& from) { FocusAutoContinuousRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoContinuousRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoContinuousRequest"; }
+
+ protected:
+  explicit FocusAutoContinuousRequest(::google::protobuf::Arena* arena);
+  FocusAutoContinuousRequest(::google::protobuf::Arena* arena, const FocusAutoContinuousRequest& from);
+  FocusAutoContinuousRequest(::google::protobuf::Arena* arena, FocusAutoContinuousRequest&& from) noexcept
+      : FocusAutoContinuousRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoContinuousRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoContinuousRequest& from_msg);
+    ::int32_t component_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class EulerAngle final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.EulerAngle) */ {
@@ -9190,7 +9990,7 @@ class EulerAngle final
     return reinterpret_cast<const EulerAngle*>(
         &_EulerAngle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 90;
+  static constexpr int kIndexInFileMessages = 98;
   friend void swap(EulerAngle& a, EulerAngle& b) { a.Swap(&b); }
   inline void Swap(EulerAngle* other) {
     if (other == this) return;
@@ -9405,7 +10205,7 @@ class CameraResult final
     return reinterpret_cast<const CameraResult*>(
         &_CameraResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 87;
+  static constexpr int kIndexInFileMessages = 95;
   friend void swap(CameraResult& a, CameraResult& b) { a.Swap(&b); }
   inline void Swap(CameraResult* other) {
     if (other == this) return;
@@ -15522,6 +16322,203 @@ class FocusOutStartResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusMetersResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusMetersResponse) */ {
+ public:
+  inline FocusMetersResponse() : FocusMetersResponse(nullptr) {}
+  ~FocusMetersResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusMetersResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusMetersResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusMetersResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusMetersResponse(const FocusMetersResponse& from) : FocusMetersResponse(nullptr, from) {}
+  inline FocusMetersResponse(FocusMetersResponse&& from) noexcept
+      : FocusMetersResponse(nullptr, std::move(from)) {}
+  inline FocusMetersResponse& operator=(const FocusMetersResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusMetersResponse& operator=(FocusMetersResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusMetersResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusMetersResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusMetersResponse*>(
+        &_FocusMetersResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 88;
+  friend void swap(FocusMetersResponse& a, FocusMetersResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusMetersResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusMetersResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusMetersResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusMetersResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusMetersResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusMetersResponse& from) { FocusMetersResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusMetersResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusMetersResponse"; }
+
+ protected:
+  explicit FocusMetersResponse(::google::protobuf::Arena* arena);
+  FocusMetersResponse(::google::protobuf::Arena* arena, const FocusMetersResponse& from);
+  FocusMetersResponse(::google::protobuf::Arena* arena, FocusMetersResponse&& from) noexcept
+      : FocusMetersResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusMetersResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusMetersResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusInStepResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStepResponse) */ {
@@ -15916,6 +16913,597 @@ class FocusInStartResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusAutoSingleResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoSingleResponse) */ {
+ public:
+  inline FocusAutoSingleResponse() : FocusAutoSingleResponse(nullptr) {}
+  ~FocusAutoSingleResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoSingleResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoSingleResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoSingleResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoSingleResponse(const FocusAutoSingleResponse& from) : FocusAutoSingleResponse(nullptr, from) {}
+  inline FocusAutoSingleResponse(FocusAutoSingleResponse&& from) noexcept
+      : FocusAutoSingleResponse(nullptr, std::move(from)) {}
+  inline FocusAutoSingleResponse& operator=(const FocusAutoSingleResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoSingleResponse& operator=(FocusAutoSingleResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoSingleResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoSingleResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoSingleResponse*>(
+        &_FocusAutoSingleResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 92;
+  friend void swap(FocusAutoSingleResponse& a, FocusAutoSingleResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoSingleResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoSingleResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoSingleResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoSingleResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoSingleResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoSingleResponse& from) { FocusAutoSingleResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoSingleResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoSingleResponse"; }
+
+ protected:
+  explicit FocusAutoSingleResponse(::google::protobuf::Arena* arena);
+  FocusAutoSingleResponse(::google::protobuf::Arena* arena, const FocusAutoSingleResponse& from);
+  FocusAutoSingleResponse(::google::protobuf::Arena* arena, FocusAutoSingleResponse&& from) noexcept
+      : FocusAutoSingleResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoSingleResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoSingleResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoResponse) */ {
+ public:
+  inline FocusAutoResponse() : FocusAutoResponse(nullptr) {}
+  ~FocusAutoResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoResponse(const FocusAutoResponse& from) : FocusAutoResponse(nullptr, from) {}
+  inline FocusAutoResponse(FocusAutoResponse&& from) noexcept
+      : FocusAutoResponse(nullptr, std::move(from)) {}
+  inline FocusAutoResponse& operator=(const FocusAutoResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoResponse& operator=(FocusAutoResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoResponse*>(
+        &_FocusAutoResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 90;
+  friend void swap(FocusAutoResponse& a, FocusAutoResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoResponse& from) { FocusAutoResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoResponse"; }
+
+ protected:
+  explicit FocusAutoResponse(::google::protobuf::Arena* arena);
+  FocusAutoResponse(::google::protobuf::Arena* arena, const FocusAutoResponse& from);
+  FocusAutoResponse(::google::protobuf::Arena* arena, FocusAutoResponse&& from) noexcept
+      : FocusAutoResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoContinuousResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusAutoContinuousResponse) */ {
+ public:
+  inline FocusAutoContinuousResponse() : FocusAutoContinuousResponse(nullptr) {}
+  ~FocusAutoContinuousResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoContinuousResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoContinuousResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoContinuousResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoContinuousResponse(const FocusAutoContinuousResponse& from) : FocusAutoContinuousResponse(nullptr, from) {}
+  inline FocusAutoContinuousResponse(FocusAutoContinuousResponse&& from) noexcept
+      : FocusAutoContinuousResponse(nullptr, std::move(from)) {}
+  inline FocusAutoContinuousResponse& operator=(const FocusAutoContinuousResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoContinuousResponse& operator=(FocusAutoContinuousResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoContinuousResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoContinuousResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoContinuousResponse*>(
+        &_FocusAutoContinuousResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 94;
+  friend void swap(FocusAutoContinuousResponse& a, FocusAutoContinuousResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoContinuousResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoContinuousResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoContinuousResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoContinuousResponse& from) { FocusAutoContinuousResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoContinuousResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusAutoContinuousResponse"; }
+
+ protected:
+  explicit FocusAutoContinuousResponse(::google::protobuf::Arena* arena);
+  FocusAutoContinuousResponse(::google::protobuf::Arena* arena, const FocusAutoContinuousResponse& from);
+  FocusAutoContinuousResponse(::google::protobuf::Arena* arena, FocusAutoContinuousResponse&& from) noexcept
+      : FocusAutoContinuousResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusAutoContinuousResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoContinuousResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CaptureInfo final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.CaptureInfo) */ {
@@ -15976,7 +17564,7 @@ class CaptureInfo final
     return reinterpret_cast<const CaptureInfo*>(
         &_CaptureInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 91;
+  static constexpr int kIndexInFileMessages = 99;
   friend void swap(CaptureInfo& a, CaptureInfo& b) { a.Swap(&b); }
   inline void Swap(CaptureInfo* other) {
     if (other == this) return;
@@ -16273,7 +17861,7 @@ class CameraList final
     return reinterpret_cast<const CameraList*>(
         &_CameraList_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 93;
+  static constexpr int kIndexInFileMessages = 101;
   friend void swap(CameraList& a, CameraList& b) { a.Swap(&b); }
   inline void Swap(CameraList* other) {
     if (other == this) return;
@@ -26913,6 +28501,532 @@ inline void FocusRangeResponse::set_allocated_camera_result(::mavsdk::rpc::camer
 
   _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusRangeResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusMetersRequest
+
+// int32 component_id = 1;
+inline void FocusMetersRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusMetersRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusMetersRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusMetersRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusMetersRequest.component_id)
+}
+inline ::int32_t FocusMetersRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusMetersRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// float distance_m = 2;
+inline void FocusMetersRequest::clear_distance_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.distance_m_ = 0;
+}
+inline float FocusMetersRequest::distance_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusMetersRequest.distance_m)
+  return _internal_distance_m();
+}
+inline void FocusMetersRequest::set_distance_m(float value) {
+  _internal_set_distance_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusMetersRequest.distance_m)
+}
+inline float FocusMetersRequest::_internal_distance_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.distance_m_;
+}
+inline void FocusMetersRequest::_internal_set_distance_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.distance_m_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusMetersResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusMetersResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusMetersResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusMetersResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusMetersResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusMetersResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusMetersResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusMetersResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusMetersResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusMetersResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusMetersResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusMetersResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusMetersResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusMetersResponse.camera_result)
+  return _msg;
+}
+inline void FocusMetersResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusMetersResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoRequest
+
+// int32 component_id = 1;
+inline void FocusAutoRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusAutoRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusAutoRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusAutoRequest.component_id)
+}
+inline ::int32_t FocusAutoRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusAutoRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusAutoResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusAutoResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusAutoResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusAutoResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusAutoResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusAutoResponse.camera_result)
+  return _msg;
+}
+inline void FocusAutoResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusAutoResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoSingleRequest
+
+// int32 component_id = 1;
+inline void FocusAutoSingleRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusAutoSingleRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoSingleRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusAutoSingleRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusAutoSingleRequest.component_id)
+}
+inline ::int32_t FocusAutoSingleRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusAutoSingleRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoSingleResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusAutoSingleResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusAutoSingleResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoSingleResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoSingleResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoSingleResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusAutoSingleResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusAutoSingleResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoSingleResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoSingleResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusAutoSingleResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoSingleResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoSingleResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusAutoSingleResponse.camera_result)
+  return _msg;
+}
+inline void FocusAutoSingleResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusAutoSingleResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoContinuousRequest
+
+// int32 component_id = 1;
+inline void FocusAutoContinuousRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusAutoContinuousRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoContinuousRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusAutoContinuousRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusAutoContinuousRequest.component_id)
+}
+inline ::int32_t FocusAutoContinuousRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusAutoContinuousRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusAutoContinuousResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusAutoContinuousResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusAutoContinuousResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoContinuousResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusAutoContinuousResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusAutoContinuousResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusAutoContinuousResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusAutoContinuousResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoContinuousResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoContinuousResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusAutoContinuousResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoContinuousResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusAutoContinuousResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusAutoContinuousResponse.camera_result)
+  return _msg;
+}
+inline void FocusAutoContinuousResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusAutoContinuousResponse.camera_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/generated/camera/camera.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera/camera.pb.h
@@ -87,12 +87,24 @@ extern FocusInStartRequestDefaultTypeInternal _FocusInStartRequest_default_insta
 class FocusInStartResponse;
 struct FocusInStartResponseDefaultTypeInternal;
 extern FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
+class FocusInStepRequest;
+struct FocusInStepRequestDefaultTypeInternal;
+extern FocusInStepRequestDefaultTypeInternal _FocusInStepRequest_default_instance_;
+class FocusInStepResponse;
+struct FocusInStepResponseDefaultTypeInternal;
+extern FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
 class FocusOutStartRequest;
 struct FocusOutStartRequestDefaultTypeInternal;
 extern FocusOutStartRequestDefaultTypeInternal _FocusOutStartRequest_default_instance_;
 class FocusOutStartResponse;
 struct FocusOutStartResponseDefaultTypeInternal;
 extern FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
+class FocusOutStepRequest;
+struct FocusOutStepRequestDefaultTypeInternal;
+extern FocusOutStepRequestDefaultTypeInternal _FocusOutStepRequest_default_instance_;
+class FocusOutStepResponse;
+struct FocusOutStepResponseDefaultTypeInternal;
+extern FocusOutStepResponseDefaultTypeInternal _FocusOutStepResponse_default_instance_;
 class FocusRangeRequest;
 struct FocusRangeRequestDefaultTypeInternal;
 extern FocusRangeRequestDefaultTypeInternal _FocusRangeRequest_default_instance_;
@@ -5500,7 +5512,7 @@ class Quaternion final
     return reinterpret_cast<const Quaternion*>(
         &_Quaternion_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 85;
+  static constexpr int kIndexInFileMessages = 89;
   friend void swap(Quaternion& a, Quaternion& b) { a.Swap(&b); }
   inline void Swap(Quaternion* other) {
     if (other == this) return;
@@ -5727,7 +5739,7 @@ class Position final
     return reinterpret_cast<const Position*>(
         &_Position_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 84;
+  static constexpr int kIndexInFileMessages = 88;
   friend void swap(Position& a, Position& b) { a.Swap(&b); }
   inline void Swap(Position* other) {
     if (other == this) return;
@@ -6575,7 +6587,7 @@ class Information final
     return reinterpret_cast<const Information*>(
         &_Information_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 92;
   friend void swap(Information& a, Information& b) { a.Swap(&b); }
   inline void Swap(Information* other) {
     if (other == this) return;
@@ -8020,7 +8032,7 @@ class FocusStopRequest final
     return reinterpret_cast<const FocusStopRequest*>(
         &_FocusStopRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 79;
+  static constexpr int kIndexInFileMessages = 83;
   friend void swap(FocusStopRequest& a, FocusStopRequest& b) { a.Swap(&b); }
   inline void Swap(FocusStopRequest* other) {
     if (other == this) return;
@@ -8211,7 +8223,7 @@ class FocusRangeRequest final
     return reinterpret_cast<const FocusRangeRequest*>(
         &_FocusRangeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 81;
+  static constexpr int kIndexInFileMessages = 85;
   friend void swap(FocusRangeRequest& a, FocusRangeRequest& b) { a.Swap(&b); }
   inline void Swap(FocusRangeRequest* other) {
     if (other == this) return;
@@ -8354,6 +8366,197 @@ class FocusRangeRequest final
 };
 // -------------------------------------------------------------------
 
+class FocusOutStepRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusOutStepRequest) */ {
+ public:
+  inline FocusOutStepRequest() : FocusOutStepRequest(nullptr) {}
+  ~FocusOutStepRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusOutStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusOutStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusOutStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusOutStepRequest(const FocusOutStepRequest& from) : FocusOutStepRequest(nullptr, from) {}
+  inline FocusOutStepRequest(FocusOutStepRequest&& from) noexcept
+      : FocusOutStepRequest(nullptr, std::move(from)) {}
+  inline FocusOutStepRequest& operator=(const FocusOutStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusOutStepRequest& operator=(FocusOutStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusOutStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusOutStepRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusOutStepRequest*>(
+        &_FocusOutStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 77;
+  friend void swap(FocusOutStepRequest& a, FocusOutStepRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusOutStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusOutStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusOutStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusOutStepRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusOutStepRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusOutStepRequest& from) { FocusOutStepRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusOutStepRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusOutStepRequest"; }
+
+ protected:
+  explicit FocusOutStepRequest(::google::protobuf::Arena* arena);
+  FocusOutStepRequest(::google::protobuf::Arena* arena, const FocusOutStepRequest& from);
+  FocusOutStepRequest(::google::protobuf::Arena* arena, FocusOutStepRequest&& from) noexcept
+      : FocusOutStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusOutStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusOutStepRequest& from_msg);
+    ::int32_t component_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusOutStartRequest final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusOutStartRequest) */ {
@@ -8414,7 +8617,7 @@ class FocusOutStartRequest final
     return reinterpret_cast<const FocusOutStartRequest*>(
         &_FocusOutStartRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 77;
+  static constexpr int kIndexInFileMessages = 81;
   friend void swap(FocusOutStartRequest& a, FocusOutStartRequest& b) { a.Swap(&b); }
   inline void Swap(FocusOutStartRequest* other) {
     if (other == this) return;
@@ -8545,6 +8748,197 @@ class FocusOutStartRequest final
 };
 // -------------------------------------------------------------------
 
+class FocusInStepRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStepRequest) */ {
+ public:
+  inline FocusInStepRequest() : FocusInStepRequest(nullptr) {}
+  ~FocusInStepRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusInStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusInStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusInStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusInStepRequest(const FocusInStepRequest& from) : FocusInStepRequest(nullptr, from) {}
+  inline FocusInStepRequest(FocusInStepRequest&& from) noexcept
+      : FocusInStepRequest(nullptr, std::move(from)) {}
+  inline FocusInStepRequest& operator=(const FocusInStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusInStepRequest& operator=(FocusInStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusInStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusInStepRequest* internal_default_instance() {
+    return reinterpret_cast<const FocusInStepRequest*>(
+        &_FocusInStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 75;
+  friend void swap(FocusInStepRequest& a, FocusInStepRequest& b) { a.Swap(&b); }
+  inline void Swap(FocusInStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusInStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusInStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusInStepRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusInStepRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusInStepRequest& from) { FocusInStepRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusInStepRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusInStepRequest"; }
+
+ protected:
+  explicit FocusInStepRequest(::google::protobuf::Arena* arena);
+  FocusInStepRequest(::google::protobuf::Arena* arena, const FocusInStepRequest& from);
+  FocusInStepRequest(::google::protobuf::Arena* arena, FocusInStepRequest&& from) noexcept
+      : FocusInStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kComponentIdFieldNumber = 1,
+  };
+  // int32 component_id = 1;
+  void clear_component_id() ;
+  ::int32_t component_id() const;
+  void set_component_id(::int32_t value);
+
+  private:
+  ::int32_t _internal_component_id() const;
+  void _internal_set_component_id(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusInStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusInStepRequest& from_msg);
+    ::int32_t component_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusInStartRequest final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStartRequest) */ {
@@ -8605,7 +8999,7 @@ class FocusInStartRequest final
     return reinterpret_cast<const FocusInStartRequest*>(
         &_FocusInStartRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 75;
+  static constexpr int kIndexInFileMessages = 79;
   friend void swap(FocusInStartRequest& a, FocusInStartRequest& b) { a.Swap(&b); }
   inline void Swap(FocusInStartRequest* other) {
     if (other == this) return;
@@ -8796,7 +9190,7 @@ class EulerAngle final
     return reinterpret_cast<const EulerAngle*>(
         &_EulerAngle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 86;
+  static constexpr int kIndexInFileMessages = 90;
   friend void swap(EulerAngle& a, EulerAngle& b) { a.Swap(&b); }
   inline void Swap(EulerAngle* other) {
     if (other == this) return;
@@ -9011,7 +9405,7 @@ class CameraResult final
     return reinterpret_cast<const CameraResult*>(
         &_CameraResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 83;
+  static constexpr int kIndexInFileMessages = 87;
   friend void swap(CameraResult& a, CameraResult& b) { a.Swap(&b); }
   inline void Swap(CameraResult* other) {
     if (other == this) return;
@@ -14400,7 +14794,7 @@ class FocusStopResponse final
     return reinterpret_cast<const FocusStopResponse*>(
         &_FocusStopResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 80;
+  static constexpr int kIndexInFileMessages = 84;
   friend void swap(FocusStopResponse& a, FocusStopResponse& b) { a.Swap(&b); }
   inline void Swap(FocusStopResponse* other) {
     if (other == this) return;
@@ -14597,7 +14991,7 @@ class FocusRangeResponse final
     return reinterpret_cast<const FocusRangeResponse*>(
         &_FocusRangeResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 82;
+  static constexpr int kIndexInFileMessages = 86;
   friend void swap(FocusRangeResponse& a, FocusRangeResponse& b) { a.Swap(&b); }
   inline void Swap(FocusRangeResponse* other) {
     if (other == this) return;
@@ -14734,6 +15128,203 @@ class FocusRangeResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusOutStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusOutStepResponse) */ {
+ public:
+  inline FocusOutStepResponse() : FocusOutStepResponse(nullptr) {}
+  ~FocusOutStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusOutStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusOutStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusOutStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusOutStepResponse(const FocusOutStepResponse& from) : FocusOutStepResponse(nullptr, from) {}
+  inline FocusOutStepResponse(FocusOutStepResponse&& from) noexcept
+      : FocusOutStepResponse(nullptr, std::move(from)) {}
+  inline FocusOutStepResponse& operator=(const FocusOutStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusOutStepResponse& operator=(FocusOutStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusOutStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusOutStepResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusOutStepResponse*>(
+        &_FocusOutStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 78;
+  friend void swap(FocusOutStepResponse& a, FocusOutStepResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusOutStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusOutStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusOutStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusOutStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusOutStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusOutStepResponse& from) { FocusOutStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusOutStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusOutStepResponse"; }
+
+ protected:
+  explicit FocusOutStepResponse(::google::protobuf::Arena* arena);
+  FocusOutStepResponse(::google::protobuf::Arena* arena, const FocusOutStepResponse& from);
+  FocusOutStepResponse(::google::protobuf::Arena* arena, FocusOutStepResponse&& from) noexcept
+      : FocusOutStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusOutStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusOutStepResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusOutStartResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusOutStartResponse) */ {
@@ -14794,7 +15385,7 @@ class FocusOutStartResponse final
     return reinterpret_cast<const FocusOutStartResponse*>(
         &_FocusOutStartResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 78;
+  static constexpr int kIndexInFileMessages = 82;
   friend void swap(FocusOutStartResponse& a, FocusOutStartResponse& b) { a.Swap(&b); }
   inline void Swap(FocusOutStartResponse* other) {
     if (other == this) return;
@@ -14931,6 +15522,203 @@ class FocusOutStartResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusInStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStepResponse) */ {
+ public:
+  inline FocusInStepResponse() : FocusInStepResponse(nullptr) {}
+  ~FocusInStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusInStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusInStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusInStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusInStepResponse(const FocusInStepResponse& from) : FocusInStepResponse(nullptr, from) {}
+  inline FocusInStepResponse(FocusInStepResponse&& from) noexcept
+      : FocusInStepResponse(nullptr, std::move(from)) {}
+  inline FocusInStepResponse& operator=(const FocusInStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusInStepResponse& operator=(FocusInStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusInStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusInStepResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusInStepResponse*>(
+        &_FocusInStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 76;
+  friend void swap(FocusInStepResponse& a, FocusInStepResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusInStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusInStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusInStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusInStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusInStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusInStepResponse& from) { FocusInStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusInStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera.FocusInStepResponse"; }
+
+ protected:
+  explicit FocusInStepResponse(::google::protobuf::Arena* arena);
+  FocusInStepResponse(::google::protobuf::Arena* arena, const FocusInStepResponse& from);
+  FocusInStepResponse(::google::protobuf::Arena* arena, FocusInStepResponse&& from) noexcept
+      : FocusInStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera.CameraResult camera_result = 1;
+  bool has_camera_result() const;
+  void clear_camera_result() ;
+  const ::mavsdk::rpc::camera::CameraResult& camera_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera::CameraResult* release_camera_result();
+  ::mavsdk::rpc::camera::CameraResult* mutable_camera_result();
+  void set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  void unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value);
+  ::mavsdk::rpc::camera::CameraResult* unsafe_arena_release_camera_result();
+
+  private:
+  const ::mavsdk::rpc::camera::CameraResult& _internal_camera_result() const;
+  ::mavsdk::rpc::camera::CameraResult* _internal_mutable_camera_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera.FocusInStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusInStepResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera::CameraResult* camera_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_2fcamera_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusInStartResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera.FocusInStartResponse) */ {
@@ -14991,7 +15779,7 @@ class FocusInStartResponse final
     return reinterpret_cast<const FocusInStartResponse*>(
         &_FocusInStartResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 76;
+  static constexpr int kIndexInFileMessages = 80;
   friend void swap(FocusInStartResponse& a, FocusInStartResponse& b) { a.Swap(&b); }
   inline void Swap(FocusInStartResponse* other) {
     if (other == this) return;
@@ -15188,7 +15976,7 @@ class CaptureInfo final
     return reinterpret_cast<const CaptureInfo*>(
         &_CaptureInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 87;
+  static constexpr int kIndexInFileMessages = 91;
   friend void swap(CaptureInfo& a, CaptureInfo& b) { a.Swap(&b); }
   inline void Swap(CaptureInfo* other) {
     if (other == this) return;
@@ -15485,7 +16273,7 @@ class CameraList final
     return reinterpret_cast<const CameraList*>(
         &_CameraList_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 93;
   friend void swap(CameraList& a, CameraList& b) { a.Swap(&b); }
   inline void Swap(CameraList* other) {
     if (other == this) return;
@@ -25347,6 +26135,258 @@ inline void TrackStopResponse::set_allocated_camera_result(::mavsdk::rpc::camera
 
   _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.TrackStopResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusInStepRequest
+
+// int32 component_id = 1;
+inline void FocusInStepRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusInStepRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusInStepRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusInStepRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusInStepRequest.component_id)
+}
+inline ::int32_t FocusInStepRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusInStepRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusInStepResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusInStepResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusInStepResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusInStepResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusInStepResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusInStepResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusInStepResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusInStepResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusInStepResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusInStepResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusInStepResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusInStepResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusInStepResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusInStepResponse.camera_result)
+  return _msg;
+}
+inline void FocusInStepResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusInStepResponse.camera_result)
+}
+
+// -------------------------------------------------------------------
+
+// FocusOutStepRequest
+
+// int32 component_id = 1;
+inline void FocusOutStepRequest::clear_component_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = 0;
+}
+inline ::int32_t FocusOutStepRequest::component_id() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusOutStepRequest.component_id)
+  return _internal_component_id();
+}
+inline void FocusOutStepRequest::set_component_id(::int32_t value) {
+  _internal_set_component_id(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera.FocusOutStepRequest.component_id)
+}
+inline ::int32_t FocusOutStepRequest::_internal_component_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.component_id_;
+}
+inline void FocusOutStepRequest::_internal_set_component_id(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.component_id_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// FocusOutStepResponse
+
+// .mavsdk.rpc.camera.CameraResult camera_result = 1;
+inline bool FocusOutStepResponse::has_camera_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_result_ != nullptr);
+  return value;
+}
+inline void FocusOutStepResponse::clear_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ != nullptr) _impl_.camera_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusOutStepResponse::_internal_camera_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera::CameraResult* p = _impl_.camera_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera::CameraResult&>(::mavsdk::rpc::camera::_CameraResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera::CameraResult& FocusOutStepResponse::camera_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera.FocusOutStepResponse.camera_result)
+  return _internal_camera_result();
+}
+inline void FocusOutStepResponse::unsafe_arena_set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_result_);
+  }
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera.FocusOutStepResponse.camera_result)
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusOutStepResponse::release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* released = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusOutStepResponse::unsafe_arena_release_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera.FocusOutStepResponse.camera_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* temp = _impl_.camera_result_;
+  _impl_.camera_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusOutStepResponse::_internal_mutable_camera_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera::CameraResult>(GetArena());
+    _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(p);
+  }
+  return _impl_.camera_result_;
+}
+inline ::mavsdk::rpc::camera::CameraResult* FocusOutStepResponse::mutable_camera_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera::CameraResult* _msg = _internal_mutable_camera_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera.FocusOutStepResponse.camera_result)
+  return _msg;
+}
+inline void FocusOutStepResponse::set_allocated_camera_result(::mavsdk::rpc::camera::CameraResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_result_ = reinterpret_cast<::mavsdk::rpc::camera::CameraResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera.FocusOutStepResponse.camera_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
@@ -55,6 +55,18 @@ static const char* CameraServerService_method_names[] = {
   "/mavsdk.rpc.camera_server.CameraServerService/RespondZoomStop",
   "/mavsdk.rpc.camera_server.CameraServerService/SubscribeZoomRange",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondZoomRange",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusInStep",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusInStep",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusOutStep",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusOutStep",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusInStart",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusInStart",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusOutStart",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusOutStart",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusStop",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusStop",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusRange",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusRange",
   "/mavsdk.rpc.camera_server.CameraServerService/SetTrackingRectangleStatus",
   "/mavsdk.rpc.camera_server.CameraServerService/SetTrackingOffStatus",
   "/mavsdk.rpc.camera_server.CameraServerService/SubscribeTrackingPointCommand",
@@ -107,18 +119,30 @@ CameraServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_RespondZoomStop_(CameraServerService_method_names[28], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SubscribeZoomRange_(CameraServerService_method_names[29], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_RespondZoomRange_(CameraServerService_method_names[30], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTrackingRectangleStatus_(CameraServerService_method_names[31], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTrackingOffStatus_(CameraServerService_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeTrackingPointCommand_(CameraServerService_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeTrackingRectangleCommand_(CameraServerService_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeTrackingOffCommand_(CameraServerService_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetPosition_(CameraServerService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetZoomFactor_(CameraServerService_method_names[41], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetFieldOfView_(CameraServerService_method_names[42], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusInStep_(CameraServerService_method_names[31], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusInStep_(CameraServerService_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusOutStep_(CameraServerService_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusOutStep_(CameraServerService_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusInStart_(CameraServerService_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusInStart_(CameraServerService_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusOutStart_(CameraServerService_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusOutStart_(CameraServerService_method_names[38], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusStop_(CameraServerService_method_names[39], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusStop_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusRange_(CameraServerService_method_names[41], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusRange_(CameraServerService_method_names[42], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTrackingRectangleStatus_(CameraServerService_method_names[43], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTrackingOffStatus_(CameraServerService_method_names[44], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeTrackingPointCommand_(CameraServerService_method_names[45], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeTrackingRectangleCommand_(CameraServerService_method_names[46], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeTrackingOffCommand_(CameraServerService_method_names[47], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[48], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[49], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[50], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPosition_(CameraServerService_method_names[51], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[52], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetZoomFactor_(CameraServerService_method_names[53], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetFieldOfView_(CameraServerService_method_names[54], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraServerService::Stub::SetInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetInformationRequest& request, ::mavsdk::rpc::camera_server::SetInformationResponse* response) {
@@ -736,6 +760,240 @@ void CameraServerService::Stub::async::RespondZoomRange(::grpc::ClientContext* c
   return result;
 }
 
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* CameraServerService::Stub::SubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusInStepResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusInStep_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStepResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusInStepResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusInStep_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* CameraServerService::Stub::AsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusInStepResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusInStep_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusInStepResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusInStep_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusInStep_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusInStep_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusInStep_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse, ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusInStep_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* CameraServerService::Stub::AsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusInStepRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* CameraServerService::Stub::SubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStepResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusOutStep_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStepResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusOutStep_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* CameraServerService::Stub::AsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStepResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusOutStep_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStepResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusOutStep_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusOutStep_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusOutStep_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusOutStep_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusOutStep_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* CameraServerService::Stub::AsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusOutStepRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* CameraServerService::Stub::SubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusInStartResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusInStart_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStartResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusInStartResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusInStart_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* CameraServerService::Stub::AsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusInStartResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusInStart_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusInStartResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusInStart_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusInStart_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusInStart_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusInStart_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse, ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusInStart_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* CameraServerService::Stub::AsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusInStartRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* CameraServerService::Stub::SubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStartResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusOutStart_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStartResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusOutStart_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* CameraServerService::Stub::AsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStartResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusOutStart_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusOutStartResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusOutStart_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusOutStart_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusOutStart_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusOutStart_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusOutStart_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* CameraServerService::Stub::AsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusOutStartRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* CameraServerService::Stub::SubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusStopResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusStop_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusStopResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusStopResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusStop_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* CameraServerService::Stub::AsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusStopResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusStop_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusStopResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusStop_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusStop_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusStop_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusStop_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusStopResponse, ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusStop_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* CameraServerService::Stub::AsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusStopRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* CameraServerService::Stub::SubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusRangeResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusRange_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusRangeResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusRangeResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusRange_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* CameraServerService::Stub::AsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusRangeResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusRange_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusRangeResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusRange_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusRange_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusRange_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusRange_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse, ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusRange_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* CameraServerService::Stub::AsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusRangeRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ::grpc::Status CameraServerService::Stub::SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetTrackingRectangleStatus_, context, request, response);
 }
@@ -1304,6 +1562,126 @@ CameraServerService::Service::Service() {
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraServerService_method_names[31],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest, ::mavsdk::rpc::camera_server::FocusInStepResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusInStepResponse>* writer) {
+               return service->SubscribeFocusInStep(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[32],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* resp) {
+               return service->RespondFocusInStep(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[33],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest, ::mavsdk::rpc::camera_server::FocusOutStepResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusOutStepResponse>* writer) {
+               return service->SubscribeFocusOutStep(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[34],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* resp) {
+               return service->RespondFocusOutStep(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[35],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest, ::mavsdk::rpc::camera_server::FocusInStartResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusInStartResponse>* writer) {
+               return service->SubscribeFocusInStart(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[36],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* resp) {
+               return service->RespondFocusInStart(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[37],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest, ::mavsdk::rpc::camera_server::FocusOutStartResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusOutStartResponse>* writer) {
+               return service->SubscribeFocusOutStart(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[38],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* resp) {
+               return service->RespondFocusOutStart(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[39],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest, ::mavsdk::rpc::camera_server::FocusStopResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusStopResponse>* writer) {
+               return service->SubscribeFocusStop(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[40],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusStopResponse* resp) {
+               return service->RespondFocusStop(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[41],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest, ::mavsdk::rpc::camera_server::FocusRangeResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusRangeResponse>* writer) {
+               return service->SubscribeFocusRange(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[42],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* resp) {
+               return service->RespondFocusRange(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[43],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1313,7 +1691,7 @@ CameraServerService::Service::Service() {
                return service->SetTrackingRectangleStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[32],
+      CameraServerService_method_names[44],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1323,7 +1701,7 @@ CameraServerService::Service::Service() {
                return service->SetTrackingOffStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[33],
+      CameraServerService_method_names[45],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1333,7 +1711,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingPointCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[34],
+      CameraServerService_method_names[46],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1343,7 +1721,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingRectangleCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[35],
+      CameraServerService_method_names[47],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1353,7 +1731,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingOffCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[36],
+      CameraServerService_method_names[48],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1363,7 +1741,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingPointCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[37],
+      CameraServerService_method_names[49],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1373,7 +1751,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingRectangleCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[38],
+      CameraServerService_method_names[50],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1383,7 +1761,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingOffCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[39],
+      CameraServerService_method_names[51],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1393,7 +1771,7 @@ CameraServerService::Service::Service() {
                return service->SetPosition(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[40],
+      CameraServerService_method_names[52],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1403,7 +1781,7 @@ CameraServerService::Service::Service() {
                return service->SetAttitudeQuaternion(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[41],
+      CameraServerService_method_names[53],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1413,7 +1791,7 @@ CameraServerService::Service::Service() {
                return service->SetZoomFactor(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[42],
+      CameraServerService_method_names[54],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1638,6 +2016,90 @@ CameraServerService::Service::~Service() {
 }
 
 ::grpc::Status CameraServerService::Service::RespondZoomRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusInStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusInStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusOutStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusOutStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.cc
@@ -67,6 +67,14 @@ static const char* CameraServerService_method_names[] = {
   "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusStop",
   "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusRange",
   "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusRange",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusMeters",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusMeters",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusAuto",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusAuto",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusAutoSingle",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusAutoSingle",
+  "/mavsdk.rpc.camera_server.CameraServerService/SubscribeFocusAutoContinuous",
+  "/mavsdk.rpc.camera_server.CameraServerService/RespondFocusAutoContinuous",
   "/mavsdk.rpc.camera_server.CameraServerService/SetTrackingRectangleStatus",
   "/mavsdk.rpc.camera_server.CameraServerService/SetTrackingOffStatus",
   "/mavsdk.rpc.camera_server.CameraServerService/SubscribeTrackingPointCommand",
@@ -131,18 +139,26 @@ CameraServerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>
   , rpcmethod_RespondFocusStop_(CameraServerService_method_names[40], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SubscribeFocusRange_(CameraServerService_method_names[41], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_RespondFocusRange_(CameraServerService_method_names[42], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTrackingRectangleStatus_(CameraServerService_method_names[43], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetTrackingOffStatus_(CameraServerService_method_names[44], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubscribeTrackingPointCommand_(CameraServerService_method_names[45], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeTrackingRectangleCommand_(CameraServerService_method_names[46], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_SubscribeTrackingOffCommand_(CameraServerService_method_names[47], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
-  , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[48], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[49], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[50], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetPosition_(CameraServerService_method_names[51], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[52], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetZoomFactor_(CameraServerService_method_names[53], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetFieldOfView_(CameraServerService_method_names[54], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusMeters_(CameraServerService_method_names[43], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusMeters_(CameraServerService_method_names[44], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusAuto_(CameraServerService_method_names[45], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusAuto_(CameraServerService_method_names[46], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusAutoSingle_(CameraServerService_method_names[47], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusAutoSingle_(CameraServerService_method_names[48], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeFocusAutoContinuous_(CameraServerService_method_names[49], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondFocusAutoContinuous_(CameraServerService_method_names[50], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTrackingRectangleStatus_(CameraServerService_method_names[51], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTrackingOffStatus_(CameraServerService_method_names[52], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubscribeTrackingPointCommand_(CameraServerService_method_names[53], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeTrackingRectangleCommand_(CameraServerService_method_names[54], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_SubscribeTrackingOffCommand_(CameraServerService_method_names[55], options.suffix_for_stats(),::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_RespondTrackingPointCommand_(CameraServerService_method_names[56], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RespondTrackingRectangleCommand_(CameraServerService_method_names[57], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RespondTrackingOffCommand_(CameraServerService_method_names[58], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetPosition_(CameraServerService_method_names[59], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetAttitudeQuaternion_(CameraServerService_method_names[60], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetZoomFactor_(CameraServerService_method_names[61], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetFieldOfView_(CameraServerService_method_names[62], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status CameraServerService::Stub::SetInformation(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetInformationRequest& request, ::mavsdk::rpc::camera_server::SetInformationResponse* response) {
@@ -994,6 +1010,162 @@ void CameraServerService::Stub::async::RespondFocusRange(::grpc::ClientContext* 
   return result;
 }
 
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* CameraServerService::Stub::SubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusMetersResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusMeters_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusMetersResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusMetersResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusMeters_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* CameraServerService::Stub::AsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusMetersResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusMeters_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusMetersResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusMeters_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusMeters_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusMeters_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusMeters_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse, ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusMeters_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* CameraServerService::Stub::AsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusMetersRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* CameraServerService::Stub::SubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusAuto_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusAuto_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* CameraServerService::Stub::AsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAuto_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAuto_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusAuto_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAuto_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAuto_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse, ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusAuto_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* CameraServerService::Stub::AsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusAutoRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* CameraServerService::Stub::SubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusAutoSingle_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusAutoSingle_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* CameraServerService::Stub::AsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAutoSingle_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAutoSingle_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusAutoSingle_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAutoSingle_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAutoSingle_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusAutoSingle_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* CameraServerService::Stub::AsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusAutoSingleRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* CameraServerService::Stub::SubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request) {
+  return ::grpc::internal::ClientReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>::Create(channel_.get(), rpcmethod_SubscribeFocusAutoContinuous_, context, request);
+}
+
+void CameraServerService::Stub::async::SubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* reactor) {
+  ::grpc::internal::ClientCallbackReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>::Create(stub_->channel_.get(), stub_->rpcmethod_SubscribeFocusAutoContinuous_, context, request, reactor);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* CameraServerService::Stub::AsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAutoContinuous_, context, request, true, tag);
+}
+
+::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* CameraServerService::Stub::PrepareAsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>::Create(channel_.get(), cq, rpcmethod_SubscribeFocusAutoContinuous_, context, request, false, nullptr);
+}
+
+::grpc::Status CameraServerService::Stub::RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_RespondFocusAutoContinuous_, context, request, response);
+}
+
+void CameraServerService::Stub::async::RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAutoContinuous_, context, request, response, std::move(f));
+}
+
+void CameraServerService::Stub::async::RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_RespondFocusAutoContinuous_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* CameraServerService::Stub::PrepareAsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_RespondFocusAutoContinuous_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* CameraServerService::Stub::AsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncRespondFocusAutoContinuousRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
 ::grpc::Status CameraServerService::Stub::SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) {
   return ::grpc::internal::BlockingUnaryCall< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetTrackingRectangleStatus_, context, request, response);
 }
@@ -1682,6 +1854,86 @@ CameraServerService::Service::Service() {
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       CameraServerService_method_names[43],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest, ::mavsdk::rpc::camera_server::FocusMetersResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusMetersResponse>* writer) {
+               return service->SubscribeFocusMeters(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[44],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* resp) {
+               return service->RespondFocusMeters(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[45],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest, ::mavsdk::rpc::camera_server::FocusAutoResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusAutoResponse>* writer) {
+               return service->SubscribeFocusAuto(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[46],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* resp) {
+               return service->RespondFocusAuto(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[47],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* writer) {
+               return service->SubscribeFocusAutoSingle(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[48],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* resp) {
+               return service->RespondFocusAutoSingle(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[49],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* req,
+             ::grpc::ServerWriter<::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* writer) {
+               return service->SubscribeFocusAutoContinuous(ctx, req, writer);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[50],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](CameraServerService::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* req,
+             ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* resp) {
+               return service->RespondFocusAutoContinuous(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      CameraServerService_method_names[51],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1691,7 +1943,7 @@ CameraServerService::Service::Service() {
                return service->SetTrackingRectangleStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[44],
+      CameraServerService_method_names[52],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1701,7 +1953,7 @@ CameraServerService::Service::Service() {
                return service->SetTrackingOffStatus(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[45],
+      CameraServerService_method_names[53],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1711,7 +1963,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingPointCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[46],
+      CameraServerService_method_names[54],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1721,7 +1973,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingRectangleCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[47],
+      CameraServerService_method_names[55],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
           [](CameraServerService::Service* service,
@@ -1731,7 +1983,7 @@ CameraServerService::Service::Service() {
                return service->SubscribeTrackingOffCommand(ctx, req, writer);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[48],
+      CameraServerService_method_names[56],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1741,7 +1993,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingPointCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[49],
+      CameraServerService_method_names[57],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1751,7 +2003,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingRectangleCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[50],
+      CameraServerService_method_names[58],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1761,7 +2013,7 @@ CameraServerService::Service::Service() {
                return service->RespondTrackingOffCommand(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[51],
+      CameraServerService_method_names[59],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1771,7 +2023,7 @@ CameraServerService::Service::Service() {
                return service->SetPosition(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[52],
+      CameraServerService_method_names[60],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1781,7 +2033,7 @@ CameraServerService::Service::Service() {
                return service->SetAttitudeQuaternion(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[53],
+      CameraServerService_method_names[61],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -1791,7 +2043,7 @@ CameraServerService::Service::Service() {
                return service->SetZoomFactor(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      CameraServerService_method_names[54],
+      CameraServerService_method_names[62],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< CameraServerService::Service, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](CameraServerService::Service* service,
@@ -2100,6 +2352,62 @@ CameraServerService::Service::~Service() {
 }
 
 ::grpc::Status CameraServerService::Service::RespondFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::SubscribeFocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* writer) {
+  (void) context;
+  (void) request;
+  (void) writer;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status CameraServerService::Service::RespondFocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
@@ -314,6 +314,114 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>> PrepareAsyncRespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>>(PrepareAsyncRespondZoomRangeRaw(context, request, cq));
     }
+    // Subscribe to focus in step command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>> SubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(SubscribeFocusInStepRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>> AsyncSubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(AsyncSubscribeFocusInStepRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>> PrepareAsyncSubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(PrepareAsyncSubscribeFocusInStepRaw(context, request, cq));
+    }
+    // Respond to focus in step.
+    virtual ::grpc::Status RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>> AsyncRespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>>(AsyncRespondFocusInStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>> PrepareAsyncRespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>>(PrepareAsyncRespondFocusInStepRaw(context, request, cq));
+    }
+    // Subscribe to focus out step command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> SubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(SubscribeFocusOutStepRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> AsyncSubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(AsyncSubscribeFocusOutStepRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> PrepareAsyncSubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(PrepareAsyncSubscribeFocusOutStepRaw(context, request, cq));
+    }
+    // Respond to focus out step.
+    virtual ::grpc::Status RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>> AsyncRespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>>(AsyncRespondFocusOutStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>> PrepareAsyncRespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>>(PrepareAsyncRespondFocusOutStepRaw(context, request, cq));
+    }
+    // Subscribe to focus in start command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>> SubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(SubscribeFocusInStartRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>> AsyncSubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(AsyncSubscribeFocusInStartRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>> PrepareAsyncSubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(PrepareAsyncSubscribeFocusInStartRaw(context, request, cq));
+    }
+    // Respond to focus in start.
+    virtual ::grpc::Status RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>> AsyncRespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>>(AsyncRespondFocusInStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>> PrepareAsyncRespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>>(PrepareAsyncRespondFocusInStartRaw(context, request, cq));
+    }
+    // Subscribe to focus out start command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> SubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(SubscribeFocusOutStartRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> AsyncSubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(AsyncSubscribeFocusOutStartRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> PrepareAsyncSubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(PrepareAsyncSubscribeFocusOutStartRaw(context, request, cq));
+    }
+    // Respond to focus out start.
+    virtual ::grpc::Status RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>> AsyncRespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>>(AsyncRespondFocusOutStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>> PrepareAsyncRespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>>(PrepareAsyncRespondFocusOutStartRaw(context, request, cq));
+    }
+    // Subscribe to focus stop command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>> SubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>>(SubscribeFocusStopRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>> AsyncSubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>>(AsyncSubscribeFocusStopRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>> PrepareAsyncSubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>>(PrepareAsyncSubscribeFocusStopRaw(context, request, cq));
+    }
+    // Respond to focus stop.
+    virtual ::grpc::Status RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>> AsyncRespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>>(AsyncRespondFocusStopRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>> PrepareAsyncRespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>>(PrepareAsyncRespondFocusStopRaw(context, request, cq));
+    }
+    // Subscribe to focus range command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>> SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(SubscribeFocusRangeRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>> AsyncSubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(AsyncSubscribeFocusRangeRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>> PrepareAsyncSubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(PrepareAsyncSubscribeFocusRangeRaw(context, request, cq));
+    }
+    // Respond to focus range.
+    virtual ::grpc::Status RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> AsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(AsyncRespondFocusRangeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> PrepareAsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(PrepareAsyncRespondFocusRangeRaw(context, request, cq));
+    }
     // Set/update the current rectangle tracking status.
     virtual ::grpc::Status SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>> AsyncSetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) {
@@ -498,6 +606,36 @@ class CameraServerService final {
       // Respond to zoom range.
       virtual void RespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void RespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus in step command.
+      virtual void SubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStepResponse>* reactor) = 0;
+      // Respond to focus in step.
+      virtual void RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus out step command.
+      virtual void SubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* reactor) = 0;
+      // Respond to focus out step.
+      virtual void RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus in start command.
+      virtual void SubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStartResponse>* reactor) = 0;
+      // Respond to focus in start.
+      virtual void RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus out start command.
+      virtual void SubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* reactor) = 0;
+      // Respond to focus out start.
+      virtual void RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus stop command.
+      virtual void SubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusStopResponse>* reactor) = 0;
+      // Respond to focus stop.
+      virtual void RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus range command.
+      virtual void SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusRangeResponse>* reactor) = 0;
+      // Respond to focus range.
+      virtual void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // Set/update the current rectangle tracking status.
       virtual void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -612,6 +750,36 @@ class CameraServerService final {
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::ZoomRangeResponse>* PrepareAsyncSubscribeZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeZoomRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>* AsyncRespondZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>* PrepareAsyncRespondZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>* SubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>* AsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStepResponse>* PrepareAsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* AsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* PrepareAsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* SubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* AsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* PrepareAsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* AsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* PrepareAsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>* SubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>* AsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusInStartResponse>* PrepareAsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* AsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* PrepareAsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* SubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* AsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* PrepareAsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* AsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* PrepareAsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>* SubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>* AsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusStopResponse>* PrepareAsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* AsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* PrepareAsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>* SubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>* AsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>* PrepareAsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* AsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* PrepareAsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* AsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* PrepareAsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* AsyncSetTrackingOffStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -888,6 +1056,102 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>> PrepareAsyncRespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>>(PrepareAsyncRespondZoomRangeRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>> SubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(SubscribeFocusInStepRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>> AsyncSubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(AsyncSubscribeFocusInStepRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>> PrepareAsyncSubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>>(PrepareAsyncSubscribeFocusInStepRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>> AsyncRespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>>(AsyncRespondFocusInStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>> PrepareAsyncRespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>>(PrepareAsyncRespondFocusInStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> SubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(SubscribeFocusOutStepRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> AsyncSubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(AsyncSubscribeFocusOutStepRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>> PrepareAsyncSubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>>(PrepareAsyncSubscribeFocusOutStepRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>> AsyncRespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>>(AsyncRespondFocusOutStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>> PrepareAsyncRespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>>(PrepareAsyncRespondFocusOutStepRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>> SubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(SubscribeFocusInStartRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>> AsyncSubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(AsyncSubscribeFocusInStartRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>> PrepareAsyncSubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>>(PrepareAsyncSubscribeFocusInStartRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>> AsyncRespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>>(AsyncRespondFocusInStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>> PrepareAsyncRespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>>(PrepareAsyncRespondFocusInStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> SubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(SubscribeFocusOutStartRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> AsyncSubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(AsyncSubscribeFocusOutStartRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>> PrepareAsyncSubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>>(PrepareAsyncSubscribeFocusOutStartRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>> AsyncRespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>>(AsyncRespondFocusOutStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>> PrepareAsyncRespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>>(PrepareAsyncRespondFocusOutStartRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusStopResponse>> SubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusStopResponse>>(SubscribeFocusStopRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>> AsyncSubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>>(AsyncSubscribeFocusStopRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>> PrepareAsyncSubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>>(PrepareAsyncSubscribeFocusStopRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>> AsyncRespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>>(AsyncRespondFocusStopRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>> PrepareAsyncRespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>>(PrepareAsyncRespondFocusStopRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>> SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(SubscribeFocusRangeRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>> AsyncSubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(AsyncSubscribeFocusRangeRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>> PrepareAsyncSubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>>(PrepareAsyncSubscribeFocusRangeRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> AsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(AsyncRespondFocusRangeRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> PrepareAsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(PrepareAsyncRespondFocusRangeRaw(context, request, cq));
+    }
     ::grpc::Status SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>> AsyncSetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>>(AsyncSetTrackingRectangleStatusRaw(context, request, cq));
@@ -1029,6 +1293,24 @@ class CameraServerService final {
       void SubscribeZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeZoomRangeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::ZoomRangeResponse>* reactor) override;
       void RespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response, std::function<void(::grpc::Status)>) override;
       void RespondZoomRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStepResponse>* reactor) override;
+      void RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusInStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* reactor) override;
+      void RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusOutStep(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusInStartResponse>* reactor) override;
+      void RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusInStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* reactor) override;
+      void RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusOutStart(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusStopResponse>* reactor) override;
+      void RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusStop(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusRangeResponse>* reactor) override;
+      void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, std::function<void(::grpc::Status)>) override;
       void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetTrackingOffStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse* response, std::function<void(::grpc::Status)>) override;
@@ -1137,6 +1419,36 @@ class CameraServerService final {
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::ZoomRangeResponse>* PrepareAsyncSubscribeZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeZoomRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>* AsyncRespondZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondZoomRangeResponse>* PrepareAsyncRespondZoomRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* SubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* AsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStepResponse>* PrepareAsyncSubscribeFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* AsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* PrepareAsyncRespondFocusInStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* SubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* AsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* PrepareAsyncSubscribeFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* AsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* PrepareAsyncRespondFocusOutStepRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* SubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* AsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusInStartResponse>* PrepareAsyncSubscribeFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* AsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* PrepareAsyncRespondFocusInStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* SubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* AsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* PrepareAsyncSubscribeFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* AsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* PrepareAsyncRespondFocusOutStartRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* SubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* AsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusStopResponse>* PrepareAsyncSubscribeFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* AsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* PrepareAsyncRespondFocusStopRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* SubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* AsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* PrepareAsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* AsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* PrepareAsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* AsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* PrepareAsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* AsyncSetTrackingOffStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -1195,6 +1507,18 @@ class CameraServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_RespondZoomStop_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeZoomRange_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondZoomRange_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusInStep_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusInStep_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusOutStep_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusOutStep_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusInStart_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusInStart_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusOutStart_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusOutStart_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusStop_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusStop_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusRange_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusRange_;
     const ::grpc::internal::RpcMethod rpcmethod_SetTrackingRectangleStatus_;
     const ::grpc::internal::RpcMethod rpcmethod_SetTrackingOffStatus_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeTrackingPointCommand_;
@@ -1276,6 +1600,30 @@ class CameraServerService final {
     virtual ::grpc::Status SubscribeZoomRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeZoomRangeRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::ZoomRangeResponse>* writer);
     // Respond to zoom range.
     virtual ::grpc::Status RespondZoomRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* request, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* response);
+    // Subscribe to focus in step command.
+    virtual ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* writer);
+    // Respond to focus in step.
+    virtual ::grpc::Status RespondFocusInStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response);
+    // Subscribe to focus out step command.
+    virtual ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* writer);
+    // Respond to focus out step.
+    virtual ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response);
+    // Subscribe to focus in start command.
+    virtual ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* writer);
+    // Respond to focus in start.
+    virtual ::grpc::Status RespondFocusInStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response);
+    // Subscribe to focus out start command.
+    virtual ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* writer);
+    // Respond to focus out start.
+    virtual ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response);
+    // Subscribe to focus stop command.
+    virtual ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* writer);
+    // Respond to focus stop.
+    virtual ::grpc::Status RespondFocusStop(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response);
+    // Subscribe to focus range command.
+    virtual ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* writer);
+    // Respond to focus range.
+    virtual ::grpc::Status RespondFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response);
     // Set/update the current rectangle tracking status.
     virtual ::grpc::Status SetTrackingRectangleStatus(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response);
     // Set the current tracking status to off.
@@ -1922,12 +2270,252 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodAsync(31);
+    }
+    ~WithAsyncMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusInStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(31, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodAsync(32);
+    }
+    ~WithAsyncMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusInStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodAsync(33);
+    }
+    ~WithAsyncMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusOutStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(33, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodAsync(34);
+    }
+    ~WithAsyncMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusOutStep(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodAsync(35);
+    }
+    ~WithAsyncMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusInStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(35, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodAsync(36);
+    }
+    ~WithAsyncMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusInStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodAsync(37);
+    }
+    ~WithAsyncMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusOutStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(37, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodAsync(38);
+    }
+    ~WithAsyncMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusOutStart(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodAsync(39);
+    }
+    ~WithAsyncMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusStop(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(39, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodAsync(40);
+    }
+    ~WithAsyncMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusStop(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodAsync(41);
+    }
+    ~WithAsyncMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusRange(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(41, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodAsync(42);
+    }
+    ~WithAsyncMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusRange(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodAsync(31);
+      ::grpc::Service::MarkMethodAsync(43);
     }
     ~WithAsyncMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1938,7 +2526,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingRectangleStatus(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1947,7 +2535,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodAsync(32);
+      ::grpc::Service::MarkMethodAsync(44);
     }
     ~WithAsyncMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1958,7 +2546,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingOffStatus(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1967,7 +2555,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodAsync(33);
+      ::grpc::Service::MarkMethodAsync(45);
     }
     ~WithAsyncMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1978,7 +2566,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingPointCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(33, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1987,7 +2575,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodAsync(34);
+      ::grpc::Service::MarkMethodAsync(46);
     }
     ~WithAsyncMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1998,7 +2586,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingRectangleCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(34, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(46, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2007,7 +2595,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodAsync(35);
+      ::grpc::Service::MarkMethodAsync(47);
     }
     ~WithAsyncMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2018,7 +2606,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(35, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2027,7 +2615,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodAsync(36);
+      ::grpc::Service::MarkMethodAsync(48);
     }
     ~WithAsyncMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2038,7 +2626,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingPointCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2047,7 +2635,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodAsync(37);
+      ::grpc::Service::MarkMethodAsync(49);
     }
     ~WithAsyncMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2058,7 +2646,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingRectangleCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2067,7 +2655,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodAsync(38);
+      ::grpc::Service::MarkMethodAsync(50);
     }
     ~WithAsyncMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2078,7 +2666,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2087,7 +2675,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetPosition() {
-      ::grpc::Service::MarkMethodAsync(39);
+      ::grpc::Service::MarkMethodAsync(51);
     }
     ~WithAsyncMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2098,7 +2686,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPosition(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetPositionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2107,7 +2695,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodAsync(40);
+      ::grpc::Service::MarkMethodAsync(52);
     }
     ~WithAsyncMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2118,7 +2706,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2127,7 +2715,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodAsync(41);
+      ::grpc::Service::MarkMethodAsync(53);
     }
     ~WithAsyncMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2138,7 +2726,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetZoomFactor(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2147,7 +2735,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodAsync(42);
+      ::grpc::Service::MarkMethodAsync(54);
     }
     ~WithAsyncMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2158,10 +2746,10 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetFieldOfView(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(54, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<WithAsyncMethod_SetZoomFactor<WithAsyncMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SubscribeFocusInStep<WithAsyncMethod_RespondFocusInStep<WithAsyncMethod_SubscribeFocusOutStep<WithAsyncMethod_RespondFocusOutStep<WithAsyncMethod_SubscribeFocusInStart<WithAsyncMethod_RespondFocusInStart<WithAsyncMethod_SubscribeFocusOutStart<WithAsyncMethod_RespondFocusOutStart<WithAsyncMethod_SubscribeFocusStop<WithAsyncMethod_RespondFocusStop<WithAsyncMethod_SubscribeFocusRange<WithAsyncMethod_RespondFocusRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<WithAsyncMethod_SetZoomFactor<WithAsyncMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetInformation : public BaseClass {
    private:
@@ -2930,18 +3518,312 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondZoomRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondZoomRangeResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodCallback(31,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest, ::mavsdk::rpc::camera_server::FocusInStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* request) { return this->SubscribeFocusInStep(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusInStepResponse>* SubscribeFocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodCallback(32,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* response) { return this->RespondFocusInStep(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusInStep(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodCallback(33,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest, ::mavsdk::rpc::camera_server::FocusOutStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* request) { return this->SubscribeFocusOutStep(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* SubscribeFocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodCallback(34,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* response) { return this->RespondFocusOutStep(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusOutStep(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodCallback(35,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest, ::mavsdk::rpc::camera_server::FocusInStartResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* request) { return this->SubscribeFocusInStart(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusInStartResponse>* SubscribeFocusInStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodCallback(36,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* response) { return this->RespondFocusInStart(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusInStart(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusInStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodCallback(37,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest, ::mavsdk::rpc::camera_server::FocusOutStartResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* request) { return this->SubscribeFocusOutStart(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* SubscribeFocusOutStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodCallback(38,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* request, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* response) { return this->RespondFocusOutStart(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusOutStart(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(38);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusOutStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodCallback(39,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest, ::mavsdk::rpc::camera_server::FocusStopResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* request) { return this->SubscribeFocusStop(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusStopResponse>* SubscribeFocusStop(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* request, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* response) { return this->RespondFocusStop(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusStop(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusStop(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodCallback(41,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest, ::mavsdk::rpc::camera_server::FocusRangeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request) { return this->SubscribeFocusRange(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusRangeResponse>* SubscribeFocusRange(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodCallback(42,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response) { return this->RespondFocusRange(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusRange(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(42);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusRange(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodCallback(31,
+      ::grpc::Service::MarkMethodCallback(43,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) { return this->SetTrackingRectangleStatus(context, request, response); }));}
     void SetMessageAllocatorFor_SetTrackingRectangleStatus(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(31);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(43);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2962,13 +3844,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodCallback(32,
+      ::grpc::Service::MarkMethodCallback(44,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse* response) { return this->SetTrackingOffStatus(context, request, response); }));}
     void SetMessageAllocatorFor_SetTrackingOffStatus(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(44);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -2989,7 +3871,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodCallback(33,
+      ::grpc::Service::MarkMethodCallback(45,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest* request) { return this->SubscribeTrackingPointCommand(context, request); }));
@@ -3011,7 +3893,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodCallback(34,
+      ::grpc::Service::MarkMethodCallback(46,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest* request) { return this->SubscribeTrackingRectangleCommand(context, request); }));
@@ -3033,7 +3915,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodCallback(35,
+      ::grpc::Service::MarkMethodCallback(47,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest* request) { return this->SubscribeTrackingOffCommand(context, request); }));
@@ -3055,13 +3937,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodCallback(36,
+      ::grpc::Service::MarkMethodCallback(48,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse* response) { return this->RespondTrackingPointCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingPointCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(48);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3082,13 +3964,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodCallback(37,
+      ::grpc::Service::MarkMethodCallback(49,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response) { return this->RespondTrackingRectangleCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingRectangleCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(37);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(49);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3109,13 +3991,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodCallback(38,
+      ::grpc::Service::MarkMethodCallback(50,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response) { return this->RespondTrackingOffCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingOffCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(38);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(50);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3136,13 +4018,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetPosition() {
-      ::grpc::Service::MarkMethodCallback(39,
+      ::grpc::Service::MarkMethodCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) { return this->SetPosition(context, request, response); }));}
     void SetMessageAllocatorFor_SetPosition(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(39);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(51);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3163,13 +4045,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodCallback(40,
+      ::grpc::Service::MarkMethodCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) { return this->SetAttitudeQuaternion(context, request, response); }));}
     void SetMessageAllocatorFor_SetAttitudeQuaternion(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(40);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(52);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3190,13 +4072,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodCallback(41,
+      ::grpc::Service::MarkMethodCallback(53,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) { return this->SetZoomFactor(context, request, response); }));}
     void SetMessageAllocatorFor_SetZoomFactor(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(41);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(53);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3217,13 +4099,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodCallback(42,
+      ::grpc::Service::MarkMethodCallback(54,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) { return this->SetFieldOfView(context, request, response); }));}
     void SetMessageAllocatorFor_SetFieldOfView(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(42);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(54);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3238,7 +4120,7 @@ class CameraServerService final {
     virtual ::grpc::ServerUnaryReactor* SetFieldOfView(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<WithCallbackMethod_SetZoomFactor<WithCallbackMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SubscribeFocusInStep<WithCallbackMethod_RespondFocusInStep<WithCallbackMethod_SubscribeFocusOutStep<WithCallbackMethod_RespondFocusOutStep<WithCallbackMethod_SubscribeFocusInStart<WithCallbackMethod_RespondFocusInStart<WithCallbackMethod_SubscribeFocusOutStart<WithCallbackMethod_RespondFocusOutStart<WithCallbackMethod_SubscribeFocusStop<WithCallbackMethod_RespondFocusStop<WithCallbackMethod_SubscribeFocusRange<WithCallbackMethod_RespondFocusRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<WithCallbackMethod_SetZoomFactor<WithCallbackMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetInformation : public BaseClass {
@@ -3768,12 +4650,216 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodGeneric(31);
+    }
+    ~WithGenericMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodGeneric(32);
+    }
+    ~WithGenericMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodGeneric(33);
+    }
+    ~WithGenericMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodGeneric(34);
+    }
+    ~WithGenericMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodGeneric(35);
+    }
+    ~WithGenericMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodGeneric(36);
+    }
+    ~WithGenericMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodGeneric(37);
+    }
+    ~WithGenericMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodGeneric(38);
+    }
+    ~WithGenericMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodGeneric(39);
+    }
+    ~WithGenericMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodGeneric(40);
+    }
+    ~WithGenericMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodGeneric(41);
+    }
+    ~WithGenericMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodGeneric(42);
+    }
+    ~WithGenericMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodGeneric(31);
+      ::grpc::Service::MarkMethodGeneric(43);
     }
     ~WithGenericMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3790,7 +4876,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodGeneric(32);
+      ::grpc::Service::MarkMethodGeneric(44);
     }
     ~WithGenericMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3807,7 +4893,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodGeneric(33);
+      ::grpc::Service::MarkMethodGeneric(45);
     }
     ~WithGenericMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3824,7 +4910,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodGeneric(34);
+      ::grpc::Service::MarkMethodGeneric(46);
     }
     ~WithGenericMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3841,7 +4927,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodGeneric(35);
+      ::grpc::Service::MarkMethodGeneric(47);
     }
     ~WithGenericMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3858,7 +4944,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodGeneric(36);
+      ::grpc::Service::MarkMethodGeneric(48);
     }
     ~WithGenericMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3875,7 +4961,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodGeneric(37);
+      ::grpc::Service::MarkMethodGeneric(49);
     }
     ~WithGenericMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3892,7 +4978,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodGeneric(38);
+      ::grpc::Service::MarkMethodGeneric(50);
     }
     ~WithGenericMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3909,7 +4995,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetPosition() {
-      ::grpc::Service::MarkMethodGeneric(39);
+      ::grpc::Service::MarkMethodGeneric(51);
     }
     ~WithGenericMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3926,7 +5012,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodGeneric(40);
+      ::grpc::Service::MarkMethodGeneric(52);
     }
     ~WithGenericMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3943,7 +5029,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodGeneric(41);
+      ::grpc::Service::MarkMethodGeneric(53);
     }
     ~WithGenericMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3960,7 +5046,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodGeneric(42);
+      ::grpc::Service::MarkMethodGeneric(54);
     }
     ~WithGenericMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4592,12 +5678,252 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodRaw(31);
+    }
+    ~WithRawMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusInStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(31, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodRaw(32);
+    }
+    ~WithRawMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusInStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodRaw(33);
+    }
+    ~WithRawMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusOutStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(33, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodRaw(34);
+    }
+    ~WithRawMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusOutStep(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodRaw(35);
+    }
+    ~WithRawMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusInStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(35, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodRaw(36);
+    }
+    ~WithRawMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusInStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodRaw(37);
+    }
+    ~WithRawMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusOutStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(37, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodRaw(38);
+    }
+    ~WithRawMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusOutStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodRaw(39);
+    }
+    ~WithRawMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusStop(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(39, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodRaw(40);
+    }
+    ~WithRawMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusStop(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodRaw(41);
+    }
+    ~WithRawMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusRange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(41, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodRaw(42);
+    }
+    ~WithRawMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusRange(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodRaw(31);
+      ::grpc::Service::MarkMethodRaw(43);
     }
     ~WithRawMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4608,7 +5934,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingRectangleStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4617,7 +5943,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodRaw(32);
+      ::grpc::Service::MarkMethodRaw(44);
     }
     ~WithRawMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4628,7 +5954,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingOffStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4637,7 +5963,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRaw(33);
+      ::grpc::Service::MarkMethodRaw(45);
     }
     ~WithRawMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4648,7 +5974,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingPointCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(33, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4657,7 +5983,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRaw(34);
+      ::grpc::Service::MarkMethodRaw(46);
     }
     ~WithRawMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4668,7 +5994,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingRectangleCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(34, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(46, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4677,7 +6003,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRaw(35);
+      ::grpc::Service::MarkMethodRaw(47);
     }
     ~WithRawMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4688,7 +6014,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(35, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4697,7 +6023,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRaw(36);
+      ::grpc::Service::MarkMethodRaw(48);
     }
     ~WithRawMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4708,7 +6034,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingPointCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4717,7 +6043,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRaw(37);
+      ::grpc::Service::MarkMethodRaw(49);
     }
     ~WithRawMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4728,7 +6054,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingRectangleCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4737,7 +6063,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRaw(38);
+      ::grpc::Service::MarkMethodRaw(50);
     }
     ~WithRawMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4748,7 +6074,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(38, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4757,7 +6083,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetPosition() {
-      ::grpc::Service::MarkMethodRaw(39);
+      ::grpc::Service::MarkMethodRaw(51);
     }
     ~WithRawMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4768,7 +6094,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPosition(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(39, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4777,7 +6103,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodRaw(40);
+      ::grpc::Service::MarkMethodRaw(52);
     }
     ~WithRawMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4788,7 +6114,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(40, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4797,7 +6123,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodRaw(41);
+      ::grpc::Service::MarkMethodRaw(53);
     }
     ~WithRawMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4808,7 +6134,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetZoomFactor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(41, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4817,7 +6143,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodRaw(42);
+      ::grpc::Service::MarkMethodRaw(54);
     }
     ~WithRawMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4828,7 +6154,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetFieldOfView(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(42, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(54, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5514,12 +6840,276 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodRawCallback(31,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusInStep(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodRawCallback(32,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusInStep(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusInStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodRawCallback(33,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusOutStep(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodRawCallback(34,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusOutStep(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusOutStep(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodRawCallback(35,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusInStart(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusInStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodRawCallback(36,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusInStart(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusInStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodRawCallback(37,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusOutStart(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusOutStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodRawCallback(38,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusOutStart(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusOutStart(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodRawCallback(39,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusStop(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusStop(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodRawCallback(40,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusStop(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusStop(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodRawCallback(41,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusRange(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusRange(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodRawCallback(42,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusRange(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusRange(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodRawCallback(31,
+      ::grpc::Service::MarkMethodRawCallback(43,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTrackingRectangleStatus(context, request, response); }));
@@ -5541,7 +7131,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodRawCallback(32,
+      ::grpc::Service::MarkMethodRawCallback(44,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTrackingOffStatus(context, request, response); }));
@@ -5563,7 +7153,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRawCallback(33,
+      ::grpc::Service::MarkMethodRawCallback(45,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingPointCommand(context, request); }));
@@ -5585,7 +7175,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRawCallback(34,
+      ::grpc::Service::MarkMethodRawCallback(46,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingRectangleCommand(context, request); }));
@@ -5607,7 +7197,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRawCallback(35,
+      ::grpc::Service::MarkMethodRawCallback(47,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingOffCommand(context, request); }));
@@ -5629,7 +7219,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRawCallback(36,
+      ::grpc::Service::MarkMethodRawCallback(48,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingPointCommand(context, request, response); }));
@@ -5651,7 +7241,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRawCallback(37,
+      ::grpc::Service::MarkMethodRawCallback(49,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingRectangleCommand(context, request, response); }));
@@ -5673,7 +7263,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRawCallback(38,
+      ::grpc::Service::MarkMethodRawCallback(50,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingOffCommand(context, request, response); }));
@@ -5695,7 +7285,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetPosition() {
-      ::grpc::Service::MarkMethodRawCallback(39,
+      ::grpc::Service::MarkMethodRawCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPosition(context, request, response); }));
@@ -5717,7 +7307,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodRawCallback(40,
+      ::grpc::Service::MarkMethodRawCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetAttitudeQuaternion(context, request, response); }));
@@ -5739,7 +7329,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodRawCallback(41,
+      ::grpc::Service::MarkMethodRawCallback(53,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetZoomFactor(context, request, response); }));
@@ -5761,7 +7351,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodRawCallback(42,
+      ::grpc::Service::MarkMethodRawCallback(54,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetFieldOfView(context, request, response); }));
@@ -6237,12 +7827,174 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedRespondZoomRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondZoomRangeRequest,::mavsdk::rpc::camera_server::RespondZoomRangeResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusInStep() {
+      ::grpc::Service::MarkMethodStreamed(32,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusInStepRequest, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* streamer) {
+                       return this->StreamedRespondFocusInStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusInStep(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusInStepRequest,::mavsdk::rpc::camera_server::RespondFocusInStepResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusOutStep() {
+      ::grpc::Service::MarkMethodStreamed(34,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* streamer) {
+                       return this->StreamedRespondFocusOutStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusOutStep(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusOutStepRequest,::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusInStart() {
+      ::grpc::Service::MarkMethodStreamed(36,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusInStartRequest, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* streamer) {
+                       return this->StreamedRespondFocusInStart(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusInStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusInStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusInStart(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusInStartRequest,::mavsdk::rpc::camera_server::RespondFocusInStartResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusOutStart() {
+      ::grpc::Service::MarkMethodStreamed(38,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* streamer) {
+                       return this->StreamedRespondFocusOutStart(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusOutStart(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusOutStartRequest,::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusStop() {
+      ::grpc::Service::MarkMethodStreamed(40,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusStopRequest, ::mavsdk::rpc::camera_server::RespondFocusStopResponse>* streamer) {
+                       return this->StreamedRespondFocusStop(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusStopRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusStopResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusStop(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusStopRequest,::mavsdk::rpc::camera_server::RespondFocusStopResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusRange() {
+      ::grpc::Service::MarkMethodStreamed(42,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusRangeRequest, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* streamer) {
+                       return this->StreamedRespondFocusRange(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest,::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodStreamed(31,
+      ::grpc::Service::MarkMethodStreamed(43,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -6269,7 +8021,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodStreamed(32,
+      ::grpc::Service::MarkMethodStreamed(44,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -6296,7 +8048,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodStreamed(36,
+      ::grpc::Service::MarkMethodStreamed(48,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6323,7 +8075,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodStreamed(37,
+      ::grpc::Service::MarkMethodStreamed(49,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6350,7 +8102,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodStreamed(38,
+      ::grpc::Service::MarkMethodStreamed(50,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6377,7 +8129,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetPosition() {
-      ::grpc::Service::MarkMethodStreamed(39,
+      ::grpc::Service::MarkMethodStreamed(51,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
             [this](::grpc::ServerContext* context,
@@ -6404,7 +8156,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodStreamed(40,
+      ::grpc::Service::MarkMethodStreamed(52,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
             [this](::grpc::ServerContext* context,
@@ -6431,7 +8183,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodStreamed(41,
+      ::grpc::Service::MarkMethodStreamed(53,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
             [this](::grpc::ServerContext* context,
@@ -6458,7 +8210,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodStreamed(42,
+      ::grpc::Service::MarkMethodStreamed(54,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
             [this](::grpc::ServerContext* context,
@@ -6479,7 +8231,7 @@ class CameraServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetFieldOfView(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest,::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_RespondFocusInStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithStreamedUnaryMethod_RespondFocusInStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithStreamedUnaryMethod_RespondFocusStop<WithStreamedUnaryMethod_RespondFocusRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTakePhoto : public BaseClass {
    private:
@@ -6859,12 +8611,174 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedSubscribeZoomRange(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeZoomRangeRequest,::mavsdk::rpc::camera_server::ZoomRangeResponse>* server_split_streamer) = 0;
   };
   template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusInStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusInStep() {
+      ::grpc::Service::MarkMethodStreamed(31,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest, ::mavsdk::rpc::camera_server::FocusInStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest, ::mavsdk::rpc::camera_server::FocusInStepResponse>* streamer) {
+                       return this->StreamedSubscribeFocusInStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusInStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusInStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusInStep(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest,::mavsdk::rpc::camera_server::FocusInStepResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusOutStep : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusOutStep() {
+      ::grpc::Service::MarkMethodStreamed(33,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest, ::mavsdk::rpc::camera_server::FocusOutStepResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest, ::mavsdk::rpc::camera_server::FocusOutStepResponse>* streamer) {
+                       return this->StreamedSubscribeFocusOutStep(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusOutStep() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusOutStep(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStepResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusOutStep(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest,::mavsdk::rpc::camera_server::FocusOutStepResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusInStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusInStart() {
+      ::grpc::Service::MarkMethodStreamed(35,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest, ::mavsdk::rpc::camera_server::FocusInStartResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest, ::mavsdk::rpc::camera_server::FocusInStartResponse>* streamer) {
+                       return this->StreamedSubscribeFocusInStart(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusInStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusInStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusInStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusInStart(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest,::mavsdk::rpc::camera_server::FocusInStartResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusOutStart : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusOutStart() {
+      ::grpc::Service::MarkMethodStreamed(37,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest, ::mavsdk::rpc::camera_server::FocusOutStartResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest, ::mavsdk::rpc::camera_server::FocusOutStartResponse>* streamer) {
+                       return this->StreamedSubscribeFocusOutStart(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusOutStart() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusOutStart(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusOutStartResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusOutStart(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest,::mavsdk::rpc::camera_server::FocusOutStartResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusStop : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusStop() {
+      ::grpc::Service::MarkMethodStreamed(39,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest, ::mavsdk::rpc::camera_server::FocusStopResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest, ::mavsdk::rpc::camera_server::FocusStopResponse>* streamer) {
+                       return this->StreamedSubscribeFocusStop(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusStop() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusStop(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusStopResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusStop(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusStopRequest,::mavsdk::rpc::camera_server::FocusStopResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusRange : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusRange() {
+      ::grpc::Service::MarkMethodStreamed(41,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest, ::mavsdk::rpc::camera_server::FocusRangeResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest, ::mavsdk::rpc::camera_server::FocusRangeResponse>* streamer) {
+                       return this->StreamedSubscribeFocusRange(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusRange() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusRange(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest,::mavsdk::rpc::camera_server::FocusRangeResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTrackingPointCommand : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodStreamed(33,
+      ::grpc::Service::MarkMethodStreamed(45,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6891,7 +8805,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodStreamed(34,
+      ::grpc::Service::MarkMethodStreamed(46,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6918,7 +8832,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodStreamed(35,
+      ::grpc::Service::MarkMethodStreamed(47,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -6939,8 +8853,8 @@ class CameraServerService final {
     // replace default version of method with split streamed
     virtual ::grpc::Status StreamedSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest,::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithStreamedUnaryMethod_RespondFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithStreamedUnaryMethod_RespondFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithStreamedUnaryMethod_RespondFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithStreamedUnaryMethod_RespondFocusRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera_server

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.grpc.pb.h
@@ -422,6 +422,78 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> PrepareAsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(PrepareAsyncRespondFocusRangeRaw(context, request, cq));
     }
+    // Subscribe to focus meters command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>> SubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(SubscribeFocusMetersRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>> AsyncSubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(AsyncSubscribeFocusMetersRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>> PrepareAsyncSubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(PrepareAsyncSubscribeFocusMetersRaw(context, request, cq));
+    }
+    // Respond to focus meters.
+    virtual ::grpc::Status RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>> AsyncRespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>>(AsyncRespondFocusMetersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>> PrepareAsyncRespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>>(PrepareAsyncRespondFocusMetersRaw(context, request, cq));
+    }
+    // Subscribe to focus auto command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>> SubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(SubscribeFocusAutoRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>> AsyncSubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(AsyncSubscribeFocusAutoRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>> PrepareAsyncSubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(PrepareAsyncSubscribeFocusAutoRaw(context, request, cq));
+    }
+    // Respond to focus auto.
+    virtual ::grpc::Status RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>> AsyncRespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>>(AsyncRespondFocusAutoRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>> PrepareAsyncRespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>>(PrepareAsyncRespondFocusAutoRaw(context, request, cq));
+    }
+    // Subscribe to focus auto single command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> SubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(SubscribeFocusAutoSingleRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> AsyncSubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(AsyncSubscribeFocusAutoSingleRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> PrepareAsyncSubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(PrepareAsyncSubscribeFocusAutoSingleRaw(context, request, cq));
+    }
+    // Respond to focus auto single.
+    virtual ::grpc::Status RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>> AsyncRespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>>(AsyncRespondFocusAutoSingleRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>> PrepareAsyncRespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>>(PrepareAsyncRespondFocusAutoSingleRaw(context, request, cq));
+    }
+    // Subscribe to focus auto continuous command.
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> SubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(SubscribeFocusAutoContinuousRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> AsyncSubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(AsyncSubscribeFocusAutoContinuousRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> PrepareAsyncSubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(PrepareAsyncSubscribeFocusAutoContinuousRaw(context, request, cq));
+    }
+    // Respond to focus auto continuous.
+    virtual ::grpc::Status RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>> AsyncRespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>>(AsyncRespondFocusAutoContinuousRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>> PrepareAsyncRespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>>(PrepareAsyncRespondFocusAutoContinuousRaw(context, request, cq));
+    }
     // Set/update the current rectangle tracking status.
     virtual ::grpc::Status SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>> AsyncSetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) {
@@ -636,6 +708,26 @@ class CameraServerService final {
       // Respond to focus range.
       virtual void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus meters command.
+      virtual void SubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusMetersResponse>* reactor) = 0;
+      // Respond to focus meters.
+      virtual void RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus auto command.
+      virtual void SubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoResponse>* reactor) = 0;
+      // Respond to focus auto.
+      virtual void RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus auto single command.
+      virtual void SubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* reactor) = 0;
+      // Respond to focus auto single.
+      virtual void RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      // Subscribe to focus auto continuous command.
+      virtual void SubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* reactor) = 0;
+      // Respond to focus auto continuous.
+      virtual void RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
       // Set/update the current rectangle tracking status.
       virtual void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -780,6 +872,26 @@ class CameraServerService final {
     virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusRangeResponse>* PrepareAsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* AsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* PrepareAsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>* SubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>* AsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusMetersResponse>* PrepareAsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* AsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* PrepareAsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>* SubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>* AsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoResponse>* PrepareAsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* AsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* PrepareAsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* SubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* AsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* PrepareAsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* AsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* PrepareAsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* SubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* AsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* PrepareAsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* AsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* PrepareAsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* AsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* PrepareAsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* AsyncSetTrackingOffStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -1152,6 +1264,70 @@ class CameraServerService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>> PrepareAsyncRespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>>(PrepareAsyncRespondFocusRangeRaw(context, request, cq));
     }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>> SubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(SubscribeFocusMetersRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>> AsyncSubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(AsyncSubscribeFocusMetersRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>> PrepareAsyncSubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>>(PrepareAsyncSubscribeFocusMetersRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>> AsyncRespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>>(AsyncRespondFocusMetersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>> PrepareAsyncRespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>>(PrepareAsyncRespondFocusMetersRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>> SubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(SubscribeFocusAutoRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>> AsyncSubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(AsyncSubscribeFocusAutoRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>> PrepareAsyncSubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>>(PrepareAsyncSubscribeFocusAutoRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>> AsyncRespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>>(AsyncRespondFocusAutoRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>> PrepareAsyncRespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>>(PrepareAsyncRespondFocusAutoRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> SubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(SubscribeFocusAutoSingleRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> AsyncSubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(AsyncSubscribeFocusAutoSingleRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>> PrepareAsyncSubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>>(PrepareAsyncSubscribeFocusAutoSingleRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>> AsyncRespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>>(AsyncRespondFocusAutoSingleRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>> PrepareAsyncRespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>>(PrepareAsyncRespondFocusAutoSingleRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> SubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(SubscribeFocusAutoContinuousRaw(context, request));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> AsyncSubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(AsyncSubscribeFocusAutoContinuousRaw(context, request, cq, tag));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>> PrepareAsyncSubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>>(PrepareAsyncSubscribeFocusAutoContinuousRaw(context, request, cq));
+    }
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>> AsyncRespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>>(AsyncRespondFocusAutoContinuousRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>> PrepareAsyncRespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>>(PrepareAsyncRespondFocusAutoContinuousRaw(context, request, cq));
+    }
     ::grpc::Status SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>> AsyncSetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>>(AsyncSetTrackingRectangleStatusRaw(context, request, cq));
@@ -1311,6 +1487,18 @@ class CameraServerService final {
       void SubscribeFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusRangeResponse>* reactor) override;
       void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, std::function<void(::grpc::Status)>) override;
       void RespondFocusRange(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusMetersResponse>* reactor) override;
+      void RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusMeters(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoResponse>* reactor) override;
+      void RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusAuto(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* reactor) override;
+      void RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusAutoSingle(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      void SubscribeFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ClientReadReactor< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* reactor) override;
+      void RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, std::function<void(::grpc::Status)>) override;
+      void RespondFocusAutoContinuous(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, std::function<void(::grpc::Status)>) override;
       void SetTrackingRectangleStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
       void SetTrackingOffStatus(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse* response, std::function<void(::grpc::Status)>) override;
@@ -1449,6 +1637,26 @@ class CameraServerService final {
     ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusRangeResponse>* PrepareAsyncSubscribeFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* AsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* PrepareAsyncRespondFocusRangeRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* SubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* AsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusMetersResponse>* PrepareAsyncSubscribeFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* AsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* PrepareAsyncRespondFocusMetersRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* SubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* AsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoResponse>* PrepareAsyncSubscribeFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* AsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* PrepareAsyncRespondFocusAutoRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* SubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* AsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* PrepareAsyncSubscribeFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* AsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* PrepareAsyncRespondFocusAutoSingleRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* SubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* AsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* PrepareAsyncSubscribeFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* AsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* PrepareAsyncRespondFocusAutoContinuousRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* AsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* PrepareAsyncSetTrackingRectangleStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* AsyncSetTrackingOffStatusRaw(::grpc::ClientContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -1519,6 +1727,14 @@ class CameraServerService final {
     const ::grpc::internal::RpcMethod rpcmethod_RespondFocusStop_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusRange_;
     const ::grpc::internal::RpcMethod rpcmethod_RespondFocusRange_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusMeters_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusMeters_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusAuto_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusAuto_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusAutoSingle_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusAutoSingle_;
+    const ::grpc::internal::RpcMethod rpcmethod_SubscribeFocusAutoContinuous_;
+    const ::grpc::internal::RpcMethod rpcmethod_RespondFocusAutoContinuous_;
     const ::grpc::internal::RpcMethod rpcmethod_SetTrackingRectangleStatus_;
     const ::grpc::internal::RpcMethod rpcmethod_SetTrackingOffStatus_;
     const ::grpc::internal::RpcMethod rpcmethod_SubscribeTrackingPointCommand_;
@@ -1624,6 +1840,22 @@ class CameraServerService final {
     virtual ::grpc::Status SubscribeFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusRangeResponse>* writer);
     // Respond to focus range.
     virtual ::grpc::Status RespondFocusRange(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* request, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* response);
+    // Subscribe to focus meters command.
+    virtual ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* writer);
+    // Respond to focus meters.
+    virtual ::grpc::Status RespondFocusMeters(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response);
+    // Subscribe to focus auto command.
+    virtual ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* writer);
+    // Respond to focus auto.
+    virtual ::grpc::Status RespondFocusAuto(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response);
+    // Subscribe to focus auto single command.
+    virtual ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* writer);
+    // Respond to focus auto single.
+    virtual ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response);
+    // Subscribe to focus auto continuous command.
+    virtual ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* writer);
+    // Respond to focus auto continuous.
+    virtual ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response);
     // Set/update the current rectangle tracking status.
     virtual ::grpc::Status SetTrackingRectangleStatus(::grpc::ServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response);
     // Set the current tracking status to off.
@@ -2510,12 +2742,172 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodAsync(43);
+    }
+    ~WithAsyncMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusMeters(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(43, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodAsync(44);
+    }
+    ~WithAsyncMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusMeters(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodAsync(45);
+    }
+    ~WithAsyncMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAuto(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodAsync(46);
+    }
+    ~WithAsyncMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAuto(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodAsync(47);
+    }
+    ~WithAsyncMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAutoSingle(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodAsync(48);
+    }
+    ~WithAsyncMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAutoSingle(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodAsync(49);
+    }
+    ~WithAsyncMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAutoContinuous(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(49, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodAsync(50);
+    }
+    ~WithAsyncMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAutoContinuous(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodAsync(43);
+      ::grpc::Service::MarkMethodAsync(51);
     }
     ~WithAsyncMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2526,7 +2918,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingRectangleStatus(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2535,7 +2927,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodAsync(44);
+      ::grpc::Service::MarkMethodAsync(52);
     }
     ~WithAsyncMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2546,7 +2938,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingOffStatus(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2555,7 +2947,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodAsync(45);
+      ::grpc::Service::MarkMethodAsync(53);
     }
     ~WithAsyncMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2566,7 +2958,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingPointCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(53, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2575,7 +2967,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodAsync(46);
+      ::grpc::Service::MarkMethodAsync(54);
     }
     ~WithAsyncMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2586,7 +2978,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingRectangleCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(46, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(54, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2595,7 +2987,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodAsync(47);
+      ::grpc::Service::MarkMethodAsync(55);
     }
     ~WithAsyncMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2606,7 +2998,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest* request, ::grpc::ServerAsyncWriter< ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(55, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2615,7 +3007,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodAsync(48);
+      ::grpc::Service::MarkMethodAsync(56);
     }
     ~WithAsyncMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2626,7 +3018,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingPointCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(56, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2635,7 +3027,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodAsync(49);
+      ::grpc::Service::MarkMethodAsync(57);
     }
     ~WithAsyncMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2646,7 +3038,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingRectangleCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(57, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2655,7 +3047,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodAsync(50);
+      ::grpc::Service::MarkMethodAsync(58);
     }
     ~WithAsyncMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2666,7 +3058,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(58, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2675,7 +3067,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetPosition() {
-      ::grpc::Service::MarkMethodAsync(51);
+      ::grpc::Service::MarkMethodAsync(59);
     }
     ~WithAsyncMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2686,7 +3078,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPosition(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetPositionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(59, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2695,7 +3087,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodAsync(52);
+      ::grpc::Service::MarkMethodAsync(60);
     }
     ~WithAsyncMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2706,7 +3098,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(60, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2715,7 +3107,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodAsync(53);
+      ::grpc::Service::MarkMethodAsync(61);
     }
     ~WithAsyncMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2726,7 +3118,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetZoomFactor(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(61, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -2735,7 +3127,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodAsync(54);
+      ::grpc::Service::MarkMethodAsync(62);
     }
     ~WithAsyncMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -2746,10 +3138,10 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetFieldOfView(::grpc::ServerContext* context, ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::grpc::ServerAsyncResponseWriter< ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(54, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(62, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SubscribeFocusInStep<WithAsyncMethod_RespondFocusInStep<WithAsyncMethod_SubscribeFocusOutStep<WithAsyncMethod_RespondFocusOutStep<WithAsyncMethod_SubscribeFocusInStart<WithAsyncMethod_RespondFocusInStart<WithAsyncMethod_SubscribeFocusOutStart<WithAsyncMethod_RespondFocusOutStart<WithAsyncMethod_SubscribeFocusStop<WithAsyncMethod_RespondFocusStop<WithAsyncMethod_SubscribeFocusRange<WithAsyncMethod_RespondFocusRange<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<WithAsyncMethod_SetZoomFactor<WithAsyncMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_SetInformation<WithAsyncMethod_SetVideoStreaming<WithAsyncMethod_SetInProgress<WithAsyncMethod_SubscribeTakePhoto<WithAsyncMethod_RespondTakePhoto<WithAsyncMethod_SubscribeStartVideo<WithAsyncMethod_RespondStartVideo<WithAsyncMethod_SubscribeStopVideo<WithAsyncMethod_RespondStopVideo<WithAsyncMethod_SubscribeStartVideoStreaming<WithAsyncMethod_RespondStartVideoStreaming<WithAsyncMethod_SubscribeStopVideoStreaming<WithAsyncMethod_RespondStopVideoStreaming<WithAsyncMethod_SubscribeSetMode<WithAsyncMethod_RespondSetMode<WithAsyncMethod_SubscribeStorageInformation<WithAsyncMethod_RespondStorageInformation<WithAsyncMethod_SubscribeCaptureStatus<WithAsyncMethod_RespondCaptureStatus<WithAsyncMethod_SubscribeFormatStorage<WithAsyncMethod_RespondFormatStorage<WithAsyncMethod_SubscribeResetSettings<WithAsyncMethod_RespondResetSettings<WithAsyncMethod_SubscribeZoomInStart<WithAsyncMethod_RespondZoomInStart<WithAsyncMethod_SubscribeZoomOutStart<WithAsyncMethod_RespondZoomOutStart<WithAsyncMethod_SubscribeZoomStop<WithAsyncMethod_RespondZoomStop<WithAsyncMethod_SubscribeZoomRange<WithAsyncMethod_RespondZoomRange<WithAsyncMethod_SubscribeFocusInStep<WithAsyncMethod_RespondFocusInStep<WithAsyncMethod_SubscribeFocusOutStep<WithAsyncMethod_RespondFocusOutStep<WithAsyncMethod_SubscribeFocusInStart<WithAsyncMethod_RespondFocusInStart<WithAsyncMethod_SubscribeFocusOutStart<WithAsyncMethod_RespondFocusOutStart<WithAsyncMethod_SubscribeFocusStop<WithAsyncMethod_RespondFocusStop<WithAsyncMethod_SubscribeFocusRange<WithAsyncMethod_RespondFocusRange<WithAsyncMethod_SubscribeFocusMeters<WithAsyncMethod_RespondFocusMeters<WithAsyncMethod_SubscribeFocusAuto<WithAsyncMethod_RespondFocusAuto<WithAsyncMethod_SubscribeFocusAutoSingle<WithAsyncMethod_RespondFocusAutoSingle<WithAsyncMethod_SubscribeFocusAutoContinuous<WithAsyncMethod_RespondFocusAutoContinuous<WithAsyncMethod_SetTrackingRectangleStatus<WithAsyncMethod_SetTrackingOffStatus<WithAsyncMethod_SubscribeTrackingPointCommand<WithAsyncMethod_SubscribeTrackingRectangleCommand<WithAsyncMethod_SubscribeTrackingOffCommand<WithAsyncMethod_RespondTrackingPointCommand<WithAsyncMethod_RespondTrackingRectangleCommand<WithAsyncMethod_RespondTrackingOffCommand<WithAsyncMethod_SetPosition<WithAsyncMethod_SetAttitudeQuaternion<WithAsyncMethod_SetZoomFactor<WithAsyncMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class WithCallbackMethod_SetInformation : public BaseClass {
    private:
@@ -3812,18 +4204,214 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusRangeRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusRangeResponse* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodCallback(43,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest, ::mavsdk::rpc::camera_server::FocusMetersResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* request) { return this->SubscribeFocusMeters(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusMetersResponse>* SubscribeFocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodCallback(44,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* request, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* response) { return this->RespondFocusMeters(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusMeters(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(44);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodCallback(45,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest, ::mavsdk::rpc::camera_server::FocusAutoResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* request) { return this->SubscribeFocusAuto(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusAutoResponse>* SubscribeFocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodCallback(46,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* response) { return this->RespondFocusAuto(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusAuto(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(46);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodCallback(47,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* request) { return this->SubscribeFocusAutoSingle(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* SubscribeFocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodCallback(48,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* response) { return this->RespondFocusAutoSingle(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusAutoSingle(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(48);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodCallback(49,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* request) { return this->SubscribeFocusAutoContinuous(context, request); }));
+    }
+    ~WithCallbackMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* SubscribeFocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithCallbackMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithCallbackMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodCallback(50,
+          new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* request, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* response) { return this->RespondFocusAutoContinuous(context, request, response); }));}
+    void SetMessageAllocatorFor_RespondFocusAutoContinuous(
+        ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* allocator) {
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(50);
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~WithCallbackMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithCallbackMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodCallback(43,
+      ::grpc::Service::MarkMethodCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse* response) { return this->SetTrackingRectangleStatus(context, request, response); }));}
     void SetMessageAllocatorFor_SetTrackingRectangleStatus(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(43);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(51);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3844,13 +4432,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodCallback(44,
+      ::grpc::Service::MarkMethodCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest* request, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse* response) { return this->SetTrackingOffStatus(context, request, response); }));}
     void SetMessageAllocatorFor_SetTrackingOffStatus(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(44);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(52);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3871,7 +4459,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodCallback(45,
+      ::grpc::Service::MarkMethodCallback(53,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest* request) { return this->SubscribeTrackingPointCommand(context, request); }));
@@ -3893,7 +4481,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodCallback(46,
+      ::grpc::Service::MarkMethodCallback(54,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest* request) { return this->SubscribeTrackingRectangleCommand(context, request); }));
@@ -3915,7 +4503,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodCallback(47,
+      ::grpc::Service::MarkMethodCallback(55,
           new ::grpc::internal::CallbackServerStreamingHandler< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest* request) { return this->SubscribeTrackingOffCommand(context, request); }));
@@ -3937,13 +4525,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodCallback(48,
+      ::grpc::Service::MarkMethodCallback(56,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse* response) { return this->RespondTrackingPointCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingPointCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(48);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(56);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3964,13 +4552,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodCallback(49,
+      ::grpc::Service::MarkMethodCallback(57,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse* response) { return this->RespondTrackingRectangleCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingRectangleCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(49);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(57);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -3991,13 +4579,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodCallback(50,
+      ::grpc::Service::MarkMethodCallback(58,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest* request, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse* response) { return this->RespondTrackingOffCommand(context, request, response); }));}
     void SetMessageAllocatorFor_RespondTrackingOffCommand(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(50);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(58);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -4018,13 +4606,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetPosition() {
-      ::grpc::Service::MarkMethodCallback(51,
+      ::grpc::Service::MarkMethodCallback(59,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetPositionRequest* request, ::mavsdk::rpc::camera_server::SetPositionResponse* response) { return this->SetPosition(context, request, response); }));}
     void SetMessageAllocatorFor_SetPosition(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(51);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(59);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -4045,13 +4633,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodCallback(52,
+      ::grpc::Service::MarkMethodCallback(60,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest* request, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse* response) { return this->SetAttitudeQuaternion(context, request, response); }));}
     void SetMessageAllocatorFor_SetAttitudeQuaternion(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(52);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(60);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -4072,13 +4660,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodCallback(53,
+      ::grpc::Service::MarkMethodCallback(61,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetZoomFactorRequest* request, ::mavsdk::rpc::camera_server::SetZoomFactorResponse* response) { return this->SetZoomFactor(context, request, response); }));}
     void SetMessageAllocatorFor_SetZoomFactor(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(53);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(61);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -4099,13 +4687,13 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithCallbackMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodCallback(54,
+      ::grpc::Service::MarkMethodCallback(62,
           new ::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* request, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* response) { return this->SetFieldOfView(context, request, response); }));}
     void SetMessageAllocatorFor_SetFieldOfView(
         ::grpc::MessageAllocator< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* allocator) {
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(54);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(62);
       static_cast<::grpc::internal::CallbackUnaryHandler< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>*>(handler)
               ->SetMessageAllocator(allocator);
     }
@@ -4120,7 +4708,7 @@ class CameraServerService final {
     virtual ::grpc::ServerUnaryReactor* SetFieldOfView(
       ::grpc::CallbackServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SetFieldOfViewRequest* /*request*/, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse* /*response*/)  { return nullptr; }
   };
-  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SubscribeFocusInStep<WithCallbackMethod_RespondFocusInStep<WithCallbackMethod_SubscribeFocusOutStep<WithCallbackMethod_RespondFocusOutStep<WithCallbackMethod_SubscribeFocusInStart<WithCallbackMethod_RespondFocusInStart<WithCallbackMethod_SubscribeFocusOutStart<WithCallbackMethod_RespondFocusOutStart<WithCallbackMethod_SubscribeFocusStop<WithCallbackMethod_RespondFocusStop<WithCallbackMethod_SubscribeFocusRange<WithCallbackMethod_RespondFocusRange<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<WithCallbackMethod_SetZoomFactor<WithCallbackMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef WithCallbackMethod_SetInformation<WithCallbackMethod_SetVideoStreaming<WithCallbackMethod_SetInProgress<WithCallbackMethod_SubscribeTakePhoto<WithCallbackMethod_RespondTakePhoto<WithCallbackMethod_SubscribeStartVideo<WithCallbackMethod_RespondStartVideo<WithCallbackMethod_SubscribeStopVideo<WithCallbackMethod_RespondStopVideo<WithCallbackMethod_SubscribeStartVideoStreaming<WithCallbackMethod_RespondStartVideoStreaming<WithCallbackMethod_SubscribeStopVideoStreaming<WithCallbackMethod_RespondStopVideoStreaming<WithCallbackMethod_SubscribeSetMode<WithCallbackMethod_RespondSetMode<WithCallbackMethod_SubscribeStorageInformation<WithCallbackMethod_RespondStorageInformation<WithCallbackMethod_SubscribeCaptureStatus<WithCallbackMethod_RespondCaptureStatus<WithCallbackMethod_SubscribeFormatStorage<WithCallbackMethod_RespondFormatStorage<WithCallbackMethod_SubscribeResetSettings<WithCallbackMethod_RespondResetSettings<WithCallbackMethod_SubscribeZoomInStart<WithCallbackMethod_RespondZoomInStart<WithCallbackMethod_SubscribeZoomOutStart<WithCallbackMethod_RespondZoomOutStart<WithCallbackMethod_SubscribeZoomStop<WithCallbackMethod_RespondZoomStop<WithCallbackMethod_SubscribeZoomRange<WithCallbackMethod_RespondZoomRange<WithCallbackMethod_SubscribeFocusInStep<WithCallbackMethod_RespondFocusInStep<WithCallbackMethod_SubscribeFocusOutStep<WithCallbackMethod_RespondFocusOutStep<WithCallbackMethod_SubscribeFocusInStart<WithCallbackMethod_RespondFocusInStart<WithCallbackMethod_SubscribeFocusOutStart<WithCallbackMethod_RespondFocusOutStart<WithCallbackMethod_SubscribeFocusStop<WithCallbackMethod_RespondFocusStop<WithCallbackMethod_SubscribeFocusRange<WithCallbackMethod_RespondFocusRange<WithCallbackMethod_SubscribeFocusMeters<WithCallbackMethod_RespondFocusMeters<WithCallbackMethod_SubscribeFocusAuto<WithCallbackMethod_RespondFocusAuto<WithCallbackMethod_SubscribeFocusAutoSingle<WithCallbackMethod_RespondFocusAutoSingle<WithCallbackMethod_SubscribeFocusAutoContinuous<WithCallbackMethod_RespondFocusAutoContinuous<WithCallbackMethod_SetTrackingRectangleStatus<WithCallbackMethod_SetTrackingOffStatus<WithCallbackMethod_SubscribeTrackingPointCommand<WithCallbackMethod_SubscribeTrackingRectangleCommand<WithCallbackMethod_SubscribeTrackingOffCommand<WithCallbackMethod_RespondTrackingPointCommand<WithCallbackMethod_RespondTrackingRectangleCommand<WithCallbackMethod_RespondTrackingOffCommand<WithCallbackMethod_SetPosition<WithCallbackMethod_SetAttitudeQuaternion<WithCallbackMethod_SetZoomFactor<WithCallbackMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   typedef CallbackService ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SetInformation : public BaseClass {
@@ -4854,12 +5442,148 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodGeneric(43);
+    }
+    ~WithGenericMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodGeneric(44);
+    }
+    ~WithGenericMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodGeneric(45);
+    }
+    ~WithGenericMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodGeneric(46);
+    }
+    ~WithGenericMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodGeneric(47);
+    }
+    ~WithGenericMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodGeneric(48);
+    }
+    ~WithGenericMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodGeneric(49);
+    }
+    ~WithGenericMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodGeneric(50);
+    }
+    ~WithGenericMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodGeneric(43);
+      ::grpc::Service::MarkMethodGeneric(51);
     }
     ~WithGenericMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4876,7 +5600,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodGeneric(44);
+      ::grpc::Service::MarkMethodGeneric(52);
     }
     ~WithGenericMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4893,7 +5617,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodGeneric(45);
+      ::grpc::Service::MarkMethodGeneric(53);
     }
     ~WithGenericMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4910,7 +5634,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodGeneric(46);
+      ::grpc::Service::MarkMethodGeneric(54);
     }
     ~WithGenericMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4927,7 +5651,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodGeneric(47);
+      ::grpc::Service::MarkMethodGeneric(55);
     }
     ~WithGenericMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4944,7 +5668,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodGeneric(48);
+      ::grpc::Service::MarkMethodGeneric(56);
     }
     ~WithGenericMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4961,7 +5685,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodGeneric(49);
+      ::grpc::Service::MarkMethodGeneric(57);
     }
     ~WithGenericMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4978,7 +5702,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodGeneric(50);
+      ::grpc::Service::MarkMethodGeneric(58);
     }
     ~WithGenericMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4995,7 +5719,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetPosition() {
-      ::grpc::Service::MarkMethodGeneric(51);
+      ::grpc::Service::MarkMethodGeneric(59);
     }
     ~WithGenericMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5012,7 +5736,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodGeneric(52);
+      ::grpc::Service::MarkMethodGeneric(60);
     }
     ~WithGenericMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5029,7 +5753,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodGeneric(53);
+      ::grpc::Service::MarkMethodGeneric(61);
     }
     ~WithGenericMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5046,7 +5770,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodGeneric(54);
+      ::grpc::Service::MarkMethodGeneric(62);
     }
     ~WithGenericMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5918,12 +6642,172 @@ class CameraServerService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodRaw(43);
+    }
+    ~WithRawMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusMeters(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(43, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodRaw(44);
+    }
+    ~WithRawMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusMeters(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodRaw(45);
+    }
+    ~WithRawMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAuto(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodRaw(46);
+    }
+    ~WithRawMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAuto(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(46, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodRaw(47);
+    }
+    ~WithRawMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodRaw(48);
+    }
+    ~WithRawMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRaw(49);
+    }
+    ~WithRawMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSubscribeFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(49, context, request, writer, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRaw(50);
+    }
+    ~WithRawMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRespondFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodRaw(43);
+      ::grpc::Service::MarkMethodRaw(51);
     }
     ~WithRawMethod_SetTrackingRectangleStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5934,7 +6818,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingRectangleStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(43, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5943,7 +6827,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodRaw(44);
+      ::grpc::Service::MarkMethodRaw(52);
     }
     ~WithRawMethod_SetTrackingOffStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5954,7 +6838,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetTrackingOffStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(44, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5963,7 +6847,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRaw(45);
+      ::grpc::Service::MarkMethodRaw(53);
     }
     ~WithRawMethod_SubscribeTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5974,7 +6858,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingPointCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(45, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(53, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5983,7 +6867,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRaw(46);
+      ::grpc::Service::MarkMethodRaw(54);
     }
     ~WithRawMethod_SubscribeTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5994,7 +6878,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingRectangleCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(46, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(54, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6003,7 +6887,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRaw(47);
+      ::grpc::Service::MarkMethodRaw(55);
     }
     ~WithRawMethod_SubscribeTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6014,7 +6898,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncServerStreaming(47, context, request, writer, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncServerStreaming(55, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6023,7 +6907,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRaw(48);
+      ::grpc::Service::MarkMethodRaw(56);
     }
     ~WithRawMethod_RespondTrackingPointCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6034,7 +6918,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingPointCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(48, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(56, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6043,7 +6927,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRaw(49);
+      ::grpc::Service::MarkMethodRaw(57);
     }
     ~WithRawMethod_RespondTrackingRectangleCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6054,7 +6938,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingRectangleCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(49, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(57, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6063,7 +6947,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRaw(50);
+      ::grpc::Service::MarkMethodRaw(58);
     }
     ~WithRawMethod_RespondTrackingOffCommand() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6074,7 +6958,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRespondTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(50, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(58, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6083,7 +6967,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetPosition() {
-      ::grpc::Service::MarkMethodRaw(51);
+      ::grpc::Service::MarkMethodRaw(59);
     }
     ~WithRawMethod_SetPosition() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6094,7 +6978,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetPosition(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(51, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(59, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6103,7 +6987,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodRaw(52);
+      ::grpc::Service::MarkMethodRaw(60);
     }
     ~WithRawMethod_SetAttitudeQuaternion() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6114,7 +6998,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetAttitudeQuaternion(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(52, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(60, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6123,7 +7007,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodRaw(53);
+      ::grpc::Service::MarkMethodRaw(61);
     }
     ~WithRawMethod_SetZoomFactor() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6134,7 +7018,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetZoomFactor(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(53, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(61, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -6143,7 +7027,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodRaw(54);
+      ::grpc::Service::MarkMethodRaw(62);
     }
     ~WithRawMethod_SetFieldOfView() override {
       BaseClassMustBeDerivedFromService(this);
@@ -6154,7 +7038,7 @@ class CameraServerService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetFieldOfView(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(54, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(62, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -7104,12 +7988,188 @@ class CameraServerService final {
       ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
   };
   template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodRawCallback(43,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusMeters(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodRawCallback(44,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusMeters(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusMeters(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodRawCallback(45,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusAuto(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodRawCallback(46,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusAuto(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAuto(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodRawCallback(47,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusAutoSingle(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodRawCallback(48,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusAutoSingle(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAutoSingle(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRawCallback(49,
+          new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeFocusAutoContinuous(context, request); }));
+    }
+    ~WithRawCallbackMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerWriteReactor< ::grpc::ByteBuffer>* SubscribeFocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/)  { return nullptr; }
+  };
+  template <class BaseClass>
+  class WithRawCallbackMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawCallbackMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodRawCallback(50,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+                   ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondFocusAutoContinuous(context, request, response); }));
+    }
+    ~WithRawCallbackMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    virtual ::grpc::ServerUnaryReactor* RespondFocusAutoContinuous(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)  { return nullptr; }
+  };
+  template <class BaseClass>
   class WithRawCallbackMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodRawCallback(43,
+      ::grpc::Service::MarkMethodRawCallback(51,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTrackingRectangleStatus(context, request, response); }));
@@ -7131,7 +8191,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodRawCallback(44,
+      ::grpc::Service::MarkMethodRawCallback(52,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTrackingOffStatus(context, request, response); }));
@@ -7153,7 +8213,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRawCallback(45,
+      ::grpc::Service::MarkMethodRawCallback(53,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingPointCommand(context, request); }));
@@ -7175,7 +8235,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRawCallback(46,
+      ::grpc::Service::MarkMethodRawCallback(54,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingRectangleCommand(context, request); }));
@@ -7197,7 +8257,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRawCallback(47,
+      ::grpc::Service::MarkMethodRawCallback(55,
           new ::grpc::internal::CallbackServerStreamingHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const::grpc::ByteBuffer* request) { return this->SubscribeTrackingOffCommand(context, request); }));
@@ -7219,7 +8279,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodRawCallback(48,
+      ::grpc::Service::MarkMethodRawCallback(56,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingPointCommand(context, request, response); }));
@@ -7241,7 +8301,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodRawCallback(49,
+      ::grpc::Service::MarkMethodRawCallback(57,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingRectangleCommand(context, request, response); }));
@@ -7263,7 +8323,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodRawCallback(50,
+      ::grpc::Service::MarkMethodRawCallback(58,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->RespondTrackingOffCommand(context, request, response); }));
@@ -7285,7 +8345,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetPosition() {
-      ::grpc::Service::MarkMethodRawCallback(51,
+      ::grpc::Service::MarkMethodRawCallback(59,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetPosition(context, request, response); }));
@@ -7307,7 +8367,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodRawCallback(52,
+      ::grpc::Service::MarkMethodRawCallback(60,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetAttitudeQuaternion(context, request, response); }));
@@ -7329,7 +8389,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodRawCallback(53,
+      ::grpc::Service::MarkMethodRawCallback(61,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetZoomFactor(context, request, response); }));
@@ -7351,7 +8411,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawCallbackMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodRawCallback(54,
+      ::grpc::Service::MarkMethodRawCallback(62,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
                    ::grpc::CallbackServerContext* context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetFieldOfView(context, request, response); }));
@@ -7989,12 +9049,120 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedRespondFocusRange(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusRangeRequest,::mavsdk::rpc::camera_server::RespondFocusRangeResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusMeters() {
+      ::grpc::Service::MarkMethodStreamed(44,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusMetersRequest, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* streamer) {
+                       return this->StreamedRespondFocusMeters(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusMetersRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusMetersResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusMeters(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusMetersRequest,::mavsdk::rpc::camera_server::RespondFocusMetersResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusAuto() {
+      ::grpc::Service::MarkMethodStreamed(46,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusAutoRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* streamer) {
+                       return this->StreamedRespondFocusAuto(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusAuto(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusAutoRequest,::mavsdk::rpc::camera_server::RespondFocusAutoResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusAutoSingle() {
+      ::grpc::Service::MarkMethodStreamed(48,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* streamer) {
+                       return this->StreamedRespondFocusAutoSingle(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest,::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_RespondFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_RespondFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodStreamed(50,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* streamer) {
+                       return this->StreamedRespondFocusAutoContinuous(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_RespondFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status RespondFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest* /*request*/, ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRespondFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest,::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_SetTrackingRectangleStatus : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTrackingRectangleStatus() {
-      ::grpc::Service::MarkMethodStreamed(43,
+      ::grpc::Service::MarkMethodStreamed(51,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -8021,7 +9189,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetTrackingOffStatus() {
-      ::grpc::Service::MarkMethodStreamed(44,
+      ::grpc::Service::MarkMethodStreamed(52,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest, ::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse>(
             [this](::grpc::ServerContext* context,
@@ -8048,7 +9216,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingPointCommand() {
-      ::grpc::Service::MarkMethodStreamed(48,
+      ::grpc::Service::MarkMethodStreamed(56,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8075,7 +9243,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodStreamed(49,
+      ::grpc::Service::MarkMethodStreamed(57,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8102,7 +9270,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RespondTrackingOffCommand() {
-      ::grpc::Service::MarkMethodStreamed(50,
+      ::grpc::Service::MarkMethodStreamed(58,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8129,7 +9297,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetPosition() {
-      ::grpc::Service::MarkMethodStreamed(51,
+      ::grpc::Service::MarkMethodStreamed(59,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetPositionRequest, ::mavsdk::rpc::camera_server::SetPositionResponse>(
             [this](::grpc::ServerContext* context,
@@ -8156,7 +9324,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetAttitudeQuaternion() {
-      ::grpc::Service::MarkMethodStreamed(52,
+      ::grpc::Service::MarkMethodStreamed(60,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest, ::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse>(
             [this](::grpc::ServerContext* context,
@@ -8183,7 +9351,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetZoomFactor() {
-      ::grpc::Service::MarkMethodStreamed(53,
+      ::grpc::Service::MarkMethodStreamed(61,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetZoomFactorRequest, ::mavsdk::rpc::camera_server::SetZoomFactorResponse>(
             [this](::grpc::ServerContext* context,
@@ -8210,7 +9378,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetFieldOfView() {
-      ::grpc::Service::MarkMethodStreamed(54,
+      ::grpc::Service::MarkMethodStreamed(62,
         new ::grpc::internal::StreamedUnaryHandler<
           ::mavsdk::rpc::camera_server::SetFieldOfViewRequest, ::mavsdk::rpc::camera_server::SetFieldOfViewResponse>(
             [this](::grpc::ServerContext* context,
@@ -8231,7 +9399,7 @@ class CameraServerService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetFieldOfView(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::mavsdk::rpc::camera_server::SetFieldOfViewRequest,::mavsdk::rpc::camera_server::SetFieldOfViewResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_RespondFocusInStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithStreamedUnaryMethod_RespondFocusInStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithStreamedUnaryMethod_RespondFocusStop<WithStreamedUnaryMethod_RespondFocusRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithStreamedUnaryMethod_RespondTakePhoto<WithStreamedUnaryMethod_RespondStartVideo<WithStreamedUnaryMethod_RespondStopVideo<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithStreamedUnaryMethod_RespondSetMode<WithStreamedUnaryMethod_RespondStorageInformation<WithStreamedUnaryMethod_RespondCaptureStatus<WithStreamedUnaryMethod_RespondFormatStorage<WithStreamedUnaryMethod_RespondResetSettings<WithStreamedUnaryMethod_RespondZoomInStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithStreamedUnaryMethod_RespondZoomStop<WithStreamedUnaryMethod_RespondZoomRange<WithStreamedUnaryMethod_RespondFocusInStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithStreamedUnaryMethod_RespondFocusInStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithStreamedUnaryMethod_RespondFocusStop<WithStreamedUnaryMethod_RespondFocusRange<WithStreamedUnaryMethod_RespondFocusMeters<WithStreamedUnaryMethod_RespondFocusAuto<WithStreamedUnaryMethod_RespondFocusAutoSingle<WithStreamedUnaryMethod_RespondFocusAutoContinuous<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTakePhoto : public BaseClass {
    private:
@@ -8773,12 +9941,120 @@ class CameraServerService final {
     virtual ::grpc::Status StreamedSubscribeFocusRange(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest,::mavsdk::rpc::camera_server::FocusRangeResponse>* server_split_streamer) = 0;
   };
   template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusMeters : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusMeters() {
+      ::grpc::Service::MarkMethodStreamed(43,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest, ::mavsdk::rpc::camera_server::FocusMetersResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest, ::mavsdk::rpc::camera_server::FocusMetersResponse>* streamer) {
+                       return this->StreamedSubscribeFocusMeters(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusMeters() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusMeters(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusMetersResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusMeters(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest,::mavsdk::rpc::camera_server::FocusMetersResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusAuto : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusAuto() {
+      ::grpc::Service::MarkMethodStreamed(45,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest, ::mavsdk::rpc::camera_server::FocusAutoResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest, ::mavsdk::rpc::camera_server::FocusAutoResponse>* streamer) {
+                       return this->StreamedSubscribeFocusAuto(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusAuto() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusAuto(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusAuto(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest,::mavsdk::rpc::camera_server::FocusAutoResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusAutoSingle : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusAutoSingle() {
+      ::grpc::Service::MarkMethodStreamed(47,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest, ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* streamer) {
+                       return this->StreamedSubscribeFocusAutoSingle(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusAutoSingle() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusAutoSingle(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusAutoSingle(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest,::mavsdk::rpc::camera_server::FocusAutoSingleResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithSplitStreamingMethod_SubscribeFocusAutoContinuous : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithSplitStreamingMethod_SubscribeFocusAutoContinuous() {
+      ::grpc::Service::MarkMethodStreamed(49,
+        new ::grpc::internal::SplitServerStreamingHandler<
+          ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerSplitStreamer<
+                     ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest, ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* streamer) {
+                       return this->StreamedSubscribeFocusAutoContinuous(context,
+                         streamer);
+                  }));
+    }
+    ~WithSplitStreamingMethod_SubscribeFocusAutoContinuous() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SubscribeFocusAutoContinuous(::grpc::ServerContext* /*context*/, const ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /*request*/, ::grpc::ServerWriter< ::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* /*writer*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedSubscribeFocusAutoContinuous(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest,::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>* server_split_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithSplitStreamingMethod_SubscribeTrackingPointCommand : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingPointCommand() {
-      ::grpc::Service::MarkMethodStreamed(45,
+      ::grpc::Service::MarkMethodStreamed(53,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest, ::mavsdk::rpc::camera_server::TrackingPointCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8805,7 +10081,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingRectangleCommand() {
-      ::grpc::Service::MarkMethodStreamed(46,
+      ::grpc::Service::MarkMethodStreamed(54,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest, ::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8832,7 +10108,7 @@ class CameraServerService final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithSplitStreamingMethod_SubscribeTrackingOffCommand() {
-      ::grpc::Service::MarkMethodStreamed(47,
+      ::grpc::Service::MarkMethodStreamed(55,
         new ::grpc::internal::SplitServerStreamingHandler<
           ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest, ::mavsdk::rpc::camera_server::TrackingOffCommandResponse>(
             [this](::grpc::ServerContext* context,
@@ -8853,8 +10129,8 @@ class CameraServerService final {
     // replace default version of method with split streamed
     virtual ::grpc::Status StreamedSubscribeTrackingOffCommand(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest,::mavsdk::rpc::camera_server::TrackingOffCommandResponse>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithStreamedUnaryMethod_RespondFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithStreamedUnaryMethod_RespondFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithStreamedUnaryMethod_RespondFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithStreamedUnaryMethod_RespondFocusRange<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithSplitStreamingMethod_SubscribeTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithSplitStreamingMethod_SubscribeFocusMeters<WithSplitStreamingMethod_SubscribeFocusAuto<WithSplitStreamingMethod_SubscribeFocusAutoSingle<WithSplitStreamingMethod_SubscribeFocusAutoContinuous<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > SplitStreamedService;
+  typedef WithStreamedUnaryMethod_SetInformation<WithStreamedUnaryMethod_SetVideoStreaming<WithStreamedUnaryMethod_SetInProgress<WithSplitStreamingMethod_SubscribeTakePhoto<WithStreamedUnaryMethod_RespondTakePhoto<WithSplitStreamingMethod_SubscribeStartVideo<WithStreamedUnaryMethod_RespondStartVideo<WithSplitStreamingMethod_SubscribeStopVideo<WithStreamedUnaryMethod_RespondStopVideo<WithSplitStreamingMethod_SubscribeStartVideoStreaming<WithStreamedUnaryMethod_RespondStartVideoStreaming<WithSplitStreamingMethod_SubscribeStopVideoStreaming<WithStreamedUnaryMethod_RespondStopVideoStreaming<WithSplitStreamingMethod_SubscribeSetMode<WithStreamedUnaryMethod_RespondSetMode<WithSplitStreamingMethod_SubscribeStorageInformation<WithStreamedUnaryMethod_RespondStorageInformation<WithSplitStreamingMethod_SubscribeCaptureStatus<WithStreamedUnaryMethod_RespondCaptureStatus<WithSplitStreamingMethod_SubscribeFormatStorage<WithStreamedUnaryMethod_RespondFormatStorage<WithSplitStreamingMethod_SubscribeResetSettings<WithStreamedUnaryMethod_RespondResetSettings<WithSplitStreamingMethod_SubscribeZoomInStart<WithStreamedUnaryMethod_RespondZoomInStart<WithSplitStreamingMethod_SubscribeZoomOutStart<WithStreamedUnaryMethod_RespondZoomOutStart<WithSplitStreamingMethod_SubscribeZoomStop<WithStreamedUnaryMethod_RespondZoomStop<WithSplitStreamingMethod_SubscribeZoomRange<WithStreamedUnaryMethod_RespondZoomRange<WithSplitStreamingMethod_SubscribeFocusInStep<WithStreamedUnaryMethod_RespondFocusInStep<WithSplitStreamingMethod_SubscribeFocusOutStep<WithStreamedUnaryMethod_RespondFocusOutStep<WithSplitStreamingMethod_SubscribeFocusInStart<WithStreamedUnaryMethod_RespondFocusInStart<WithSplitStreamingMethod_SubscribeFocusOutStart<WithStreamedUnaryMethod_RespondFocusOutStart<WithSplitStreamingMethod_SubscribeFocusStop<WithStreamedUnaryMethod_RespondFocusStop<WithSplitStreamingMethod_SubscribeFocusRange<WithStreamedUnaryMethod_RespondFocusRange<WithSplitStreamingMethod_SubscribeFocusMeters<WithStreamedUnaryMethod_RespondFocusMeters<WithSplitStreamingMethod_SubscribeFocusAuto<WithStreamedUnaryMethod_RespondFocusAuto<WithSplitStreamingMethod_SubscribeFocusAutoSingle<WithStreamedUnaryMethod_RespondFocusAutoSingle<WithSplitStreamingMethod_SubscribeFocusAutoContinuous<WithStreamedUnaryMethod_RespondFocusAutoContinuous<WithStreamedUnaryMethod_SetTrackingRectangleStatus<WithStreamedUnaryMethod_SetTrackingOffStatus<WithSplitStreamingMethod_SubscribeTrackingPointCommand<WithSplitStreamingMethod_SubscribeTrackingRectangleCommand<WithSplitStreamingMethod_SubscribeTrackingOffCommand<WithStreamedUnaryMethod_RespondTrackingPointCommand<WithStreamedUnaryMethod_RespondTrackingRectangleCommand<WithStreamedUnaryMethod_RespondTrackingOffCommand<WithStreamedUnaryMethod_SetPosition<WithStreamedUnaryMethod_SetAttitudeQuaternion<WithStreamedUnaryMethod_SetZoomFactor<WithStreamedUnaryMethod_SetFieldOfView<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace camera_server

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
@@ -549,6 +549,114 @@ struct SubscribeFormatStorageRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFormatStorageRequestDefaultTypeInternal _SubscribeFormatStorageRequest_default_instance_;
               template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusStopRequest::SubscribeFocusStopRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusStopRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusStopRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusStopRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusStopRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusStopRequestDefaultTypeInternal _SubscribeFocusStopRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusRangeRequest::SubscribeFocusRangeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusRangeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusRangeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusRangeRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusRangeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusRangeRequestDefaultTypeInternal _SubscribeFocusRangeRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusOutStepRequest::SubscribeFocusOutStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusOutStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusOutStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusOutStepRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusOutStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusOutStepRequestDefaultTypeInternal _SubscribeFocusOutStepRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusOutStartRequest::SubscribeFocusOutStartRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusOutStartRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusOutStartRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusOutStartRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusOutStartRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusOutStartRequestDefaultTypeInternal _SubscribeFocusOutStartRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusInStepRequest::SubscribeFocusInStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusInStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusInStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusInStepRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusInStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusInStepRequestDefaultTypeInternal _SubscribeFocusInStepRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusInStartRequest::SubscribeFocusInStartRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusInStartRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusInStartRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusInStartRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusInStartRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusInStartRequestDefaultTypeInternal _SubscribeFocusInStartRequest_default_instance_;
+              template <typename>
 PROTOBUF_CONSTEXPR SubscribeCaptureStatusRequest::SubscribeCaptureStatusRequest(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
@@ -1247,6 +1355,156 @@ struct RespondFormatStorageRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFormatStorageRequestDefaultTypeInternal _RespondFormatStorageRequest_default_instance_;
 
+inline constexpr RespondFocusStopRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_stop_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusStopRequest::RespondFocusStopRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusStopRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusStopRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusStopRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusStopRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusStopRequestDefaultTypeInternal _RespondFocusStopRequest_default_instance_;
+
+inline constexpr RespondFocusRangeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_range_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusRangeRequest::RespondFocusRangeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusRangeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusRangeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusRangeRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusRangeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusRangeRequestDefaultTypeInternal _RespondFocusRangeRequest_default_instance_;
+
+inline constexpr RespondFocusOutStepRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_out_step_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusOutStepRequest::RespondFocusOutStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusOutStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusOutStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusOutStepRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusOutStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStepRequestDefaultTypeInternal _RespondFocusOutStepRequest_default_instance_;
+
+inline constexpr RespondFocusOutStartRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_out_start_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusOutStartRequest::RespondFocusOutStartRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusOutStartRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusOutStartRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusOutStartRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusOutStartRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStartRequestDefaultTypeInternal _RespondFocusOutStartRequest_default_instance_;
+
+inline constexpr RespondFocusInStepRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_in_step_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusInStepRequest::RespondFocusInStepRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusInStepRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusInStepRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusInStepRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusInStepRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStepRequestDefaultTypeInternal _RespondFocusInStepRequest_default_instance_;
+
+inline constexpr RespondFocusInStartRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_in_start_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusInStartRequest::RespondFocusInStartRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusInStartRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusInStartRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusInStartRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusInStartRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStartRequestDefaultTypeInternal _RespondFocusInStartRequest_default_instance_;
+
 inline constexpr ResetSettingsResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : reserved_{0},
@@ -1397,6 +1655,156 @@ struct FormatStorageResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FormatStorageResponseDefaultTypeInternal _FormatStorageResponse_default_instance_;
+
+inline constexpr FocusStopResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusStopResponse::FocusStopResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusStopResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusStopResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusStopResponseDefaultTypeInternal() {}
+  union {
+    FocusStopResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusStopResponseDefaultTypeInternal _FocusStopResponse_default_instance_;
+
+inline constexpr FocusRangeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_distance_m_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusRangeResponse::FocusRangeResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusRangeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusRangeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusRangeResponseDefaultTypeInternal() {}
+  union {
+    FocusRangeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusRangeResponseDefaultTypeInternal _FocusRangeResponse_default_instance_;
+
+inline constexpr FocusOutStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusOutStepResponse::FocusOutStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusOutStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusOutStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusOutStepResponseDefaultTypeInternal() {}
+  union {
+    FocusOutStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStepResponseDefaultTypeInternal _FocusOutStepResponse_default_instance_;
+
+inline constexpr FocusOutStartResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusOutStartResponse::FocusOutStartResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusOutStartResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusOutStartResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusOutStartResponseDefaultTypeInternal() {}
+  union {
+    FocusOutStartResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
+
+inline constexpr FocusInStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusInStepResponse::FocusInStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusInStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusInStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusInStepResponseDefaultTypeInternal() {}
+  union {
+    FocusInStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
+
+inline constexpr FocusInStartResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusInStartResponse::FocusInStartResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusInStartResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusInStartResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusInStartResponseDefaultTypeInternal() {}
+  union {
+    FocusInStartResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
 
 inline constexpr CaptureStatusResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -2282,6 +2690,156 @@ struct RespondFormatStorageResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFormatStorageResponseDefaultTypeInternal _RespondFormatStorageResponse_default_instance_;
 
+inline constexpr RespondFocusStopResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusStopResponse::RespondFocusStopResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusStopResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusStopResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusStopResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusStopResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusStopResponseDefaultTypeInternal _RespondFocusStopResponse_default_instance_;
+
+inline constexpr RespondFocusRangeResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusRangeResponse::RespondFocusRangeResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusRangeResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusRangeResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusRangeResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusRangeResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusRangeResponseDefaultTypeInternal _RespondFocusRangeResponse_default_instance_;
+
+inline constexpr RespondFocusOutStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusOutStepResponse::RespondFocusOutStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusOutStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusOutStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusOutStepResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusOutStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStepResponseDefaultTypeInternal _RespondFocusOutStepResponse_default_instance_;
+
+inline constexpr RespondFocusOutStartResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusOutStartResponse::RespondFocusOutStartResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusOutStartResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusOutStartResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusOutStartResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusOutStartResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStartResponseDefaultTypeInternal _RespondFocusOutStartResponse_default_instance_;
+
+inline constexpr RespondFocusInStepResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusInStepResponse::RespondFocusInStepResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusInStepResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusInStepResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusInStepResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusInStepResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStepResponseDefaultTypeInternal _RespondFocusInStepResponse_default_instance_;
+
+inline constexpr RespondFocusInStartResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusInStartResponse::RespondFocusInStartResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusInStartResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusInStartResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusInStartResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusInStartResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStartResponseDefaultTypeInternal _RespondFocusInStartResponse_default_instance_;
+
 inline constexpr RespondCaptureStatusResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -2972,6 +3530,222 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondZoomRangeResponse, _impl_.camera_server_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusInStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusInStepResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStepRequest, _impl_.focus_in_step_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStepResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStepResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusOutStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusOutStepResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStepRequest, _impl_.focus_out_step_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStepResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusInStartResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusInStartResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStartRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStartRequest, _impl_.focus_in_start_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStartResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStartResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusInStartResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusOutStartResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusOutStartResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStartRequest, _impl_.focus_out_start_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusOutStartResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusStopRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusStopResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusStopResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusStopRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusStopRequest, _impl_.focus_stop_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusStopResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusStopResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusStopResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusRangeResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusRangeResponse, _impl_.focus_distance_m_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeRequest, _impl_.focus_range_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::Information, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -3416,42 +4190,66 @@ static const ::_pbi::MigrationSchema
         {544, -1, -1, sizeof(::mavsdk::rpc::camera_server::ZoomRangeResponse)},
         {553, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondZoomRangeRequest)},
         {562, 571, -1, sizeof(::mavsdk::rpc::camera_server::RespondZoomRangeResponse)},
-        {572, -1, -1, sizeof(::mavsdk::rpc::camera_server::Information)},
-        {593, -1, -1, sizeof(::mavsdk::rpc::camera_server::VideoStreaming)},
-        {603, -1, -1, sizeof(::mavsdk::rpc::camera_server::Position)},
-        {615, -1, -1, sizeof(::mavsdk::rpc::camera_server::Quaternion)},
-        {627, 641, -1, sizeof(::mavsdk::rpc::camera_server::CaptureInfo)},
-        {647, -1, -1, sizeof(::mavsdk::rpc::camera_server::CameraServerResult)},
-        {657, -1, -1, sizeof(::mavsdk::rpc::camera_server::StorageInformation)},
-        {673, -1, -1, sizeof(::mavsdk::rpc::camera_server::CaptureStatus)},
-        {687, 696, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusRequest)},
-        {697, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusResponse)},
-        {705, 714, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest)},
-        {715, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse)},
-        {723, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest)},
-        {731, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse)},
-        {739, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest)},
-        {747, 756, -1, sizeof(::mavsdk::rpc::camera_server::TrackingPointCommandResponse)},
-        {757, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest)},
-        {765, 774, -1, sizeof(::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse)},
-        {775, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest)},
-        {783, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackingOffCommandResponse)},
-        {792, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest)},
-        {801, 810, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse)},
-        {811, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest)},
-        {820, 829, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
-        {830, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
-        {839, 848, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
-        {849, 858, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionRequest)},
-        {859, 868, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
-        {869, 878, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
-        {879, 888, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
-        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorRequest)},
-        {898, 907, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorResponse)},
-        {908, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewRequest)},
-        {918, 927, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewResponse)},
-        {928, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
-        {939, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
+        {572, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest)},
+        {580, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusInStepResponse)},
+        {589, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusInStepRequest)},
+        {598, 607, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusInStepResponse)},
+        {608, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest)},
+        {616, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusOutStepResponse)},
+        {625, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusOutStepRequest)},
+        {634, 643, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusOutStepResponse)},
+        {644, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest)},
+        {652, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusInStartResponse)},
+        {661, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusInStartRequest)},
+        {670, 679, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusInStartResponse)},
+        {680, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest)},
+        {688, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusOutStartResponse)},
+        {697, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusOutStartRequest)},
+        {706, 715, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusOutStartResponse)},
+        {716, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusStopRequest)},
+        {724, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusStopResponse)},
+        {733, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusStopRequest)},
+        {742, 751, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusStopResponse)},
+        {752, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest)},
+        {760, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusRangeResponse)},
+        {769, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusRangeRequest)},
+        {778, 787, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusRangeResponse)},
+        {788, -1, -1, sizeof(::mavsdk::rpc::camera_server::Information)},
+        {809, -1, -1, sizeof(::mavsdk::rpc::camera_server::VideoStreaming)},
+        {819, -1, -1, sizeof(::mavsdk::rpc::camera_server::Position)},
+        {831, -1, -1, sizeof(::mavsdk::rpc::camera_server::Quaternion)},
+        {843, 857, -1, sizeof(::mavsdk::rpc::camera_server::CaptureInfo)},
+        {863, -1, -1, sizeof(::mavsdk::rpc::camera_server::CameraServerResult)},
+        {873, -1, -1, sizeof(::mavsdk::rpc::camera_server::StorageInformation)},
+        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::CaptureStatus)},
+        {903, 912, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusRequest)},
+        {913, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusResponse)},
+        {921, 930, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest)},
+        {931, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse)},
+        {939, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest)},
+        {947, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse)},
+        {955, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest)},
+        {963, 972, -1, sizeof(::mavsdk::rpc::camera_server::TrackingPointCommandResponse)},
+        {973, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest)},
+        {981, 990, -1, sizeof(::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse)},
+        {991, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest)},
+        {999, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackingOffCommandResponse)},
+        {1008, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest)},
+        {1017, 1026, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse)},
+        {1027, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest)},
+        {1036, 1045, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
+        {1046, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
+        {1055, 1064, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
+        {1065, 1074, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionRequest)},
+        {1075, 1084, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
+        {1085, 1094, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
+        {1095, 1104, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
+        {1105, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorRequest)},
+        {1114, 1123, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorResponse)},
+        {1124, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewRequest)},
+        {1134, 1143, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewResponse)},
+        {1144, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
+        {1155, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_SetInformationRequest_default_instance_._instance,
@@ -3516,6 +4314,30 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_ZoomRangeResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondZoomRangeRequest_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondZoomRangeResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusInStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusInStepResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusInStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusInStepResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusOutStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusOutStepResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusOutStepRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusOutStepResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusInStartRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusInStartResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusInStartRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusInStartResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusOutStartRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusOutStartResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusOutStartRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusOutStartResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusStopRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusStopResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusStopRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusStopResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusRangeRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusRangeResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusRangeRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusRangeResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_Information_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_VideoStreaming_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_Position_default_instance_._instance,
@@ -3676,279 +4498,362 @@ const char descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto[]
     "mera_server.CameraFeedback\"f\n\030RespondZoo"
     "mRangeResponse\022J\n\024camera_server_result\030\001"
     " \001(\0132,.mavsdk.rpc.camera_server.CameraSe"
-    "rverResult\"\214\003\n\013Information\022\023\n\013vendor_nam"
-    "e\030\001 \001(\t\022\022\n\nmodel_name\030\002 \001(\t\022\030\n\020firmware_"
-    "version\030\003 \001(\t\022\027\n\017focal_length_mm\030\004 \001(\002\022!"
-    "\n\031horizontal_sensor_size_mm\030\005 \001(\002\022\037\n\027ver"
-    "tical_sensor_size_mm\030\006 \001(\002\022 \n\030horizontal"
-    "_resolution_px\030\007 \001(\r\022\036\n\026vertical_resolut"
-    "ion_px\030\010 \001(\r\022\017\n\007lens_id\030\t \001(\r\022\037\n\027definit"
-    "ion_file_version\030\n \001(\r\022\033\n\023definition_fil"
-    "e_uri\030\013 \001(\t\022%\n\035image_in_video_mode_suppo"
-    "rted\030\014 \001(\010\022%\n\035video_in_image_mode_suppor"
-    "ted\030\r \001(\010\";\n\016VideoStreaming\022\027\n\017has_rtsp_"
-    "server\030\001 \001(\010\022\020\n\010rtsp_uri\030\002 \001(\t\"q\n\010Positi"
-    "on\022\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitude_de"
-    "g\030\002 \001(\001\022\033\n\023absolute_altitude_m\030\003 \001(\002\022\033\n\023"
-    "relative_altitude_m\030\004 \001(\002\"8\n\nQuaternion\022"
-    "\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 "
-    "\001(\002\"\320\001\n\013CaptureInfo\0224\n\010position\030\001 \001(\0132\"."
-    "mavsdk.rpc.camera_server.Position\022A\n\023att"
-    "itude_quaternion\030\002 \001(\0132$.mavsdk.rpc.came"
-    "ra_server.Quaternion\022\023\n\013time_utc_us\030\003 \001("
-    "\004\022\022\n\nis_success\030\004 \001(\010\022\r\n\005index\030\005 \001(\005\022\020\n\010"
-    "file_url\030\006 \001(\t\"\263\002\n\022CameraServerResult\022C\n"
-    "\006result\030\001 \001(\01623.mavsdk.rpc.camera_server"
-    ".CameraServerResult.Result\022\022\n\nresult_str"
-    "\030\002 \001(\t\"\303\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n"
-    "\016RESULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PROGRESS\020"
-    "\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rRESULT_DENIED\020\004\022\020\n"
-    "\014RESULT_ERROR\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\031\n\025R"
-    "ESULT_WRONG_ARGUMENT\020\007\022\024\n\020RESULT_NO_SYST"
-    "EM\020\010\"\214\005\n\022StorageInformation\022\030\n\020used_stor"
-    "age_mib\030\001 \001(\002\022\035\n\025available_storage_mib\030\002"
-    " \001(\002\022\031\n\021total_storage_mib\030\003 \001(\002\022R\n\016stora"
-    "ge_status\030\004 \001(\0162:.mavsdk.rpc.camera_serv"
-    "er.StorageInformation.StorageStatus\022\022\n\ns"
-    "torage_id\030\005 \001(\r\022N\n\014storage_type\030\006 \001(\01628."
-    "mavsdk.rpc.camera_server.StorageInformat"
-    "ion.StorageType\022\030\n\020read_speed_mib_s\030\007 \001("
-    "\002\022\031\n\021write_speed_mib_s\030\010 \001(\002\"\221\001\n\rStorage"
-    "Status\022 \n\034STORAGE_STATUS_NOT_AVAILABLE\020\000"
-    "\022\036\n\032STORAGE_STATUS_UNFORMATTED\020\001\022\034\n\030STOR"
-    "AGE_STATUS_FORMATTED\020\002\022 \n\034STORAGE_STATUS"
-    "_NOT_SUPPORTED\020\003\"\240\001\n\013StorageType\022\030\n\024STOR"
-    "AGE_TYPE_UNKNOWN\020\000\022\032\n\026STORAGE_TYPE_USB_S"
-    "TICK\020\001\022\023\n\017STORAGE_TYPE_SD\020\002\022\030\n\024STORAGE_T"
-    "YPE_MICROSD\020\003\022\023\n\017STORAGE_TYPE_HD\020\007\022\027\n\022ST"
-    "ORAGE_TYPE_OTHER\020\376\001\"\356\003\n\rCaptureStatus\022\030\n"
-    "\020image_interval_s\030\001 \001(\002\022\030\n\020recording_tim"
-    "e_s\030\002 \001(\002\022\036\n\026available_capacity_mib\030\003 \001("
-    "\002\022I\n\014image_status\030\004 \001(\01623.mavsdk.rpc.cam"
-    "era_server.CaptureStatus.ImageStatus\022I\n\014"
-    "video_status\030\005 \001(\01623.mavsdk.rpc.camera_s"
-    "erver.CaptureStatus.VideoStatus\022\023\n\013image"
-    "_count\030\006 \001(\005\"\221\001\n\013ImageStatus\022\025\n\021IMAGE_ST"
-    "ATUS_IDLE\020\000\022$\n IMAGE_STATUS_CAPTURE_IN_P"
-    "ROGRESS\020\001\022\036\n\032IMAGE_STATUS_INTERVAL_IDLE\020"
-    "\002\022%\n!IMAGE_STATUS_INTERVAL_IN_PROGRESS\020\003"
-    "\"J\n\013VideoStatus\022\025\n\021VIDEO_STATUS_IDLE\020\000\022$"
-    "\n VIDEO_STATUS_CAPTURE_IN_PROGRESS\020\001\"\\\n\035"
-    "SetTrackingPointStatusRequest\022;\n\rtracked"
-    "_point\030\001 \001(\0132$.mavsdk.rpc.camera_server."
-    "TrackPoint\" \n\036SetTrackingPointStatusResp"
-    "onse\"h\n!SetTrackingRectangleStatusReques"
-    "t\022C\n\021tracked_rectangle\030\001 \001(\0132(.mavsdk.rp"
-    "c.camera_server.TrackRectangle\"$\n\"SetTra"
-    "ckingRectangleStatusResponse\"\035\n\033SetTrack"
-    "ingOffStatusRequest\"\036\n\034SetTrackingOffSta"
-    "tusResponse\"&\n$SubscribeTrackingPointCom"
-    "mandRequest\"Y\n\034TrackingPointCommandRespo"
-    "nse\0229\n\013track_point\030\001 \001(\0132$.mavsdk.rpc.ca"
-    "mera_server.TrackPoint\"*\n(SubscribeTrack"
-    "ingRectangleCommandRequest\"e\n TrackingRe"
-    "ctangleCommandResponse\022A\n\017track_rectangl"
-    "e\030\001 \001(\0132(.mavsdk.rpc.camera_server.Track"
-    "Rectangle\"$\n\"SubscribeTrackingOffCommand"
-    "Request\"+\n\032TrackingOffCommandResponse\022\r\n"
-    "\005dummy\030\001 \001(\005\"k\n\"RespondTrackingPointComm"
-    "andRequest\022E\n\023stop_video_feedback\030\001 \001(\0162"
-    "(.mavsdk.rpc.camera_server.CameraFeedbac"
-    "k\"q\n#RespondTrackingPointCommandResponse"
-    "\022J\n\024camera_server_result\030\001 \001(\0132,.mavsdk."
-    "rpc.camera_server.CameraServerResult\"o\n&"
-    "RespondTrackingRectangleCommandRequest\022E"
-    "\n\023stop_video_feedback\030\001 \001(\0162(.mavsdk.rpc"
-    ".camera_server.CameraFeedback\"u\n\'Respond"
-    "TrackingRectangleCommandResponse\022J\n\024came"
-    "ra_server_result\030\001 \001(\0132,.mavsdk.rpc.came"
-    "ra_server.CameraServerResult\"i\n RespondT"
-    "rackingOffCommandRequest\022E\n\023stop_video_f"
-    "eedback\030\001 \001(\0162(.mavsdk.rpc.camera_server"
-    ".CameraFeedback\"o\n!RespondTrackingOffCom"
-    "mandResponse\022J\n\024camera_server_result\030\001 \001"
-    "(\0132,.mavsdk.rpc.camera_server.CameraServ"
-    "erResult\"J\n\022SetPositionRequest\0224\n\010positi"
-    "on\030\001 \001(\0132\".mavsdk.rpc.camera_server.Posi"
-    "tion\"a\n\023SetPositionResponse\022J\n\024camera_se"
-    "rver_result\030\001 \001(\0132,.mavsdk.rpc.camera_se"
-    "rver.CameraServerResult\"a\n\034SetAttitudeQu"
-    "aternionRequest\022A\n\023attitude_quaternion\030\001"
-    " \001(\0132$.mavsdk.rpc.camera_server.Quaterni"
-    "on\"k\n\035SetAttitudeQuaternionResponse\022J\n\024c"
-    "amera_server_result\030\001 \001(\0132,.mavsdk.rpc.c"
-    "amera_server.CameraServerResult\"+\n\024SetZo"
-    "omFactorRequest\022\023\n\013zoom_factor\030\001 \001(\002\"c\n\025"
-    "SetZoomFactorResponse\022J\n\024camera_server_r"
+    "rverResult\"\035\n\033SubscribeFocusInStepReques"
+    "t\"\'\n\023FocusInStepResponse\022\020\n\010reserved\030\001 \001"
+    "(\005\"e\n\031RespondFocusInStepRequest\022H\n\026focus"
+    "_in_step_feedback\030\001 \001(\0162(.mavsdk.rpc.cam"
+    "era_server.CameraFeedback\"h\n\032RespondFocu"
+    "sInStepResponse\022J\n\024camera_server_result\030"
+    "\001 \001(\0132,.mavsdk.rpc.camera_server.CameraS"
+    "erverResult\"\036\n\034SubscribeFocusOutStepRequ"
+    "est\"(\n\024FocusOutStepResponse\022\020\n\010reserved\030"
+    "\001 \001(\005\"g\n\032RespondFocusOutStepRequest\022I\n\027f"
+    "ocus_out_step_feedback\030\001 \001(\0162(.mavsdk.rp"
+    "c.camera_server.CameraFeedback\"i\n\033Respon"
+    "dFocusOutStepResponse\022J\n\024camera_server_r"
     "esult\030\001 \001(\0132,.mavsdk.rpc.camera_server.C"
-    "ameraServerResult\"M\n\025SetFieldOfViewReque"
-    "st\022\032\n\022horizontal_fov_deg\030\001 \001(\002\022\030\n\020vertic"
-    "al_fov_deg\030\002 \001(\002\"d\n\026SetFieldOfViewRespon"
-    "se\022J\n\024camera_server_result\030\001 \001(\0132,.mavsd"
-    "k.rpc.camera_server.CameraServerResult\">"
-    "\n\nTrackPoint\022\017\n\007point_x\030\001 \001(\002\022\017\n\007point_y"
-    "\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\"\204\001\n\016TrackRectangl"
-    "e\022\031\n\021top_left_corner_x\030\001 \001(\002\022\031\n\021top_left"
-    "_corner_y\030\002 \001(\002\022\035\n\025bottom_right_corner_x"
-    "\030\003 \001(\002\022\035\n\025bottom_right_corner_y\030\004 \001(\002*{\n"
-    "\016CameraFeedback\022\033\n\027CAMERA_FEEDBACK_UNKNO"
-    "WN\020\000\022\026\n\022CAMERA_FEEDBACK_OK\020\001\022\030\n\024CAMERA_F"
-    "EEDBACK_BUSY\020\002\022\032\n\026CAMERA_FEEDBACK_FAILED"
-    "\020\003*8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHO"
-    "TO\020\001\022\016\n\nMODE_VIDEO\020\0022\256/\n\023CameraServerSer"
-    "vice\022y\n\016SetInformation\022/.mavsdk.rpc.came"
-    "ra_server.SetInformationRequest\0320.mavsdk"
-    ".rpc.camera_server.SetInformationRespons"
-    "e\"\004\200\265\030\001\022\202\001\n\021SetVideoStreaming\0222.mavsdk.r"
-    "pc.camera_server.SetVideoStreamingReques"
-    "t\0323.mavsdk.rpc.camera_server.SetVideoStr"
-    "eamingResponse\"\004\200\265\030\001\022v\n\rSetInProgress\022.."
-    "mavsdk.rpc.camera_server.SetInProgressRe"
-    "quest\032/.mavsdk.rpc.camera_server.SetInPr"
-    "ogressResponse\"\004\200\265\030\001\022~\n\022SubscribeTakePho"
-    "to\0223.mavsdk.rpc.camera_server.SubscribeT"
-    "akePhotoRequest\032+.mavsdk.rpc.camera_serv"
-    "er.TakePhotoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondT"
-    "akePhoto\0221.mavsdk.rpc.camera_server.Resp"
-    "ondTakePhotoRequest\0322.mavsdk.rpc.camera_"
-    "server.RespondTakePhotoResponse\"\004\200\265\030\001\022\201\001"
-    "\n\023SubscribeStartVideo\0224.mavsdk.rpc.camer"
-    "a_server.SubscribeStartVideoRequest\032,.ma"
-    "vsdk.rpc.camera_server.StartVideoRespons"
-    "e\"\004\200\265\030\0000\001\022\202\001\n\021RespondStartVideo\0222.mavsdk"
-    ".rpc.camera_server.RespondStartVideoRequ"
-    "est\0323.mavsdk.rpc.camera_server.RespondSt"
-    "artVideoResponse\"\004\200\265\030\001\022~\n\022SubscribeStopV"
-    "ideo\0223.mavsdk.rpc.camera_server.Subscrib"
-    "eStopVideoRequest\032+.mavsdk.rpc.camera_se"
-    "rver.StopVideoResponse\"\004\200\265\030\0000\001\022\177\n\020Respon"
-    "dStopVideo\0221.mavsdk.rpc.camera_server.Re"
-    "spondStopVideoRequest\0322.mavsdk.rpc.camer"
-    "a_server.RespondStopVideoResponse\"\004\200\265\030\001\022"
-    "\234\001\n\034SubscribeStartVideoStreaming\022=.mavsd"
-    "k.rpc.camera_server.SubscribeStartVideoS"
-    "treamingRequest\0325.mavsdk.rpc.camera_serv"
-    "er.StartVideoStreamingResponse\"\004\200\265\030\0000\001\022\235"
-    "\001\n\032RespondStartVideoStreaming\022;.mavsdk.r"
-    "pc.camera_server.RespondStartVideoStream"
-    "ingRequest\032<.mavsdk.rpc.camera_server.Re"
-    "spondStartVideoStreamingResponse\"\004\200\265\030\001\022\231"
-    "\001\n\033SubscribeStopVideoStreaming\022<.mavsdk."
-    "rpc.camera_server.SubscribeStopVideoStre"
-    "amingRequest\0324.mavsdk.rpc.camera_server."
-    "StopVideoStreamingResponse\"\004\200\265\030\0000\001\022\232\001\n\031R"
-    "espondStopVideoStreaming\022:.mavsdk.rpc.ca"
-    "mera_server.RespondStopVideoStreamingReq"
-    "uest\032;.mavsdk.rpc.camera_server.RespondS"
-    "topVideoStreamingResponse\"\004\200\265\030\001\022x\n\020Subsc"
-    "ribeSetMode\0221.mavsdk.rpc.camera_server.S"
-    "ubscribeSetModeRequest\032).mavsdk.rpc.came"
-    "ra_server.SetModeResponse\"\004\200\265\030\0000\001\022y\n\016Res"
-    "pondSetMode\022/.mavsdk.rpc.camera_server.R"
-    "espondSetModeRequest\0320.mavsdk.rpc.camera"
-    "_server.RespondSetModeResponse\"\004\200\265\030\001\022\231\001\n"
-    "\033SubscribeStorageInformation\022<.mavsdk.rp"
-    "c.camera_server.SubscribeStorageInformat"
-    "ionRequest\0324.mavsdk.rpc.camera_server.St"
-    "orageInformationResponse\"\004\200\265\030\0000\001\022\232\001\n\031Res"
-    "pondStorageInformation\022:.mavsdk.rpc.came"
-    "ra_server.RespondStorageInformationReque"
-    "st\032;.mavsdk.rpc.camera_server.RespondSto"
-    "rageInformationResponse\"\004\200\265\030\001\022\212\001\n\026Subscr"
-    "ibeCaptureStatus\0227.mavsdk.rpc.camera_ser"
-    "ver.SubscribeCaptureStatusRequest\032/.mavs"
-    "dk.rpc.camera_server.CaptureStatusRespon"
-    "se\"\004\200\265\030\0000\001\022\213\001\n\024RespondCaptureStatus\0225.ma"
-    "vsdk.rpc.camera_server.RespondCaptureSta"
-    "tusRequest\0326.mavsdk.rpc.camera_server.Re"
-    "spondCaptureStatusResponse\"\004\200\265\030\001\022\212\001\n\026Sub"
-    "scribeFormatStorage\0227.mavsdk.rpc.camera_"
-    "server.SubscribeFormatStorageRequest\032/.m"
-    "avsdk.rpc.camera_server.FormatStorageRes"
-    "ponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondFormatStorage\0225"
-    ".mavsdk.rpc.camera_server.RespondFormatS"
-    "torageRequest\0326.mavsdk.rpc.camera_server"
-    ".RespondFormatStorageResponse\"\004\200\265\030\001\022\212\001\n\026"
-    "SubscribeResetSettings\0227.mavsdk.rpc.came"
-    "ra_server.SubscribeResetSettingsRequest\032"
-    "/.mavsdk.rpc.camera_server.ResetSettings"
-    "Response\"\004\200\265\030\0000\001\022\213\001\n\024RespondResetSetting"
-    "s\0225.mavsdk.rpc.camera_server.RespondRese"
-    "tSettingsRequest\0326.mavsdk.rpc.camera_ser"
-    "ver.RespondResetSettingsResponse\"\004\200\265\030\001\022\204"
-    "\001\n\024SubscribeZoomInStart\0225.mavsdk.rpc.cam"
-    "era_server.SubscribeZoomInStartRequest\032-"
-    ".mavsdk.rpc.camera_server.ZoomInStartRes"
-    "ponse\"\004\200\265\030\0000\001\022\205\001\n\022RespondZoomInStart\0223.m"
-    "avsdk.rpc.camera_server.RespondZoomInSta"
-    "rtRequest\0324.mavsdk.rpc.camera_server.Res"
-    "pondZoomInStartResponse\"\004\200\265\030\001\022\207\001\n\025Subscr"
-    "ibeZoomOutStart\0226.mavsdk.rpc.camera_serv"
-    "er.SubscribeZoomOutStartRequest\032..mavsdk"
-    ".rpc.camera_server.ZoomOutStartResponse\""
-    "\004\200\265\030\0000\001\022\210\001\n\023RespondZoomOutStart\0224.mavsdk"
-    ".rpc.camera_server.RespondZoomOutStartRe"
-    "quest\0325.mavsdk.rpc.camera_server.Respond"
-    "ZoomOutStartResponse\"\004\200\265\030\001\022{\n\021SubscribeZ"
-    "oomStop\0222.mavsdk.rpc.camera_server.Subsc"
-    "ribeZoomStopRequest\032*.mavsdk.rpc.camera_"
-    "server.ZoomStopResponse\"\004\200\265\030\0000\001\022|\n\017Respo"
-    "ndZoomStop\0220.mavsdk.rpc.camera_server.Re"
-    "spondZoomStopRequest\0321.mavsdk.rpc.camera"
-    "_server.RespondZoomStopResponse\"\004\200\265\030\001\022~\n"
-    "\022SubscribeZoomRange\0223.mavsdk.rpc.camera_"
-    "server.SubscribeZoomRangeRequest\032+.mavsd"
-    "k.rpc.camera_server.ZoomRangeResponse\"\004\200"
-    "\265\030\0000\001\022\177\n\020RespondZoomRange\0221.mavsdk.rpc.c"
-    "amera_server.RespondZoomRangeRequest\0322.m"
-    "avsdk.rpc.camera_server.RespondZoomRange"
-    "Response\"\004\200\265\030\001\022\235\001\n\032SetTrackingRectangleS"
-    "tatus\022;.mavsdk.rpc.camera_server.SetTrac"
-    "kingRectangleStatusRequest\032<.mavsdk.rpc."
-    "camera_server.SetTrackingRectangleStatus"
-    "Response\"\004\200\265\030\001\022\213\001\n\024SetTrackingOffStatus\022"
-    "5.mavsdk.rpc.camera_server.SetTrackingOf"
-    "fStatusRequest\0326.mavsdk.rpc.camera_serve"
-    "r.SetTrackingOffStatusResponse\"\004\200\265\030\001\022\237\001\n"
-    "\035SubscribeTrackingPointCommand\022>.mavsdk."
-    "rpc.camera_server.SubscribeTrackingPoint"
-    "CommandRequest\0326.mavsdk.rpc.camera_serve"
-    "r.TrackingPointCommandResponse\"\004\200\265\030\0000\001\022\253"
-    "\001\n!SubscribeTrackingRectangleCommand\022B.m"
-    "avsdk.rpc.camera_server.SubscribeTrackin"
-    "gRectangleCommandRequest\032:.mavsdk.rpc.ca"
-    "mera_server.TrackingRectangleCommandResp"
-    "onse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrackingOffCom"
-    "mand\022<.mavsdk.rpc.camera_server.Subscrib"
-    "eTrackingOffCommandRequest\0324.mavsdk.rpc."
-    "camera_server.TrackingOffCommandResponse"
-    "\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPointCommand"
-    "\022<.mavsdk.rpc.camera_server.RespondTrack"
-    "ingPointCommandRequest\032=.mavsdk.rpc.came"
-    "ra_server.RespondTrackingPointCommandRes"
-    "ponse\"\004\200\265\030\001\022\254\001\n\037RespondTrackingRectangle"
-    "Command\022@.mavsdk.rpc.camera_server.Respo"
-    "ndTrackingRectangleCommandRequest\032A.mavs"
-    "dk.rpc.camera_server.RespondTrackingRect"
-    "angleCommandResponse\"\004\200\265\030\001\022\232\001\n\031RespondTr"
-    "ackingOffCommand\022:.mavsdk.rpc.camera_ser"
-    "ver.RespondTrackingOffCommandRequest\032;.m"
-    "avsdk.rpc.camera_server.RespondTrackingO"
-    "ffCommandResponse\"\004\200\265\030\001\022p\n\013SetPosition\022,"
-    ".mavsdk.rpc.camera_server.SetPositionReq"
-    "uest\032-.mavsdk.rpc.camera_server.SetPosit"
-    "ionResponse\"\004\200\265\030\001\022\216\001\n\025SetAttitudeQuatern"
-    "ion\0226.mavsdk.rpc.camera_server.SetAttitu"
-    "deQuaternionRequest\0327.mavsdk.rpc.camera_"
-    "server.SetAttitudeQuaternionResponse\"\004\200\265"
-    "\030\001\022v\n\rSetZoomFactor\022..mavsdk.rpc.camera_"
-    "server.SetZoomFactorRequest\032/.mavsdk.rpc"
-    ".camera_server.SetZoomFactorResponse\"\004\200\265"
-    "\030\001\022y\n\016SetFieldOfView\022/.mavsdk.rpc.camera"
-    "_server.SetFieldOfViewRequest\0320.mavsdk.r"
-    "pc.camera_server.SetFieldOfViewResponse\""
-    "\004\200\265\030\001B,\n\027io.mavsdk.camera_serverB\021Camera"
-    "ServerProtob\006proto3"
+    "ameraServerResult\"\036\n\034SubscribeFocusInSta"
+    "rtRequest\"(\n\024FocusInStartResponse\022\020\n\010res"
+    "erved\030\001 \001(\005\"g\n\032RespondFocusInStartReques"
+    "t\022I\n\027focus_in_start_feedback\030\001 \001(\0162(.mav"
+    "sdk.rpc.camera_server.CameraFeedback\"i\n\033"
+    "RespondFocusInStartResponse\022J\n\024camera_se"
+    "rver_result\030\001 \001(\0132,.mavsdk.rpc.camera_se"
+    "rver.CameraServerResult\"\037\n\035SubscribeFocu"
+    "sOutStartRequest\")\n\025FocusOutStartRespons"
+    "e\022\020\n\010reserved\030\001 \001(\005\"i\n\033RespondFocusOutSt"
+    "artRequest\022J\n\030focus_out_start_feedback\030\001"
+    " \001(\0162(.mavsdk.rpc.camera_server.CameraFe"
+    "edback\"j\n\034RespondFocusOutStartResponse\022J"
+    "\n\024camera_server_result\030\001 \001(\0132,.mavsdk.rp"
+    "c.camera_server.CameraServerResult\"\033\n\031Su"
+    "bscribeFocusStopRequest\"%\n\021FocusStopResp"
+    "onse\022\020\n\010reserved\030\001 \001(\005\"`\n\027RespondFocusSt"
+    "opRequest\022E\n\023focus_stop_feedback\030\001 \001(\0162("
+    ".mavsdk.rpc.camera_server.CameraFeedback"
+    "\"f\n\030RespondFocusStopResponse\022J\n\024camera_s"
+    "erver_result\030\001 \001(\0132,.mavsdk.rpc.camera_s"
+    "erver.CameraServerResult\"\034\n\032SubscribeFoc"
+    "usRangeRequest\".\n\022FocusRangeResponse\022\030\n\020"
+    "focus_distance_m\030\001 \001(\002\"b\n\030RespondFocusRa"
+    "ngeRequest\022F\n\024focus_range_feedback\030\001 \001(\016"
+    "2(.mavsdk.rpc.camera_server.CameraFeedba"
+    "ck\"g\n\031RespondFocusRangeResponse\022J\n\024camer"
+    "a_server_result\030\001 \001(\0132,.mavsdk.rpc.camer"
+    "a_server.CameraServerResult\"\214\003\n\013Informat"
+    "ion\022\023\n\013vendor_name\030\001 \001(\t\022\022\n\nmodel_name\030\002"
+    " \001(\t\022\030\n\020firmware_version\030\003 \001(\t\022\027\n\017focal_"
+    "length_mm\030\004 \001(\002\022!\n\031horizontal_sensor_siz"
+    "e_mm\030\005 \001(\002\022\037\n\027vertical_sensor_size_mm\030\006 "
+    "\001(\002\022 \n\030horizontal_resolution_px\030\007 \001(\r\022\036\n"
+    "\026vertical_resolution_px\030\010 \001(\r\022\017\n\007lens_id"
+    "\030\t \001(\r\022\037\n\027definition_file_version\030\n \001(\r\022"
+    "\033\n\023definition_file_uri\030\013 \001(\t\022%\n\035image_in"
+    "_video_mode_supported\030\014 \001(\010\022%\n\035video_in_"
+    "image_mode_supported\030\r \001(\010\";\n\016VideoStrea"
+    "ming\022\027\n\017has_rtsp_server\030\001 \001(\010\022\020\n\010rtsp_ur"
+    "i\030\002 \001(\t\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001("
+    "\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_alt"
+    "itude_m\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 \001"
+    "(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t"
+    "\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"\320\001\n\013CaptureInfo\0224\n\010"
+    "position\030\001 \001(\0132\".mavsdk.rpc.camera_serve"
+    "r.Position\022A\n\023attitude_quaternion\030\002 \001(\0132"
+    "$.mavsdk.rpc.camera_server.Quaternion\022\023\n"
+    "\013time_utc_us\030\003 \001(\004\022\022\n\nis_success\030\004 \001(\010\022\r"
+    "\n\005index\030\005 \001(\005\022\020\n\010file_url\030\006 \001(\t\"\263\002\n\022Came"
+    "raServerResult\022C\n\006result\030\001 \001(\01623.mavsdk."
+    "rpc.camera_server.CameraServerResult.Res"
+    "ult\022\022\n\nresult_str\030\002 \001(\t\"\303\001\n\006Result\022\022\n\016RE"
+    "SULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RE"
+    "SULT_IN_PROGRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rR"
+    "ESULT_DENIED\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RESU"
+    "LT_TIMEOUT\020\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007\022"
+    "\024\n\020RESULT_NO_SYSTEM\020\010\"\214\005\n\022StorageInforma"
+    "tion\022\030\n\020used_storage_mib\030\001 \001(\002\022\035\n\025availa"
+    "ble_storage_mib\030\002 \001(\002\022\031\n\021total_storage_m"
+    "ib\030\003 \001(\002\022R\n\016storage_status\030\004 \001(\0162:.mavsd"
+    "k.rpc.camera_server.StorageInformation.S"
+    "torageStatus\022\022\n\nstorage_id\030\005 \001(\r\022N\n\014stor"
+    "age_type\030\006 \001(\01628.mavsdk.rpc.camera_serve"
+    "r.StorageInformation.StorageType\022\030\n\020read"
+    "_speed_mib_s\030\007 \001(\002\022\031\n\021write_speed_mib_s\030"
+    "\010 \001(\002\"\221\001\n\rStorageStatus\022 \n\034STORAGE_STATU"
+    "S_NOT_AVAILABLE\020\000\022\036\n\032STORAGE_STATUS_UNFO"
+    "RMATTED\020\001\022\034\n\030STORAGE_STATUS_FORMATTED\020\002\022"
+    " \n\034STORAGE_STATUS_NOT_SUPPORTED\020\003\"\240\001\n\013St"
+    "orageType\022\030\n\024STORAGE_TYPE_UNKNOWN\020\000\022\032\n\026S"
+    "TORAGE_TYPE_USB_STICK\020\001\022\023\n\017STORAGE_TYPE_"
+    "SD\020\002\022\030\n\024STORAGE_TYPE_MICROSD\020\003\022\023\n\017STORAG"
+    "E_TYPE_HD\020\007\022\027\n\022STORAGE_TYPE_OTHER\020\376\001\"\356\003\n"
+    "\rCaptureStatus\022\030\n\020image_interval_s\030\001 \001(\002"
+    "\022\030\n\020recording_time_s\030\002 \001(\002\022\036\n\026available_"
+    "capacity_mib\030\003 \001(\002\022I\n\014image_status\030\004 \001(\016"
+    "23.mavsdk.rpc.camera_server.CaptureStatu"
+    "s.ImageStatus\022I\n\014video_status\030\005 \001(\01623.ma"
+    "vsdk.rpc.camera_server.CaptureStatus.Vid"
+    "eoStatus\022\023\n\013image_count\030\006 \001(\005\"\221\001\n\013ImageS"
+    "tatus\022\025\n\021IMAGE_STATUS_IDLE\020\000\022$\n IMAGE_ST"
+    "ATUS_CAPTURE_IN_PROGRESS\020\001\022\036\n\032IMAGE_STAT"
+    "US_INTERVAL_IDLE\020\002\022%\n!IMAGE_STATUS_INTER"
+    "VAL_IN_PROGRESS\020\003\"J\n\013VideoStatus\022\025\n\021VIDE"
+    "O_STATUS_IDLE\020\000\022$\n VIDEO_STATUS_CAPTURE_"
+    "IN_PROGRESS\020\001\"\\\n\035SetTrackingPointStatusR"
+    "equest\022;\n\rtracked_point\030\001 \001(\0132$.mavsdk.r"
+    "pc.camera_server.TrackPoint\" \n\036SetTracki"
+    "ngPointStatusResponse\"h\n!SetTrackingRect"
+    "angleStatusRequest\022C\n\021tracked_rectangle\030"
+    "\001 \001(\0132(.mavsdk.rpc.camera_server.TrackRe"
+    "ctangle\"$\n\"SetTrackingRectangleStatusRes"
+    "ponse\"\035\n\033SetTrackingOffStatusRequest\"\036\n\034"
+    "SetTrackingOffStatusResponse\"&\n$Subscrib"
+    "eTrackingPointCommandRequest\"Y\n\034Tracking"
+    "PointCommandResponse\0229\n\013track_point\030\001 \001("
+    "\0132$.mavsdk.rpc.camera_server.TrackPoint\""
+    "*\n(SubscribeTrackingRectangleCommandRequ"
+    "est\"e\n TrackingRectangleCommandResponse\022"
+    "A\n\017track_rectangle\030\001 \001(\0132(.mavsdk.rpc.ca"
+    "mera_server.TrackRectangle\"$\n\"SubscribeT"
+    "rackingOffCommandRequest\"+\n\032TrackingOffC"
+    "ommandResponse\022\r\n\005dummy\030\001 \001(\005\"k\n\"Respond"
+    "TrackingPointCommandRequest\022E\n\023stop_vide"
+    "o_feedback\030\001 \001(\0162(.mavsdk.rpc.camera_ser"
+    "ver.CameraFeedback\"q\n#RespondTrackingPoi"
+    "ntCommandResponse\022J\n\024camera_server_resul"
+    "t\030\001 \001(\0132,.mavsdk.rpc.camera_server.Camer"
+    "aServerResult\"o\n&RespondTrackingRectangl"
+    "eCommandRequest\022E\n\023stop_video_feedback\030\001"
+    " \001(\0162(.mavsdk.rpc.camera_server.CameraFe"
+    "edback\"u\n\'RespondTrackingRectangleComman"
+    "dResponse\022J\n\024camera_server_result\030\001 \001(\0132"
+    ",.mavsdk.rpc.camera_server.CameraServerR"
+    "esult\"i\n RespondTrackingOffCommandReques"
+    "t\022E\n\023stop_video_feedback\030\001 \001(\0162(.mavsdk."
+    "rpc.camera_server.CameraFeedback\"o\n!Resp"
+    "ondTrackingOffCommandResponse\022J\n\024camera_"
+    "server_result\030\001 \001(\0132,.mavsdk.rpc.camera_"
+    "server.CameraServerResult\"J\n\022SetPosition"
+    "Request\0224\n\010position\030\001 \001(\0132\".mavsdk.rpc.c"
+    "amera_server.Position\"a\n\023SetPositionResp"
+    "onse\022J\n\024camera_server_result\030\001 \001(\0132,.mav"
+    "sdk.rpc.camera_server.CameraServerResult"
+    "\"a\n\034SetAttitudeQuaternionRequest\022A\n\023atti"
+    "tude_quaternion\030\001 \001(\0132$.mavsdk.rpc.camer"
+    "a_server.Quaternion\"k\n\035SetAttitudeQuater"
+    "nionResponse\022J\n\024camera_server_result\030\001 \001"
+    "(\0132,.mavsdk.rpc.camera_server.CameraServ"
+    "erResult\"+\n\024SetZoomFactorRequest\022\023\n\013zoom"
+    "_factor\030\001 \001(\002\"c\n\025SetZoomFactorResponse\022J"
+    "\n\024camera_server_result\030\001 \001(\0132,.mavsdk.rp"
+    "c.camera_server.CameraServerResult\"M\n\025Se"
+    "tFieldOfViewRequest\022\032\n\022horizontal_fov_de"
+    "g\030\001 \001(\002\022\030\n\020vertical_fov_deg\030\002 \001(\002\"d\n\026Set"
+    "FieldOfViewResponse\022J\n\024camera_server_res"
+    "ult\030\001 \001(\0132,.mavsdk.rpc.camera_server.Cam"
+    "eraServerResult\">\n\nTrackPoint\022\017\n\007point_x"
+    "\030\001 \001(\002\022\017\n\007point_y\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\""
+    "\204\001\n\016TrackRectangle\022\031\n\021top_left_corner_x\030"
+    "\001 \001(\002\022\031\n\021top_left_corner_y\030\002 \001(\002\022\035\n\025bott"
+    "om_right_corner_x\030\003 \001(\002\022\035\n\025bottom_right_"
+    "corner_y\030\004 \001(\002*{\n\016CameraFeedback\022\033\n\027CAME"
+    "RA_FEEDBACK_UNKNOWN\020\000\022\026\n\022CAMERA_FEEDBACK"
+    "_OK\020\001\022\030\n\024CAMERA_FEEDBACK_BUSY\020\002\022\032\n\026CAMER"
+    "A_FEEDBACK_FAILED\020\003*8\n\004Mode\022\020\n\014MODE_UNKN"
+    "OWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\0022\214<"
+    "\n\023CameraServerService\022y\n\016SetInformation\022"
+    "/.mavsdk.rpc.camera_server.SetInformatio"
+    "nRequest\0320.mavsdk.rpc.camera_server.SetI"
+    "nformationResponse\"\004\200\265\030\001\022\202\001\n\021SetVideoStr"
+    "eaming\0222.mavsdk.rpc.camera_server.SetVid"
+    "eoStreamingRequest\0323.mavsdk.rpc.camera_s"
+    "erver.SetVideoStreamingResponse\"\004\200\265\030\001\022v\n"
+    "\rSetInProgress\022..mavsdk.rpc.camera_serve"
+    "r.SetInProgressRequest\032/.mavsdk.rpc.came"
+    "ra_server.SetInProgressResponse\"\004\200\265\030\001\022~\n"
+    "\022SubscribeTakePhoto\0223.mavsdk.rpc.camera_"
+    "server.SubscribeTakePhotoRequest\032+.mavsd"
+    "k.rpc.camera_server.TakePhotoResponse\"\004\200"
+    "\265\030\0000\001\022\177\n\020RespondTakePhoto\0221.mavsdk.rpc.c"
+    "amera_server.RespondTakePhotoRequest\0322.m"
+    "avsdk.rpc.camera_server.RespondTakePhoto"
+    "Response\"\004\200\265\030\001\022\201\001\n\023SubscribeStartVideo\0224"
+    ".mavsdk.rpc.camera_server.SubscribeStart"
+    "VideoRequest\032,.mavsdk.rpc.camera_server."
+    "StartVideoResponse\"\004\200\265\030\0000\001\022\202\001\n\021RespondSt"
+    "artVideo\0222.mavsdk.rpc.camera_server.Resp"
+    "ondStartVideoRequest\0323.mavsdk.rpc.camera"
+    "_server.RespondStartVideoResponse\"\004\200\265\030\001\022"
+    "~\n\022SubscribeStopVideo\0223.mavsdk.rpc.camer"
+    "a_server.SubscribeStopVideoRequest\032+.mav"
+    "sdk.rpc.camera_server.StopVideoResponse\""
+    "\004\200\265\030\0000\001\022\177\n\020RespondStopVideo\0221.mavsdk.rpc"
+    ".camera_server.RespondStopVideoRequest\0322"
+    ".mavsdk.rpc.camera_server.RespondStopVid"
+    "eoResponse\"\004\200\265\030\001\022\234\001\n\034SubscribeStartVideo"
+    "Streaming\022=.mavsdk.rpc.camera_server.Sub"
+    "scribeStartVideoStreamingRequest\0325.mavsd"
+    "k.rpc.camera_server.StartVideoStreamingR"
+    "esponse\"\004\200\265\030\0000\001\022\235\001\n\032RespondStartVideoStr"
+    "eaming\022;.mavsdk.rpc.camera_server.Respon"
+    "dStartVideoStreamingRequest\032<.mavsdk.rpc"
+    ".camera_server.RespondStartVideoStreamin"
+    "gResponse\"\004\200\265\030\001\022\231\001\n\033SubscribeStopVideoSt"
+    "reaming\022<.mavsdk.rpc.camera_server.Subsc"
+    "ribeStopVideoStreamingRequest\0324.mavsdk.r"
+    "pc.camera_server.StopVideoStreamingRespo"
+    "nse\"\004\200\265\030\0000\001\022\232\001\n\031RespondStopVideoStreamin"
+    "g\022:.mavsdk.rpc.camera_server.RespondStop"
+    "VideoStreamingRequest\032;.mavsdk.rpc.camer"
+    "a_server.RespondStopVideoStreamingRespon"
+    "se\"\004\200\265\030\001\022x\n\020SubscribeSetMode\0221.mavsdk.rp"
+    "c.camera_server.SubscribeSetModeRequest\032"
+    ").mavsdk.rpc.camera_server.SetModeRespon"
+    "se\"\004\200\265\030\0000\001\022y\n\016RespondSetMode\022/.mavsdk.rp"
+    "c.camera_server.RespondSetModeRequest\0320."
+    "mavsdk.rpc.camera_server.RespondSetModeR"
+    "esponse\"\004\200\265\030\001\022\231\001\n\033SubscribeStorageInform"
+    "ation\022<.mavsdk.rpc.camera_server.Subscri"
+    "beStorageInformationRequest\0324.mavsdk.rpc"
+    ".camera_server.StorageInformationRespons"
+    "e\"\004\200\265\030\0000\001\022\232\001\n\031RespondStorageInformation\022"
+    ":.mavsdk.rpc.camera_server.RespondStorag"
+    "eInformationRequest\032;.mavsdk.rpc.camera_"
+    "server.RespondStorageInformationResponse"
+    "\"\004\200\265\030\001\022\212\001\n\026SubscribeCaptureStatus\0227.mavs"
+    "dk.rpc.camera_server.SubscribeCaptureSta"
+    "tusRequest\032/.mavsdk.rpc.camera_server.Ca"
+    "ptureStatusResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondC"
+    "aptureStatus\0225.mavsdk.rpc.camera_server."
+    "RespondCaptureStatusRequest\0326.mavsdk.rpc"
+    ".camera_server.RespondCaptureStatusRespo"
+    "nse\"\004\200\265\030\001\022\212\001\n\026SubscribeFormatStorage\0227.m"
+    "avsdk.rpc.camera_server.SubscribeFormatS"
+    "torageRequest\032/.mavsdk.rpc.camera_server"
+    ".FormatStorageResponse\"\004\200\265\030\0000\001\022\213\001\n\024Respo"
+    "ndFormatStorage\0225.mavsdk.rpc.camera_serv"
+    "er.RespondFormatStorageRequest\0326.mavsdk."
+    "rpc.camera_server.RespondFormatStorageRe"
+    "sponse\"\004\200\265\030\001\022\212\001\n\026SubscribeResetSettings\022"
+    "7.mavsdk.rpc.camera_server.SubscribeRese"
+    "tSettingsRequest\032/.mavsdk.rpc.camera_ser"
+    "ver.ResetSettingsResponse\"\004\200\265\030\0000\001\022\213\001\n\024Re"
+    "spondResetSettings\0225.mavsdk.rpc.camera_s"
+    "erver.RespondResetSettingsRequest\0326.mavs"
+    "dk.rpc.camera_server.RespondResetSetting"
+    "sResponse\"\004\200\265\030\001\022\204\001\n\024SubscribeZoomInStart"
+    "\0225.mavsdk.rpc.camera_server.SubscribeZoo"
+    "mInStartRequest\032-.mavsdk.rpc.camera_serv"
+    "er.ZoomInStartResponse\"\004\200\265\030\0000\001\022\205\001\n\022Respo"
+    "ndZoomInStart\0223.mavsdk.rpc.camera_server"
+    ".RespondZoomInStartRequest\0324.mavsdk.rpc."
+    "camera_server.RespondZoomInStartResponse"
+    "\"\004\200\265\030\001\022\207\001\n\025SubscribeZoomOutStart\0226.mavsd"
+    "k.rpc.camera_server.SubscribeZoomOutStar"
+    "tRequest\032..mavsdk.rpc.camera_server.Zoom"
+    "OutStartResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondZoom"
+    "OutStart\0224.mavsdk.rpc.camera_server.Resp"
+    "ondZoomOutStartRequest\0325.mavsdk.rpc.came"
+    "ra_server.RespondZoomOutStartResponse\"\004\200"
+    "\265\030\001\022{\n\021SubscribeZoomStop\0222.mavsdk.rpc.ca"
+    "mera_server.SubscribeZoomStopRequest\032*.m"
+    "avsdk.rpc.camera_server.ZoomStopResponse"
+    "\"\004\200\265\030\0000\001\022|\n\017RespondZoomStop\0220.mavsdk.rpc"
+    ".camera_server.RespondZoomStopRequest\0321."
+    "mavsdk.rpc.camera_server.RespondZoomStop"
+    "Response\"\004\200\265\030\001\022~\n\022SubscribeZoomRange\0223.m"
+    "avsdk.rpc.camera_server.SubscribeZoomRan"
+    "geRequest\032+.mavsdk.rpc.camera_server.Zoo"
+    "mRangeResponse\"\004\200\265\030\0000\001\022\177\n\020RespondZoomRan"
+    "ge\0221.mavsdk.rpc.camera_server.RespondZoo"
+    "mRangeRequest\0322.mavsdk.rpc.camera_server"
+    ".RespondZoomRangeResponse\"\004\200\265\030\001\022\204\001\n\024Subs"
+    "cribeFocusInStep\0225.mavsdk.rpc.camera_ser"
+    "ver.SubscribeFocusInStepRequest\032-.mavsdk"
+    ".rpc.camera_server.FocusInStepResponse\"\004"
+    "\200\265\030\0000\001\022\205\001\n\022RespondFocusInStep\0223.mavsdk.r"
+    "pc.camera_server.RespondFocusInStepReque"
+    "st\0324.mavsdk.rpc.camera_server.RespondFoc"
+    "usInStepResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeFocu"
+    "sOutStep\0226.mavsdk.rpc.camera_server.Subs"
+    "cribeFocusOutStepRequest\032..mavsdk.rpc.ca"
+    "mera_server.FocusOutStepResponse\"\004\200\265\030\0000\001"
+    "\022\210\001\n\023RespondFocusOutStep\0224.mavsdk.rpc.ca"
+    "mera_server.RespondFocusOutStepRequest\0325"
+    ".mavsdk.rpc.camera_server.RespondFocusOu"
+    "tStepResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeFocusIn"
+    "Start\0226.mavsdk.rpc.camera_server.Subscri"
+    "beFocusInStartRequest\032..mavsdk.rpc.camer"
+    "a_server.FocusInStartResponse\"\004\200\265\030\0000\001\022\210\001"
+    "\n\023RespondFocusInStart\0224.mavsdk.rpc.camer"
+    "a_server.RespondFocusInStartRequest\0325.ma"
+    "vsdk.rpc.camera_server.RespondFocusInSta"
+    "rtResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeFocusOutSt"
+    "art\0227.mavsdk.rpc.camera_server.Subscribe"
+    "FocusOutStartRequest\032/.mavsdk.rpc.camera"
+    "_server.FocusOutStartResponse\"\004\200\265\030\0000\001\022\213\001"
+    "\n\024RespondFocusOutStart\0225.mavsdk.rpc.came"
+    "ra_server.RespondFocusOutStartRequest\0326."
+    "mavsdk.rpc.camera_server.RespondFocusOut"
+    "StartResponse\"\004\200\265\030\001\022~\n\022SubscribeFocusSto"
+    "p\0223.mavsdk.rpc.camera_server.SubscribeFo"
+    "cusStopRequest\032+.mavsdk.rpc.camera_serve"
+    "r.FocusStopResponse\"\004\200\265\030\0000\001\022\177\n\020RespondFo"
+    "cusStop\0221.mavsdk.rpc.camera_server.Respo"
+    "ndFocusStopRequest\0322.mavsdk.rpc.camera_s"
+    "erver.RespondFocusStopResponse\"\004\200\265\030\001\022\201\001\n"
+    "\023SubscribeFocusRange\0224.mavsdk.rpc.camera"
+    "_server.SubscribeFocusRangeRequest\032,.mav"
+    "sdk.rpc.camera_server.FocusRangeResponse"
+    "\"\004\200\265\030\0000\001\022\202\001\n\021RespondFocusRange\0222.mavsdk."
+    "rpc.camera_server.RespondFocusRangeReque"
+    "st\0323.mavsdk.rpc.camera_server.RespondFoc"
+    "usRangeResponse\"\004\200\265\030\001\022\235\001\n\032SetTrackingRec"
+    "tangleStatus\022;.mavsdk.rpc.camera_server."
+    "SetTrackingRectangleStatusRequest\032<.mavs"
+    "dk.rpc.camera_server.SetTrackingRectangl"
+    "eStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTrackingOff"
+    "Status\0225.mavsdk.rpc.camera_server.SetTra"
+    "ckingOffStatusRequest\0326.mavsdk.rpc.camer"
+    "a_server.SetTrackingOffStatusResponse\"\004\200"
+    "\265\030\001\022\237\001\n\035SubscribeTrackingPointCommand\022>."
+    "mavsdk.rpc.camera_server.SubscribeTracki"
+    "ngPointCommandRequest\0326.mavsdk.rpc.camer"
+    "a_server.TrackingPointCommandResponse\"\004\200"
+    "\265\030\0000\001\022\253\001\n!SubscribeTrackingRectangleComm"
+    "and\022B.mavsdk.rpc.camera_server.Subscribe"
+    "TrackingRectangleCommandRequest\032:.mavsdk"
+    ".rpc.camera_server.TrackingRectangleComm"
+    "andResponse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrackin"
+    "gOffCommand\022<.mavsdk.rpc.camera_server.S"
+    "ubscribeTrackingOffCommandRequest\0324.mavs"
+    "dk.rpc.camera_server.TrackingOffCommandR"
+    "esponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPoint"
+    "Command\022<.mavsdk.rpc.camera_server.Respo"
+    "ndTrackingPointCommandRequest\032=.mavsdk.r"
+    "pc.camera_server.RespondTrackingPointCom"
+    "mandResponse\"\004\200\265\030\001\022\254\001\n\037RespondTrackingRe"
+    "ctangleCommand\022@.mavsdk.rpc.camera_serve"
+    "r.RespondTrackingRectangleCommandRequest"
+    "\032A.mavsdk.rpc.camera_server.RespondTrack"
+    "ingRectangleCommandResponse\"\004\200\265\030\001\022\232\001\n\031Re"
+    "spondTrackingOffCommand\022:.mavsdk.rpc.cam"
+    "era_server.RespondTrackingOffCommandRequ"
+    "est\032;.mavsdk.rpc.camera_server.RespondTr"
+    "ackingOffCommandResponse\"\004\200\265\030\001\022p\n\013SetPos"
+    "ition\022,.mavsdk.rpc.camera_server.SetPosi"
+    "tionRequest\032-.mavsdk.rpc.camera_server.S"
+    "etPositionResponse\"\004\200\265\030\001\022\216\001\n\025SetAttitude"
+    "Quaternion\0226.mavsdk.rpc.camera_server.Se"
+    "tAttitudeQuaternionRequest\0327.mavsdk.rpc."
+    "camera_server.SetAttitudeQuaternionRespo"
+    "nse\"\004\200\265\030\001\022v\n\rSetZoomFactor\022..mavsdk.rpc."
+    "camera_server.SetZoomFactorRequest\032/.mav"
+    "sdk.rpc.camera_server.SetZoomFactorRespo"
+    "nse\"\004\200\265\030\001\022y\n\016SetFieldOfView\022/.mavsdk.rpc"
+    ".camera_server.SetFieldOfViewRequest\0320.m"
+    "avsdk.rpc.camera_server.SetFieldOfViewRe"
+    "sponse\"\004\200\265\030\001B,\n\027io.mavsdk.camera_serverB"
+    "\021CameraServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps[1] =
     {
@@ -3958,13 +4863,13 @@ static ::absl::once_flag descriptor_table_camera_5fserver_2fcamera_5fserver_2epr
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto = {
     false,
     false,
-    15739,
+    19066,
     descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto,
     "camera_server/camera_server.proto",
     &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
     descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps,
     1,
-    98,
+    122,
     schemas,
     file_default_instances,
     TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets,
@@ -16535,6 +17440,4607 @@ void RespondZoomRangeResponse::InternalSwap(RespondZoomRangeResponse* PROTOBUF_R
 }
 
 ::google::protobuf::Metadata RespondZoomRangeResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusInStepRequest::_Internal {
+ public:
+};
+
+SubscribeFocusInStepRequest::SubscribeFocusInStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusInStepRequest)
+}
+SubscribeFocusInStepRequest::SubscribeFocusInStepRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusInStepRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusInStepRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusInStepRequest)
+}
+
+inline void* SubscribeFocusInStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusInStepRequest(arena);
+}
+constexpr auto SubscribeFocusInStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusInStepRequest),
+                                            alignof(SubscribeFocusInStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusInStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusInStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusInStepRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusInStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusInStepRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusInStepRequest>(), &SubscribeFocusInStepRequest::ByteSizeLong,
+            &SubscribeFocusInStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusInStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusInStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusInStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusInStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusInStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusInStepRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusInStepResponse::_Internal {
+ public:
+};
+
+FocusInStepResponse::FocusInStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusInStepResponse)
+}
+FocusInStepResponse::FocusInStepResponse(
+    ::google::protobuf::Arena* arena, const FocusInStepResponse& from)
+    : FocusInStepResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusInStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusInStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusInStepResponse::~FocusInStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusInStepResponse)
+  SharedDtor(*this);
+}
+inline void FocusInStepResponse::SharedDtor(MessageLite& self) {
+  FocusInStepResponse& this_ = static_cast<FocusInStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusInStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusInStepResponse(arena);
+}
+constexpr auto FocusInStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusInStepResponse),
+                                            alignof(FocusInStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusInStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusInStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusInStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusInStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusInStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusInStepResponse>(), &FocusInStepResponse::ByteSizeLong,
+            &FocusInStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusInStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusInStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusInStepResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusInStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusInStepResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusInStepResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusInStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusInStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusInStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusInStepResponse& this_ = static_cast<const FocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusInStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusInStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusInStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusInStepResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusInStepResponse& this_ = static_cast<const FocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusInStepResponse::ByteSizeLong() const {
+          const FocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusInStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusInStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusInStepResponse*>(&to_msg);
+  auto& from = static_cast<const FocusInStepResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusInStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusInStepResponse::CopyFrom(const FocusInStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusInStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusInStepResponse::InternalSwap(FocusInStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusInStepResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusInStepRequest::_Internal {
+ public:
+};
+
+RespondFocusInStepRequest::RespondFocusInStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+}
+RespondFocusInStepRequest::RespondFocusInStepRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusInStepRequest& from)
+    : RespondFocusInStepRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStepRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusInStepRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_in_step_feedback_ = {};
+}
+RespondFocusInStepRequest::~RespondFocusInStepRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusInStepRequest::SharedDtor(MessageLite& self) {
+  RespondFocusInStepRequest& this_ = static_cast<RespondFocusInStepRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusInStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusInStepRequest(arena);
+}
+constexpr auto RespondFocusInStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusInStepRequest),
+                                            alignof(RespondFocusInStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusInStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusInStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusInStepRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusInStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusInStepRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusInStepRequest>(), &RespondFocusInStepRequest::ByteSizeLong,
+            &RespondFocusInStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusInStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusInStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusInStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusInStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusInStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusInStepRequest, _impl_.focus_in_step_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusInStepRequest, _impl_.focus_in_step_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusInStepRequest, _impl_.focus_in_step_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusInStepRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_in_step_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusInStepRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusInStepRequest& this_ = static_cast<const RespondFocusInStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusInStepRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusInStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+          if (this_._internal_focus_in_step_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_in_step_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusInStepRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusInStepRequest& this_ = static_cast<const RespondFocusInStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusInStepRequest::ByteSizeLong() const {
+          const RespondFocusInStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+            if (this_._internal_focus_in_step_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_in_step_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusInStepRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusInStepRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusInStepRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_in_step_feedback() != 0) {
+    _this->_impl_.focus_in_step_feedback_ = from._impl_.focus_in_step_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusInStepRequest::CopyFrom(const RespondFocusInStepRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusInStepRequest::InternalSwap(RespondFocusInStepRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_in_step_feedback_, other->_impl_.focus_in_step_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusInStepRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusInStepResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusInStepResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusInStepResponse, _impl_._has_bits_);
+};
+
+RespondFocusInStepResponse::RespondFocusInStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusInStepResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusInStepResponse::RespondFocusInStepResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusInStepResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusInStepResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusInStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusInStepResponse::~RespondFocusInStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusInStepResponse::SharedDtor(MessageLite& self) {
+  RespondFocusInStepResponse& this_ = static_cast<RespondFocusInStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusInStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusInStepResponse(arena);
+}
+constexpr auto RespondFocusInStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusInStepResponse),
+                                            alignof(RespondFocusInStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusInStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusInStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusInStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusInStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusInStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusInStepResponse>(), &RespondFocusInStepResponse::ByteSizeLong,
+            &RespondFocusInStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusInStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusInStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusInStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusInStepResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusInStepResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusInStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusInStepResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusInStepResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusInStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusInStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusInStepResponse& this_ = static_cast<const RespondFocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusInStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusInStepResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusInStepResponse& this_ = static_cast<const RespondFocusInStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusInStepResponse::ByteSizeLong() const {
+          const RespondFocusInStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusInStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusInStepResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusInStepResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusInStepResponse::CopyFrom(const RespondFocusInStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusInStepResponse::InternalSwap(RespondFocusInStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusInStepResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusOutStepRequest::_Internal {
+ public:
+};
+
+SubscribeFocusOutStepRequest::SubscribeFocusOutStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusOutStepRequest)
+}
+SubscribeFocusOutStepRequest::SubscribeFocusOutStepRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusOutStepRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusOutStepRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusOutStepRequest)
+}
+
+inline void* SubscribeFocusOutStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusOutStepRequest(arena);
+}
+constexpr auto SubscribeFocusOutStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusOutStepRequest),
+                                            alignof(SubscribeFocusOutStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusOutStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusOutStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusOutStepRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusOutStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusOutStepRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusOutStepRequest>(), &SubscribeFocusOutStepRequest::ByteSizeLong,
+            &SubscribeFocusOutStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusOutStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusOutStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusOutStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusOutStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusOutStepRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusOutStepResponse::_Internal {
+ public:
+};
+
+FocusOutStepResponse::FocusOutStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusOutStepResponse)
+}
+FocusOutStepResponse::FocusOutStepResponse(
+    ::google::protobuf::Arena* arena, const FocusOutStepResponse& from)
+    : FocusOutStepResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusOutStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusOutStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusOutStepResponse::~FocusOutStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusOutStepResponse)
+  SharedDtor(*this);
+}
+inline void FocusOutStepResponse::SharedDtor(MessageLite& self) {
+  FocusOutStepResponse& this_ = static_cast<FocusOutStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusOutStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusOutStepResponse(arena);
+}
+constexpr auto FocusOutStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusOutStepResponse),
+                                            alignof(FocusOutStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusOutStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusOutStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusOutStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusOutStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusOutStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusOutStepResponse>(), &FocusOutStepResponse::ByteSizeLong,
+            &FocusOutStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusOutStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusOutStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusOutStepResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusOutStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusOutStepResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusOutStepResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusOutStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusOutStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusOutStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusOutStepResponse& this_ = static_cast<const FocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusOutStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusOutStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusOutStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusOutStepResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusOutStepResponse& this_ = static_cast<const FocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusOutStepResponse::ByteSizeLong() const {
+          const FocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusOutStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusOutStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusOutStepResponse*>(&to_msg);
+  auto& from = static_cast<const FocusOutStepResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusOutStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusOutStepResponse::CopyFrom(const FocusOutStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusOutStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusOutStepResponse::InternalSwap(FocusOutStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusOutStepResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusOutStepRequest::_Internal {
+ public:
+};
+
+RespondFocusOutStepRequest::RespondFocusOutStepRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+}
+RespondFocusOutStepRequest::RespondFocusOutStepRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusOutStepRequest& from)
+    : RespondFocusOutStepRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStepRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusOutStepRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_out_step_feedback_ = {};
+}
+RespondFocusOutStepRequest::~RespondFocusOutStepRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusOutStepRequest::SharedDtor(MessageLite& self) {
+  RespondFocusOutStepRequest& this_ = static_cast<RespondFocusOutStepRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusOutStepRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusOutStepRequest(arena);
+}
+constexpr auto RespondFocusOutStepRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusOutStepRequest),
+                                            alignof(RespondFocusOutStepRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusOutStepRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusOutStepRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusOutStepRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusOutStepRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusOutStepRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusOutStepRequest>(), &RespondFocusOutStepRequest::ByteSizeLong,
+            &RespondFocusOutStepRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusOutStepRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusOutStepRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusOutStepRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusOutStepRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusOutStepRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusOutStepRequest, _impl_.focus_out_step_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusOutStepRequest, _impl_.focus_out_step_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusOutStepRequest, _impl_.focus_out_step_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusOutStepRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_out_step_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusOutStepRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusOutStepRequest& this_ = static_cast<const RespondFocusOutStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusOutStepRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusOutStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+          if (this_._internal_focus_out_step_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_out_step_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusOutStepRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusOutStepRequest& this_ = static_cast<const RespondFocusOutStepRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusOutStepRequest::ByteSizeLong() const {
+          const RespondFocusOutStepRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+            if (this_._internal_focus_out_step_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_out_step_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusOutStepRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusOutStepRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusOutStepRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_out_step_feedback() != 0) {
+    _this->_impl_.focus_out_step_feedback_ = from._impl_.focus_out_step_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusOutStepRequest::CopyFrom(const RespondFocusOutStepRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusOutStepRequest::InternalSwap(RespondFocusOutStepRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_out_step_feedback_, other->_impl_.focus_out_step_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusOutStepRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusOutStepResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusOutStepResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusOutStepResponse, _impl_._has_bits_);
+};
+
+RespondFocusOutStepResponse::RespondFocusOutStepResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusOutStepResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusOutStepResponse::RespondFocusOutStepResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusOutStepResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusOutStepResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStepResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusOutStepResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusOutStepResponse::~RespondFocusOutStepResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusOutStepResponse::SharedDtor(MessageLite& self) {
+  RespondFocusOutStepResponse& this_ = static_cast<RespondFocusOutStepResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusOutStepResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusOutStepResponse(arena);
+}
+constexpr auto RespondFocusOutStepResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusOutStepResponse),
+                                            alignof(RespondFocusOutStepResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusOutStepResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusOutStepResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusOutStepResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusOutStepResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusOutStepResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusOutStepResponse>(), &RespondFocusOutStepResponse::ByteSizeLong,
+            &RespondFocusOutStepResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusOutStepResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusOutStepResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusOutStepResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusOutStepResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusOutStepResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusOutStepResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusOutStepResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusOutStepResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusOutStepResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusOutStepResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusOutStepResponse& this_ = static_cast<const RespondFocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusOutStepResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusOutStepResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusOutStepResponse& this_ = static_cast<const RespondFocusOutStepResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusOutStepResponse::ByteSizeLong() const {
+          const RespondFocusOutStepResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusOutStepResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusOutStepResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusOutStepResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusOutStepResponse::CopyFrom(const RespondFocusOutStepResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusOutStepResponse::InternalSwap(RespondFocusOutStepResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusOutStepResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusInStartRequest::_Internal {
+ public:
+};
+
+SubscribeFocusInStartRequest::SubscribeFocusInStartRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusInStartRequest)
+}
+SubscribeFocusInStartRequest::SubscribeFocusInStartRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusInStartRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusInStartRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusInStartRequest)
+}
+
+inline void* SubscribeFocusInStartRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusInStartRequest(arena);
+}
+constexpr auto SubscribeFocusInStartRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusInStartRequest),
+                                            alignof(SubscribeFocusInStartRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusInStartRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusInStartRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusInStartRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusInStartRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusInStartRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusInStartRequest>(), &SubscribeFocusInStartRequest::ByteSizeLong,
+            &SubscribeFocusInStartRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusInStartRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusInStartRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusInStartRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusInStartRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusInStartRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusInStartRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusInStartResponse::_Internal {
+ public:
+};
+
+FocusInStartResponse::FocusInStartResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusInStartResponse)
+}
+FocusInStartResponse::FocusInStartResponse(
+    ::google::protobuf::Arena* arena, const FocusInStartResponse& from)
+    : FocusInStartResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusInStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusInStartResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusInStartResponse::~FocusInStartResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusInStartResponse)
+  SharedDtor(*this);
+}
+inline void FocusInStartResponse::SharedDtor(MessageLite& self) {
+  FocusInStartResponse& this_ = static_cast<FocusInStartResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusInStartResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusInStartResponse(arena);
+}
+constexpr auto FocusInStartResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusInStartResponse),
+                                            alignof(FocusInStartResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusInStartResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusInStartResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusInStartResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusInStartResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusInStartResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusInStartResponse>(), &FocusInStartResponse::ByteSizeLong,
+            &FocusInStartResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusInStartResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusInStartResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusInStartResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusInStartResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusInStartResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusInStartResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusInStartResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusInStartResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusInStartResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusInStartResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusInStartResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusInStartResponse& this_ = static_cast<const FocusInStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusInStartResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusInStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusInStartResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusInStartResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusInStartResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusInStartResponse& this_ = static_cast<const FocusInStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusInStartResponse::ByteSizeLong() const {
+          const FocusInStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusInStartResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusInStartResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusInStartResponse*>(&to_msg);
+  auto& from = static_cast<const FocusInStartResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusInStartResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusInStartResponse::CopyFrom(const FocusInStartResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusInStartResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusInStartResponse::InternalSwap(FocusInStartResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusInStartResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusInStartRequest::_Internal {
+ public:
+};
+
+RespondFocusInStartRequest::RespondFocusInStartRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+}
+RespondFocusInStartRequest::RespondFocusInStartRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusInStartRequest& from)
+    : RespondFocusInStartRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStartRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusInStartRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_in_start_feedback_ = {};
+}
+RespondFocusInStartRequest::~RespondFocusInStartRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusInStartRequest::SharedDtor(MessageLite& self) {
+  RespondFocusInStartRequest& this_ = static_cast<RespondFocusInStartRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusInStartRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusInStartRequest(arena);
+}
+constexpr auto RespondFocusInStartRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusInStartRequest),
+                                            alignof(RespondFocusInStartRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusInStartRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusInStartRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusInStartRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusInStartRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusInStartRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusInStartRequest>(), &RespondFocusInStartRequest::ByteSizeLong,
+            &RespondFocusInStartRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusInStartRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusInStartRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusInStartRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusInStartRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusInStartRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusInStartRequest, _impl_.focus_in_start_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusInStartRequest, _impl_.focus_in_start_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusInStartRequest, _impl_.focus_in_start_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusInStartRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_in_start_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusInStartRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusInStartRequest& this_ = static_cast<const RespondFocusInStartRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusInStartRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusInStartRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+          if (this_._internal_focus_in_start_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_in_start_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusInStartRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusInStartRequest& this_ = static_cast<const RespondFocusInStartRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusInStartRequest::ByteSizeLong() const {
+          const RespondFocusInStartRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+            if (this_._internal_focus_in_start_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_in_start_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusInStartRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusInStartRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusInStartRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_in_start_feedback() != 0) {
+    _this->_impl_.focus_in_start_feedback_ = from._impl_.focus_in_start_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusInStartRequest::CopyFrom(const RespondFocusInStartRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusInStartRequest::InternalSwap(RespondFocusInStartRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_in_start_feedback_, other->_impl_.focus_in_start_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusInStartRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusInStartResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusInStartResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusInStartResponse, _impl_._has_bits_);
+};
+
+RespondFocusInStartResponse::RespondFocusInStartResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusInStartResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusInStartResponse::RespondFocusInStartResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusInStartResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusInStartResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusInStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusInStartResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusInStartResponse::~RespondFocusInStartResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusInStartResponse::SharedDtor(MessageLite& self) {
+  RespondFocusInStartResponse& this_ = static_cast<RespondFocusInStartResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusInStartResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusInStartResponse(arena);
+}
+constexpr auto RespondFocusInStartResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusInStartResponse),
+                                            alignof(RespondFocusInStartResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusInStartResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusInStartResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusInStartResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusInStartResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusInStartResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusInStartResponse>(), &RespondFocusInStartResponse::ByteSizeLong,
+            &RespondFocusInStartResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusInStartResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusInStartResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusInStartResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusInStartResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusInStartResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusInStartResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusInStartResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusInStartResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusInStartResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusInStartResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusInStartResponse& this_ = static_cast<const RespondFocusInStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusInStartResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusInStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusInStartResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusInStartResponse& this_ = static_cast<const RespondFocusInStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusInStartResponse::ByteSizeLong() const {
+          const RespondFocusInStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusInStartResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusInStartResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusInStartResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusInStartResponse::CopyFrom(const RespondFocusInStartResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusInStartResponse::InternalSwap(RespondFocusInStartResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusInStartResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusOutStartRequest::_Internal {
+ public:
+};
+
+SubscribeFocusOutStartRequest::SubscribeFocusOutStartRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusOutStartRequest)
+}
+SubscribeFocusOutStartRequest::SubscribeFocusOutStartRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusOutStartRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusOutStartRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusOutStartRequest)
+}
+
+inline void* SubscribeFocusOutStartRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusOutStartRequest(arena);
+}
+constexpr auto SubscribeFocusOutStartRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusOutStartRequest),
+                                            alignof(SubscribeFocusOutStartRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusOutStartRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusOutStartRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusOutStartRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusOutStartRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusOutStartRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusOutStartRequest>(), &SubscribeFocusOutStartRequest::ByteSizeLong,
+            &SubscribeFocusOutStartRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusOutStartRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusOutStartRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusOutStartRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusOutStartRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusOutStartRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusOutStartResponse::_Internal {
+ public:
+};
+
+FocusOutStartResponse::FocusOutStartResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusOutStartResponse)
+}
+FocusOutStartResponse::FocusOutStartResponse(
+    ::google::protobuf::Arena* arena, const FocusOutStartResponse& from)
+    : FocusOutStartResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusOutStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusOutStartResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusOutStartResponse::~FocusOutStartResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusOutStartResponse)
+  SharedDtor(*this);
+}
+inline void FocusOutStartResponse::SharedDtor(MessageLite& self) {
+  FocusOutStartResponse& this_ = static_cast<FocusOutStartResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusOutStartResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusOutStartResponse(arena);
+}
+constexpr auto FocusOutStartResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusOutStartResponse),
+                                            alignof(FocusOutStartResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusOutStartResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusOutStartResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusOutStartResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusOutStartResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusOutStartResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusOutStartResponse>(), &FocusOutStartResponse::ByteSizeLong,
+            &FocusOutStartResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusOutStartResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusOutStartResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusOutStartResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusOutStartResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusOutStartResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusOutStartResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusOutStartResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusOutStartResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusOutStartResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusOutStartResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusOutStartResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusOutStartResponse& this_ = static_cast<const FocusOutStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusOutStartResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusOutStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusOutStartResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusOutStartResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusOutStartResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusOutStartResponse& this_ = static_cast<const FocusOutStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusOutStartResponse::ByteSizeLong() const {
+          const FocusOutStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusOutStartResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusOutStartResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusOutStartResponse*>(&to_msg);
+  auto& from = static_cast<const FocusOutStartResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusOutStartResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusOutStartResponse::CopyFrom(const FocusOutStartResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusOutStartResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusOutStartResponse::InternalSwap(FocusOutStartResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusOutStartResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusOutStartRequest::_Internal {
+ public:
+};
+
+RespondFocusOutStartRequest::RespondFocusOutStartRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+}
+RespondFocusOutStartRequest::RespondFocusOutStartRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusOutStartRequest& from)
+    : RespondFocusOutStartRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStartRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusOutStartRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_out_start_feedback_ = {};
+}
+RespondFocusOutStartRequest::~RespondFocusOutStartRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusOutStartRequest::SharedDtor(MessageLite& self) {
+  RespondFocusOutStartRequest& this_ = static_cast<RespondFocusOutStartRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusOutStartRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusOutStartRequest(arena);
+}
+constexpr auto RespondFocusOutStartRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusOutStartRequest),
+                                            alignof(RespondFocusOutStartRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusOutStartRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusOutStartRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusOutStartRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusOutStartRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusOutStartRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusOutStartRequest>(), &RespondFocusOutStartRequest::ByteSizeLong,
+            &RespondFocusOutStartRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusOutStartRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusOutStartRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusOutStartRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusOutStartRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusOutStartRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusOutStartRequest, _impl_.focus_out_start_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusOutStartRequest, _impl_.focus_out_start_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusOutStartRequest, _impl_.focus_out_start_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusOutStartRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_out_start_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusOutStartRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusOutStartRequest& this_ = static_cast<const RespondFocusOutStartRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusOutStartRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusOutStartRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+          if (this_._internal_focus_out_start_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_out_start_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusOutStartRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusOutStartRequest& this_ = static_cast<const RespondFocusOutStartRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusOutStartRequest::ByteSizeLong() const {
+          const RespondFocusOutStartRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+            if (this_._internal_focus_out_start_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_out_start_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusOutStartRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusOutStartRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusOutStartRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_out_start_feedback() != 0) {
+    _this->_impl_.focus_out_start_feedback_ = from._impl_.focus_out_start_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusOutStartRequest::CopyFrom(const RespondFocusOutStartRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusOutStartRequest::InternalSwap(RespondFocusOutStartRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_out_start_feedback_, other->_impl_.focus_out_start_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusOutStartRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusOutStartResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusOutStartResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusOutStartResponse, _impl_._has_bits_);
+};
+
+RespondFocusOutStartResponse::RespondFocusOutStartResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusOutStartResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusOutStartResponse::RespondFocusOutStartResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusOutStartResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusOutStartResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusOutStartResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusOutStartResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusOutStartResponse::~RespondFocusOutStartResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusOutStartResponse::SharedDtor(MessageLite& self) {
+  RespondFocusOutStartResponse& this_ = static_cast<RespondFocusOutStartResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusOutStartResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusOutStartResponse(arena);
+}
+constexpr auto RespondFocusOutStartResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusOutStartResponse),
+                                            alignof(RespondFocusOutStartResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusOutStartResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusOutStartResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusOutStartResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusOutStartResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusOutStartResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusOutStartResponse>(), &RespondFocusOutStartResponse::ByteSizeLong,
+            &RespondFocusOutStartResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusOutStartResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusOutStartResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusOutStartResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusOutStartResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusOutStartResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusOutStartResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusOutStartResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusOutStartResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusOutStartResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusOutStartResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusOutStartResponse& this_ = static_cast<const RespondFocusOutStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusOutStartResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusOutStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusOutStartResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusOutStartResponse& this_ = static_cast<const RespondFocusOutStartResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusOutStartResponse::ByteSizeLong() const {
+          const RespondFocusOutStartResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusOutStartResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusOutStartResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusOutStartResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusOutStartResponse::CopyFrom(const RespondFocusOutStartResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusOutStartResponse::InternalSwap(RespondFocusOutStartResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusOutStartResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusStopRequest::_Internal {
+ public:
+};
+
+SubscribeFocusStopRequest::SubscribeFocusStopRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusStopRequest)
+}
+SubscribeFocusStopRequest::SubscribeFocusStopRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusStopRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusStopRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusStopRequest)
+}
+
+inline void* SubscribeFocusStopRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusStopRequest(arena);
+}
+constexpr auto SubscribeFocusStopRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusStopRequest),
+                                            alignof(SubscribeFocusStopRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusStopRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusStopRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusStopRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusStopRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusStopRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusStopRequest>(), &SubscribeFocusStopRequest::ByteSizeLong,
+            &SubscribeFocusStopRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusStopRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusStopRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusStopRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusStopRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusStopRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusStopRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusStopResponse::_Internal {
+ public:
+};
+
+FocusStopResponse::FocusStopResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusStopResponse)
+}
+FocusStopResponse::FocusStopResponse(
+    ::google::protobuf::Arena* arena, const FocusStopResponse& from)
+    : FocusStopResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusStopResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusStopResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusStopResponse::~FocusStopResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusStopResponse)
+  SharedDtor(*this);
+}
+inline void FocusStopResponse::SharedDtor(MessageLite& self) {
+  FocusStopResponse& this_ = static_cast<FocusStopResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusStopResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusStopResponse(arena);
+}
+constexpr auto FocusStopResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusStopResponse),
+                                            alignof(FocusStopResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusStopResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusStopResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusStopResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusStopResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusStopResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusStopResponse>(), &FocusStopResponse::ByteSizeLong,
+            &FocusStopResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusStopResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusStopResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusStopResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusStopResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusStopResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusStopResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusStopResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusStopResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusStopResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusStopResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusStopResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusStopResponse& this_ = static_cast<const FocusStopResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusStopResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusStopResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusStopResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusStopResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusStopResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusStopResponse& this_ = static_cast<const FocusStopResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusStopResponse::ByteSizeLong() const {
+          const FocusStopResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusStopResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusStopResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusStopResponse*>(&to_msg);
+  auto& from = static_cast<const FocusStopResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusStopResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusStopResponse::CopyFrom(const FocusStopResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusStopResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusStopResponse::InternalSwap(FocusStopResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusStopResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusStopRequest::_Internal {
+ public:
+};
+
+RespondFocusStopRequest::RespondFocusStopRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+}
+RespondFocusStopRequest::RespondFocusStopRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusStopRequest& from)
+    : RespondFocusStopRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusStopRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusStopRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_stop_feedback_ = {};
+}
+RespondFocusStopRequest::~RespondFocusStopRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusStopRequest::SharedDtor(MessageLite& self) {
+  RespondFocusStopRequest& this_ = static_cast<RespondFocusStopRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusStopRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusStopRequest(arena);
+}
+constexpr auto RespondFocusStopRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusStopRequest),
+                                            alignof(RespondFocusStopRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusStopRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusStopRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusStopRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusStopRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusStopRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusStopRequest>(), &RespondFocusStopRequest::ByteSizeLong,
+            &RespondFocusStopRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusStopRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusStopRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusStopRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusStopRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusStopRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusStopRequest, _impl_.focus_stop_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusStopRequest, _impl_.focus_stop_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusStopRequest, _impl_.focus_stop_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusStopRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_stop_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusStopRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusStopRequest& this_ = static_cast<const RespondFocusStopRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusStopRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusStopRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+          if (this_._internal_focus_stop_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_stop_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusStopRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusStopRequest& this_ = static_cast<const RespondFocusStopRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusStopRequest::ByteSizeLong() const {
+          const RespondFocusStopRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+            if (this_._internal_focus_stop_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_stop_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusStopRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusStopRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusStopRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_stop_feedback() != 0) {
+    _this->_impl_.focus_stop_feedback_ = from._impl_.focus_stop_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusStopRequest::CopyFrom(const RespondFocusStopRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusStopRequest::InternalSwap(RespondFocusStopRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_stop_feedback_, other->_impl_.focus_stop_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusStopRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusStopResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusStopResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusStopResponse, _impl_._has_bits_);
+};
+
+RespondFocusStopResponse::RespondFocusStopResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusStopResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusStopResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusStopResponse::RespondFocusStopResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusStopResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusStopResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusStopResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusStopResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusStopResponse::~RespondFocusStopResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusStopResponse::SharedDtor(MessageLite& self) {
+  RespondFocusStopResponse& this_ = static_cast<RespondFocusStopResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusStopResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusStopResponse(arena);
+}
+constexpr auto RespondFocusStopResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusStopResponse),
+                                            alignof(RespondFocusStopResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusStopResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusStopResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusStopResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusStopResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusStopResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusStopResponse>(), &RespondFocusStopResponse::ByteSizeLong,
+            &RespondFocusStopResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusStopResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusStopResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusStopResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusStopResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusStopResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusStopResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusStopResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusStopResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusStopResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusStopResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusStopResponse& this_ = static_cast<const RespondFocusStopResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusStopResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusStopResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusStopResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusStopResponse& this_ = static_cast<const RespondFocusStopResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusStopResponse::ByteSizeLong() const {
+          const RespondFocusStopResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusStopResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusStopResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusStopResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusStopResponse::CopyFrom(const RespondFocusStopResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusStopResponse::InternalSwap(RespondFocusStopResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusStopResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusRangeRequest::_Internal {
+ public:
+};
+
+SubscribeFocusRangeRequest::SubscribeFocusRangeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusRangeRequest)
+}
+SubscribeFocusRangeRequest::SubscribeFocusRangeRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusRangeRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusRangeRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusRangeRequest)
+}
+
+inline void* SubscribeFocusRangeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusRangeRequest(arena);
+}
+constexpr auto SubscribeFocusRangeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusRangeRequest),
+                                            alignof(SubscribeFocusRangeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusRangeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusRangeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusRangeRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusRangeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusRangeRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusRangeRequest>(), &SubscribeFocusRangeRequest::ByteSizeLong,
+            &SubscribeFocusRangeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusRangeRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusRangeRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusRangeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusRangeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusRangeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusRangeRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusRangeResponse::_Internal {
+ public:
+};
+
+FocusRangeResponse::FocusRangeResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusRangeResponse)
+}
+FocusRangeResponse::FocusRangeResponse(
+    ::google::protobuf::Arena* arena, const FocusRangeResponse& from)
+    : FocusRangeResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusRangeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusRangeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_distance_m_ = {};
+}
+FocusRangeResponse::~FocusRangeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusRangeResponse)
+  SharedDtor(*this);
+}
+inline void FocusRangeResponse::SharedDtor(MessageLite& self) {
+  FocusRangeResponse& this_ = static_cast<FocusRangeResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusRangeResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusRangeResponse(arena);
+}
+constexpr auto FocusRangeResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusRangeResponse),
+                                            alignof(FocusRangeResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusRangeResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusRangeResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusRangeResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusRangeResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusRangeResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusRangeResponse>(), &FocusRangeResponse::ByteSizeLong,
+            &FocusRangeResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusRangeResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusRangeResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusRangeResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusRangeResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusRangeResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float focus_distance_m = 1;
+    {::_pbi::TcParser::FastF32S1,
+     {13, 63, 0, PROTOBUF_FIELD_OFFSET(FocusRangeResponse, _impl_.focus_distance_m_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // float focus_distance_m = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusRangeResponse, _impl_.focus_distance_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusRangeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusRangeResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_distance_m_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusRangeResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusRangeResponse& this_ = static_cast<const FocusRangeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusRangeResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusRangeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusRangeResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // float focus_distance_m = 1;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_focus_distance_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                1, this_._internal_focus_distance_m(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusRangeResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusRangeResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusRangeResponse& this_ = static_cast<const FocusRangeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusRangeResponse::ByteSizeLong() const {
+          const FocusRangeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusRangeResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // float focus_distance_m = 1;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_focus_distance_m()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusRangeResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusRangeResponse*>(&to_msg);
+  auto& from = static_cast<const FocusRangeResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusRangeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint32_t>(from._internal_focus_distance_m()) != 0) {
+    _this->_impl_.focus_distance_m_ = from._impl_.focus_distance_m_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusRangeResponse::CopyFrom(const FocusRangeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusRangeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusRangeResponse::InternalSwap(FocusRangeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.focus_distance_m_, other->_impl_.focus_distance_m_);
+}
+
+::google::protobuf::Metadata FocusRangeResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusRangeRequest::_Internal {
+ public:
+};
+
+RespondFocusRangeRequest::RespondFocusRangeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+}
+RespondFocusRangeRequest::RespondFocusRangeRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusRangeRequest& from)
+    : RespondFocusRangeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusRangeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusRangeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_range_feedback_ = {};
+}
+RespondFocusRangeRequest::~RespondFocusRangeRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusRangeRequest::SharedDtor(MessageLite& self) {
+  RespondFocusRangeRequest& this_ = static_cast<RespondFocusRangeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusRangeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusRangeRequest(arena);
+}
+constexpr auto RespondFocusRangeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusRangeRequest),
+                                            alignof(RespondFocusRangeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusRangeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusRangeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusRangeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusRangeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusRangeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusRangeRequest>(), &RespondFocusRangeRequest::ByteSizeLong,
+            &RespondFocusRangeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusRangeRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusRangeRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusRangeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusRangeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusRangeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusRangeRequest, _impl_.focus_range_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusRangeRequest, _impl_.focus_range_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusRangeRequest, _impl_.focus_range_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusRangeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_range_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusRangeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusRangeRequest& this_ = static_cast<const RespondFocusRangeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusRangeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusRangeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+          if (this_._internal_focus_range_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_range_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusRangeRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusRangeRequest& this_ = static_cast<const RespondFocusRangeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusRangeRequest::ByteSizeLong() const {
+          const RespondFocusRangeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+            if (this_._internal_focus_range_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_range_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusRangeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusRangeRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusRangeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_range_feedback() != 0) {
+    _this->_impl_.focus_range_feedback_ = from._impl_.focus_range_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusRangeRequest::CopyFrom(const RespondFocusRangeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusRangeRequest::InternalSwap(RespondFocusRangeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_range_feedback_, other->_impl_.focus_range_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusRangeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusRangeResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusRangeResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusRangeResponse, _impl_._has_bits_);
+};
+
+RespondFocusRangeResponse::RespondFocusRangeResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusRangeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusRangeResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusRangeResponse::RespondFocusRangeResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusRangeResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusRangeResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusRangeResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusRangeResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusRangeResponse::~RespondFocusRangeResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusRangeResponse::SharedDtor(MessageLite& self) {
+  RespondFocusRangeResponse& this_ = static_cast<RespondFocusRangeResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusRangeResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusRangeResponse(arena);
+}
+constexpr auto RespondFocusRangeResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusRangeResponse),
+                                            alignof(RespondFocusRangeResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusRangeResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusRangeResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusRangeResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusRangeResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusRangeResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusRangeResponse>(), &RespondFocusRangeResponse::ByteSizeLong,
+            &RespondFocusRangeResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusRangeResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusRangeResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusRangeResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusRangeResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusRangeResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusRangeResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusRangeResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusRangeResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusRangeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusRangeResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusRangeResponse& this_ = static_cast<const RespondFocusRangeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusRangeResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusRangeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusRangeResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusRangeResponse& this_ = static_cast<const RespondFocusRangeResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusRangeResponse::ByteSizeLong() const {
+          const RespondFocusRangeResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusRangeResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusRangeResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusRangeResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusRangeResponse::CopyFrom(const RespondFocusRangeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusRangeResponse::InternalSwap(RespondFocusRangeResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusRangeResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.cc
@@ -621,6 +621,24 @@ struct SubscribeFocusOutStartRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusOutStartRequestDefaultTypeInternal _SubscribeFocusOutStartRequest_default_instance_;
               template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusMetersRequest::SubscribeFocusMetersRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusMetersRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusMetersRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusMetersRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusMetersRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusMetersRequestDefaultTypeInternal _SubscribeFocusMetersRequest_default_instance_;
+              template <typename>
 PROTOBUF_CONSTEXPR SubscribeFocusInStepRequest::SubscribeFocusInStepRequest(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
@@ -656,6 +674,60 @@ struct SubscribeFocusInStartRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusInStartRequestDefaultTypeInternal _SubscribeFocusInStartRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusAutoSingleRequest::SubscribeFocusAutoSingleRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusAutoSingleRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusAutoSingleRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusAutoSingleRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusAutoSingleRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusAutoSingleRequestDefaultTypeInternal _SubscribeFocusAutoSingleRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusAutoRequest::SubscribeFocusAutoRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusAutoRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusAutoRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusAutoRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusAutoRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusAutoRequestDefaultTypeInternal _SubscribeFocusAutoRequest_default_instance_;
+              template <typename>
+PROTOBUF_CONSTEXPR SubscribeFocusAutoContinuousRequest::SubscribeFocusAutoContinuousRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(_class_data_.base()){}
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase() {
+}
+#endif  // PROTOBUF_CUSTOM_VTABLE
+struct SubscribeFocusAutoContinuousRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR SubscribeFocusAutoContinuousRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~SubscribeFocusAutoContinuousRequestDefaultTypeInternal() {}
+  union {
+    SubscribeFocusAutoContinuousRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 SubscribeFocusAutoContinuousRequestDefaultTypeInternal _SubscribeFocusAutoContinuousRequest_default_instance_;
               template <typename>
 PROTOBUF_CONSTEXPR SubscribeCaptureStatusRequest::SubscribeCaptureStatusRequest(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
@@ -1455,6 +1527,31 @@ struct RespondFocusOutStartRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStartRequestDefaultTypeInternal _RespondFocusOutStartRequest_default_instance_;
 
+inline constexpr RespondFocusMetersRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_meters_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusMetersRequest::RespondFocusMetersRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusMetersRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusMetersRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusMetersRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusMetersRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusMetersRequestDefaultTypeInternal _RespondFocusMetersRequest_default_instance_;
+
 inline constexpr RespondFocusInStepRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : focus_in_step_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
@@ -1504,6 +1601,81 @@ struct RespondFocusInStartRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStartRequestDefaultTypeInternal _RespondFocusInStartRequest_default_instance_;
+
+inline constexpr RespondFocusAutoSingleRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_auto_single_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoSingleRequest::RespondFocusAutoSingleRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoSingleRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoSingleRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoSingleRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoSingleRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoSingleRequestDefaultTypeInternal _RespondFocusAutoSingleRequest_default_instance_;
+
+inline constexpr RespondFocusAutoRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_auto_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoRequest::RespondFocusAutoRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoRequestDefaultTypeInternal _RespondFocusAutoRequest_default_instance_;
+
+inline constexpr RespondFocusAutoContinuousRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_auto_continuous_feedback_{static_cast< ::mavsdk::rpc::camera_server::CameraFeedback >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoContinuousRequest::RespondFocusAutoContinuousRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoContinuousRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoContinuousRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoContinuousRequestDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoContinuousRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoContinuousRequestDefaultTypeInternal _RespondFocusAutoContinuousRequest_default_instance_;
 
 inline constexpr ResetSettingsResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1756,6 +1928,31 @@ struct FocusOutStartResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
 
+inline constexpr FocusMetersResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : focus_distance_m_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusMetersResponse::FocusMetersResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusMetersResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusMetersResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusMetersResponseDefaultTypeInternal() {}
+  union {
+    FocusMetersResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusMetersResponseDefaultTypeInternal _FocusMetersResponse_default_instance_;
+
 inline constexpr FocusInStepResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : reserved_{0},
@@ -1805,6 +2002,81 @@ struct FocusInStartResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
+
+inline constexpr FocusAutoSingleResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoSingleResponse::FocusAutoSingleResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoSingleResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoSingleResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoSingleResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoSingleResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoSingleResponseDefaultTypeInternal _FocusAutoSingleResponse_default_instance_;
+
+inline constexpr FocusAutoResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoResponse::FocusAutoResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoResponseDefaultTypeInternal _FocusAutoResponse_default_instance_;
+
+inline constexpr FocusAutoContinuousResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : reserved_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR FocusAutoContinuousResponse::FocusAutoContinuousResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct FocusAutoContinuousResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR FocusAutoContinuousResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~FocusAutoContinuousResponseDefaultTypeInternal() {}
+  union {
+    FocusAutoContinuousResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 FocusAutoContinuousResponseDefaultTypeInternal _FocusAutoContinuousResponse_default_instance_;
 
 inline constexpr CaptureStatusResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -2790,6 +3062,31 @@ struct RespondFocusOutStartResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusOutStartResponseDefaultTypeInternal _RespondFocusOutStartResponse_default_instance_;
 
+inline constexpr RespondFocusMetersResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusMetersResponse::RespondFocusMetersResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusMetersResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusMetersResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusMetersResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusMetersResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusMetersResponseDefaultTypeInternal _RespondFocusMetersResponse_default_instance_;
+
 inline constexpr RespondFocusInStepResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -2839,6 +3136,81 @@ struct RespondFocusInStartResponseDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusInStartResponseDefaultTypeInternal _RespondFocusInStartResponse_default_instance_;
+
+inline constexpr RespondFocusAutoSingleResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoSingleResponse::RespondFocusAutoSingleResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoSingleResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoSingleResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoSingleResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoSingleResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoSingleResponseDefaultTypeInternal _RespondFocusAutoSingleResponse_default_instance_;
+
+inline constexpr RespondFocusAutoResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoResponse::RespondFocusAutoResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoResponseDefaultTypeInternal _RespondFocusAutoResponse_default_instance_;
+
+inline constexpr RespondFocusAutoContinuousResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        camera_server_result_{nullptr} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR RespondFocusAutoContinuousResponse::RespondFocusAutoContinuousResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct RespondFocusAutoContinuousResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR RespondFocusAutoContinuousResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~RespondFocusAutoContinuousResponseDefaultTypeInternal() {}
+  union {
+    RespondFocusAutoContinuousResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RespondFocusAutoContinuousResponseDefaultTypeInternal _RespondFocusAutoContinuousResponse_default_instance_;
 
 inline constexpr RespondCaptureStatusResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -3746,6 +4118,150 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusRangeResponse, _impl_.camera_server_result_),
         0,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusMetersResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusMetersResponse, _impl_.focus_distance_m_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusMetersRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusMetersRequest, _impl_.focus_meters_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusMetersResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusMetersResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusMetersResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoRequest, _impl_.focus_auto_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoSingleResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoSingleResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest, _impl_.focus_auto_single_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoContinuousResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::FocusAutoContinuousResponse, _impl_.reserved_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest, _impl_.focus_auto_continuous_feedback_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse, _impl_.camera_server_result_),
+        0,
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::mavsdk::rpc::camera_server::Information, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -4214,42 +4730,58 @@ static const ::_pbi::MigrationSchema
         {760, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusRangeResponse)},
         {769, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusRangeRequest)},
         {778, 787, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusRangeResponse)},
-        {788, -1, -1, sizeof(::mavsdk::rpc::camera_server::Information)},
-        {809, -1, -1, sizeof(::mavsdk::rpc::camera_server::VideoStreaming)},
-        {819, -1, -1, sizeof(::mavsdk::rpc::camera_server::Position)},
-        {831, -1, -1, sizeof(::mavsdk::rpc::camera_server::Quaternion)},
-        {843, 857, -1, sizeof(::mavsdk::rpc::camera_server::CaptureInfo)},
-        {863, -1, -1, sizeof(::mavsdk::rpc::camera_server::CameraServerResult)},
-        {873, -1, -1, sizeof(::mavsdk::rpc::camera_server::StorageInformation)},
-        {889, -1, -1, sizeof(::mavsdk::rpc::camera_server::CaptureStatus)},
-        {903, 912, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusRequest)},
-        {913, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusResponse)},
-        {921, 930, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest)},
-        {931, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse)},
-        {939, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest)},
-        {947, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse)},
-        {955, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest)},
-        {963, 972, -1, sizeof(::mavsdk::rpc::camera_server::TrackingPointCommandResponse)},
-        {973, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest)},
-        {981, 990, -1, sizeof(::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse)},
-        {991, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest)},
-        {999, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackingOffCommandResponse)},
-        {1008, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest)},
-        {1017, 1026, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse)},
-        {1027, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest)},
-        {1036, 1045, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
-        {1046, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
-        {1055, 1064, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
-        {1065, 1074, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionRequest)},
-        {1075, 1084, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
-        {1085, 1094, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
-        {1095, 1104, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
-        {1105, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorRequest)},
-        {1114, 1123, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorResponse)},
-        {1124, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewRequest)},
-        {1134, 1143, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewResponse)},
-        {1144, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
-        {1155, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
+        {788, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest)},
+        {796, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusMetersResponse)},
+        {805, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusMetersRequest)},
+        {814, 823, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusMetersResponse)},
+        {824, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest)},
+        {832, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusAutoResponse)},
+        {841, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoRequest)},
+        {850, 859, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoResponse)},
+        {860, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest)},
+        {868, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusAutoSingleResponse)},
+        {877, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest)},
+        {886, 895, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse)},
+        {896, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest)},
+        {904, -1, -1, sizeof(::mavsdk::rpc::camera_server::FocusAutoContinuousResponse)},
+        {913, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest)},
+        {922, 931, -1, sizeof(::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse)},
+        {932, -1, -1, sizeof(::mavsdk::rpc::camera_server::Information)},
+        {953, -1, -1, sizeof(::mavsdk::rpc::camera_server::VideoStreaming)},
+        {963, -1, -1, sizeof(::mavsdk::rpc::camera_server::Position)},
+        {975, -1, -1, sizeof(::mavsdk::rpc::camera_server::Quaternion)},
+        {987, 1001, -1, sizeof(::mavsdk::rpc::camera_server::CaptureInfo)},
+        {1007, -1, -1, sizeof(::mavsdk::rpc::camera_server::CameraServerResult)},
+        {1017, -1, -1, sizeof(::mavsdk::rpc::camera_server::StorageInformation)},
+        {1033, -1, -1, sizeof(::mavsdk::rpc::camera_server::CaptureStatus)},
+        {1047, 1056, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusRequest)},
+        {1057, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingPointStatusResponse)},
+        {1065, 1074, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusRequest)},
+        {1075, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingRectangleStatusResponse)},
+        {1083, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusRequest)},
+        {1091, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetTrackingOffStatusResponse)},
+        {1099, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingPointCommandRequest)},
+        {1107, 1116, -1, sizeof(::mavsdk::rpc::camera_server::TrackingPointCommandResponse)},
+        {1117, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingRectangleCommandRequest)},
+        {1125, 1134, -1, sizeof(::mavsdk::rpc::camera_server::TrackingRectangleCommandResponse)},
+        {1135, -1, -1, sizeof(::mavsdk::rpc::camera_server::SubscribeTrackingOffCommandRequest)},
+        {1143, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackingOffCommandResponse)},
+        {1152, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandRequest)},
+        {1161, 1170, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingPointCommandResponse)},
+        {1171, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandRequest)},
+        {1180, 1189, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingRectangleCommandResponse)},
+        {1190, -1, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandRequest)},
+        {1199, 1208, -1, sizeof(::mavsdk::rpc::camera_server::RespondTrackingOffCommandResponse)},
+        {1209, 1218, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionRequest)},
+        {1219, 1228, -1, sizeof(::mavsdk::rpc::camera_server::SetPositionResponse)},
+        {1229, 1238, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionRequest)},
+        {1239, 1248, -1, sizeof(::mavsdk::rpc::camera_server::SetAttitudeQuaternionResponse)},
+        {1249, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorRequest)},
+        {1258, 1267, -1, sizeof(::mavsdk::rpc::camera_server::SetZoomFactorResponse)},
+        {1268, -1, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewRequest)},
+        {1278, 1287, -1, sizeof(::mavsdk::rpc::camera_server::SetFieldOfViewResponse)},
+        {1288, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackPoint)},
+        {1299, -1, -1, sizeof(::mavsdk::rpc::camera_server::TrackRectangle)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_SetInformationRequest_default_instance_._instance,
@@ -4338,6 +4870,22 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::mavsdk::rpc::camera_server::_FocusRangeResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondFocusRangeRequest_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_RespondFocusRangeResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusMetersRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusMetersResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusMetersRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusMetersResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusAutoRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusAutoResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusAutoSingleRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusAutoSingleResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoSingleRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoSingleResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_SubscribeFocusAutoContinuousRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_FocusAutoContinuousResponse_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoContinuousRequest_default_instance_._instance,
+    &::mavsdk::rpc::camera_server::_RespondFocusAutoContinuousResponse_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_Information_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_VideoStreaming_default_instance_._instance,
     &::mavsdk::rpc::camera_server::_Position_default_instance_._instance,
@@ -4540,320 +5088,378 @@ const char descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto[]
     "2(.mavsdk.rpc.camera_server.CameraFeedba"
     "ck\"g\n\031RespondFocusRangeResponse\022J\n\024camer"
     "a_server_result\030\001 \001(\0132,.mavsdk.rpc.camer"
-    "a_server.CameraServerResult\"\214\003\n\013Informat"
-    "ion\022\023\n\013vendor_name\030\001 \001(\t\022\022\n\nmodel_name\030\002"
-    " \001(\t\022\030\n\020firmware_version\030\003 \001(\t\022\027\n\017focal_"
-    "length_mm\030\004 \001(\002\022!\n\031horizontal_sensor_siz"
-    "e_mm\030\005 \001(\002\022\037\n\027vertical_sensor_size_mm\030\006 "
-    "\001(\002\022 \n\030horizontal_resolution_px\030\007 \001(\r\022\036\n"
-    "\026vertical_resolution_px\030\010 \001(\r\022\017\n\007lens_id"
-    "\030\t \001(\r\022\037\n\027definition_file_version\030\n \001(\r\022"
-    "\033\n\023definition_file_uri\030\013 \001(\t\022%\n\035image_in"
-    "_video_mode_supported\030\014 \001(\010\022%\n\035video_in_"
-    "image_mode_supported\030\r \001(\010\";\n\016VideoStrea"
-    "ming\022\027\n\017has_rtsp_server\030\001 \001(\010\022\020\n\010rtsp_ur"
-    "i\030\002 \001(\t\"q\n\010Position\022\024\n\014latitude_deg\030\001 \001("
-    "\001\022\025\n\rlongitude_deg\030\002 \001(\001\022\033\n\023absolute_alt"
-    "itude_m\030\003 \001(\002\022\033\n\023relative_altitude_m\030\004 \001"
-    "(\002\"8\n\nQuaternion\022\t\n\001w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t"
-    "\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002\"\320\001\n\013CaptureInfo\0224\n\010"
-    "position\030\001 \001(\0132\".mavsdk.rpc.camera_serve"
-    "r.Position\022A\n\023attitude_quaternion\030\002 \001(\0132"
-    "$.mavsdk.rpc.camera_server.Quaternion\022\023\n"
-    "\013time_utc_us\030\003 \001(\004\022\022\n\nis_success\030\004 \001(\010\022\r"
-    "\n\005index\030\005 \001(\005\022\020\n\010file_url\030\006 \001(\t\"\263\002\n\022Came"
-    "raServerResult\022C\n\006result\030\001 \001(\01623.mavsdk."
-    "rpc.camera_server.CameraServerResult.Res"
-    "ult\022\022\n\nresult_str\030\002 \001(\t\"\303\001\n\006Result\022\022\n\016RE"
-    "SULT_UNKNOWN\020\000\022\022\n\016RESULT_SUCCESS\020\001\022\026\n\022RE"
-    "SULT_IN_PROGRESS\020\002\022\017\n\013RESULT_BUSY\020\003\022\021\n\rR"
-    "ESULT_DENIED\020\004\022\020\n\014RESULT_ERROR\020\005\022\022\n\016RESU"
-    "LT_TIMEOUT\020\006\022\031\n\025RESULT_WRONG_ARGUMENT\020\007\022"
-    "\024\n\020RESULT_NO_SYSTEM\020\010\"\214\005\n\022StorageInforma"
-    "tion\022\030\n\020used_storage_mib\030\001 \001(\002\022\035\n\025availa"
-    "ble_storage_mib\030\002 \001(\002\022\031\n\021total_storage_m"
-    "ib\030\003 \001(\002\022R\n\016storage_status\030\004 \001(\0162:.mavsd"
-    "k.rpc.camera_server.StorageInformation.S"
-    "torageStatus\022\022\n\nstorage_id\030\005 \001(\r\022N\n\014stor"
-    "age_type\030\006 \001(\01628.mavsdk.rpc.camera_serve"
-    "r.StorageInformation.StorageType\022\030\n\020read"
-    "_speed_mib_s\030\007 \001(\002\022\031\n\021write_speed_mib_s\030"
-    "\010 \001(\002\"\221\001\n\rStorageStatus\022 \n\034STORAGE_STATU"
-    "S_NOT_AVAILABLE\020\000\022\036\n\032STORAGE_STATUS_UNFO"
-    "RMATTED\020\001\022\034\n\030STORAGE_STATUS_FORMATTED\020\002\022"
-    " \n\034STORAGE_STATUS_NOT_SUPPORTED\020\003\"\240\001\n\013St"
-    "orageType\022\030\n\024STORAGE_TYPE_UNKNOWN\020\000\022\032\n\026S"
-    "TORAGE_TYPE_USB_STICK\020\001\022\023\n\017STORAGE_TYPE_"
-    "SD\020\002\022\030\n\024STORAGE_TYPE_MICROSD\020\003\022\023\n\017STORAG"
-    "E_TYPE_HD\020\007\022\027\n\022STORAGE_TYPE_OTHER\020\376\001\"\356\003\n"
-    "\rCaptureStatus\022\030\n\020image_interval_s\030\001 \001(\002"
-    "\022\030\n\020recording_time_s\030\002 \001(\002\022\036\n\026available_"
-    "capacity_mib\030\003 \001(\002\022I\n\014image_status\030\004 \001(\016"
-    "23.mavsdk.rpc.camera_server.CaptureStatu"
-    "s.ImageStatus\022I\n\014video_status\030\005 \001(\01623.ma"
-    "vsdk.rpc.camera_server.CaptureStatus.Vid"
-    "eoStatus\022\023\n\013image_count\030\006 \001(\005\"\221\001\n\013ImageS"
-    "tatus\022\025\n\021IMAGE_STATUS_IDLE\020\000\022$\n IMAGE_ST"
-    "ATUS_CAPTURE_IN_PROGRESS\020\001\022\036\n\032IMAGE_STAT"
-    "US_INTERVAL_IDLE\020\002\022%\n!IMAGE_STATUS_INTER"
-    "VAL_IN_PROGRESS\020\003\"J\n\013VideoStatus\022\025\n\021VIDE"
-    "O_STATUS_IDLE\020\000\022$\n VIDEO_STATUS_CAPTURE_"
-    "IN_PROGRESS\020\001\"\\\n\035SetTrackingPointStatusR"
-    "equest\022;\n\rtracked_point\030\001 \001(\0132$.mavsdk.r"
-    "pc.camera_server.TrackPoint\" \n\036SetTracki"
-    "ngPointStatusResponse\"h\n!SetTrackingRect"
-    "angleStatusRequest\022C\n\021tracked_rectangle\030"
-    "\001 \001(\0132(.mavsdk.rpc.camera_server.TrackRe"
-    "ctangle\"$\n\"SetTrackingRectangleStatusRes"
-    "ponse\"\035\n\033SetTrackingOffStatusRequest\"\036\n\034"
-    "SetTrackingOffStatusResponse\"&\n$Subscrib"
-    "eTrackingPointCommandRequest\"Y\n\034Tracking"
-    "PointCommandResponse\0229\n\013track_point\030\001 \001("
-    "\0132$.mavsdk.rpc.camera_server.TrackPoint\""
-    "*\n(SubscribeTrackingRectangleCommandRequ"
-    "est\"e\n TrackingRectangleCommandResponse\022"
-    "A\n\017track_rectangle\030\001 \001(\0132(.mavsdk.rpc.ca"
-    "mera_server.TrackRectangle\"$\n\"SubscribeT"
-    "rackingOffCommandRequest\"+\n\032TrackingOffC"
-    "ommandResponse\022\r\n\005dummy\030\001 \001(\005\"k\n\"Respond"
-    "TrackingPointCommandRequest\022E\n\023stop_vide"
-    "o_feedback\030\001 \001(\0162(.mavsdk.rpc.camera_ser"
-    "ver.CameraFeedback\"q\n#RespondTrackingPoi"
-    "ntCommandResponse\022J\n\024camera_server_resul"
-    "t\030\001 \001(\0132,.mavsdk.rpc.camera_server.Camer"
-    "aServerResult\"o\n&RespondTrackingRectangl"
-    "eCommandRequest\022E\n\023stop_video_feedback\030\001"
-    " \001(\0162(.mavsdk.rpc.camera_server.CameraFe"
-    "edback\"u\n\'RespondTrackingRectangleComman"
+    "a_server.CameraServerResult\"\035\n\033Subscribe"
+    "FocusMetersRequest\"/\n\023FocusMetersRespons"
+    "e\022\030\n\020focus_distance_m\030\001 \001(\002\"d\n\031RespondFo"
+    "cusMetersRequest\022G\n\025focus_meters_feedbac"
+    "k\030\001 \001(\0162(.mavsdk.rpc.camera_server.Camer"
+    "aFeedback\"h\n\032RespondFocusMetersResponse\022"
+    "J\n\024camera_server_result\030\001 \001(\0132,.mavsdk.r"
+    "pc.camera_server.CameraServerResult\"\033\n\031S"
+    "ubscribeFocusAutoRequest\"%\n\021FocusAutoRes"
+    "ponse\022\020\n\010reserved\030\001 \001(\005\"`\n\027RespondFocusA"
+    "utoRequest\022E\n\023focus_auto_feedback\030\001 \001(\0162"
+    "(.mavsdk.rpc.camera_server.CameraFeedbac"
+    "k\"f\n\030RespondFocusAutoResponse\022J\n\024camera_"
+    "server_result\030\001 \001(\0132,.mavsdk.rpc.camera_"
+    "server.CameraServerResult\"!\n\037SubscribeFo"
+    "cusAutoSingleRequest\"+\n\027FocusAutoSingleR"
+    "esponse\022\020\n\010reserved\030\001 \001(\005\"m\n\035RespondFocu"
+    "sAutoSingleRequest\022L\n\032focus_auto_single_"
+    "feedback\030\001 \001(\0162(.mavsdk.rpc.camera_serve"
+    "r.CameraFeedback\"l\n\036RespondFocusAutoSing"
+    "leResponse\022J\n\024camera_server_result\030\001 \001(\013"
+    "2,.mavsdk.rpc.camera_server.CameraServer"
+    "Result\"%\n#SubscribeFocusAutoContinuousRe"
+    "quest\"/\n\033FocusAutoContinuousResponse\022\020\n\010"
+    "reserved\030\001 \001(\005\"u\n!RespondFocusAutoContin"
+    "uousRequest\022P\n\036focus_auto_continuous_fee"
+    "dback\030\001 \001(\0162(.mavsdk.rpc.camera_server.C"
+    "ameraFeedback\"p\n\"RespondFocusAutoContinu"
+    "ousResponse\022J\n\024camera_server_result\030\001 \001("
+    "\0132,.mavsdk.rpc.camera_server.CameraServe"
+    "rResult\"\214\003\n\013Information\022\023\n\013vendor_name\030\001"
+    " \001(\t\022\022\n\nmodel_name\030\002 \001(\t\022\030\n\020firmware_ver"
+    "sion\030\003 \001(\t\022\027\n\017focal_length_mm\030\004 \001(\002\022!\n\031h"
+    "orizontal_sensor_size_mm\030\005 \001(\002\022\037\n\027vertic"
+    "al_sensor_size_mm\030\006 \001(\002\022 \n\030horizontal_re"
+    "solution_px\030\007 \001(\r\022\036\n\026vertical_resolution"
+    "_px\030\010 \001(\r\022\017\n\007lens_id\030\t \001(\r\022\037\n\027definition"
+    "_file_version\030\n \001(\r\022\033\n\023definition_file_u"
+    "ri\030\013 \001(\t\022%\n\035image_in_video_mode_supporte"
+    "d\030\014 \001(\010\022%\n\035video_in_image_mode_supported"
+    "\030\r \001(\010\";\n\016VideoStreaming\022\027\n\017has_rtsp_ser"
+    "ver\030\001 \001(\010\022\020\n\010rtsp_uri\030\002 \001(\t\"q\n\010Position\022"
+    "\024\n\014latitude_deg\030\001 \001(\001\022\025\n\rlongitude_deg\030\002"
+    " \001(\001\022\033\n\023absolute_altitude_m\030\003 \001(\002\022\033\n\023rel"
+    "ative_altitude_m\030\004 \001(\002\"8\n\nQuaternion\022\t\n\001"
+    "w\030\001 \001(\002\022\t\n\001x\030\002 \001(\002\022\t\n\001y\030\003 \001(\002\022\t\n\001z\030\004 \001(\002"
+    "\"\320\001\n\013CaptureInfo\0224\n\010position\030\001 \001(\0132\".mav"
+    "sdk.rpc.camera_server.Position\022A\n\023attitu"
+    "de_quaternion\030\002 \001(\0132$.mavsdk.rpc.camera_"
+    "server.Quaternion\022\023\n\013time_utc_us\030\003 \001(\004\022\022"
+    "\n\nis_success\030\004 \001(\010\022\r\n\005index\030\005 \001(\005\022\020\n\010fil"
+    "e_url\030\006 \001(\t\"\263\002\n\022CameraServerResult\022C\n\006re"
+    "sult\030\001 \001(\01623.mavsdk.rpc.camera_server.Ca"
+    "meraServerResult.Result\022\022\n\nresult_str\030\002 "
+    "\001(\t\"\303\001\n\006Result\022\022\n\016RESULT_UNKNOWN\020\000\022\022\n\016RE"
+    "SULT_SUCCESS\020\001\022\026\n\022RESULT_IN_PROGRESS\020\002\022\017"
+    "\n\013RESULT_BUSY\020\003\022\021\n\rRESULT_DENIED\020\004\022\020\n\014RE"
+    "SULT_ERROR\020\005\022\022\n\016RESULT_TIMEOUT\020\006\022\031\n\025RESU"
+    "LT_WRONG_ARGUMENT\020\007\022\024\n\020RESULT_NO_SYSTEM\020"
+    "\010\"\214\005\n\022StorageInformation\022\030\n\020used_storage"
+    "_mib\030\001 \001(\002\022\035\n\025available_storage_mib\030\002 \001("
+    "\002\022\031\n\021total_storage_mib\030\003 \001(\002\022R\n\016storage_"
+    "status\030\004 \001(\0162:.mavsdk.rpc.camera_server."
+    "StorageInformation.StorageStatus\022\022\n\nstor"
+    "age_id\030\005 \001(\r\022N\n\014storage_type\030\006 \001(\01628.mav"
+    "sdk.rpc.camera_server.StorageInformation"
+    ".StorageType\022\030\n\020read_speed_mib_s\030\007 \001(\002\022\031"
+    "\n\021write_speed_mib_s\030\010 \001(\002\"\221\001\n\rStorageSta"
+    "tus\022 \n\034STORAGE_STATUS_NOT_AVAILABLE\020\000\022\036\n"
+    "\032STORAGE_STATUS_UNFORMATTED\020\001\022\034\n\030STORAGE"
+    "_STATUS_FORMATTED\020\002\022 \n\034STORAGE_STATUS_NO"
+    "T_SUPPORTED\020\003\"\240\001\n\013StorageType\022\030\n\024STORAGE"
+    "_TYPE_UNKNOWN\020\000\022\032\n\026STORAGE_TYPE_USB_STIC"
+    "K\020\001\022\023\n\017STORAGE_TYPE_SD\020\002\022\030\n\024STORAGE_TYPE"
+    "_MICROSD\020\003\022\023\n\017STORAGE_TYPE_HD\020\007\022\027\n\022STORA"
+    "GE_TYPE_OTHER\020\376\001\"\356\003\n\rCaptureStatus\022\030\n\020im"
+    "age_interval_s\030\001 \001(\002\022\030\n\020recording_time_s"
+    "\030\002 \001(\002\022\036\n\026available_capacity_mib\030\003 \001(\002\022I"
+    "\n\014image_status\030\004 \001(\01623.mavsdk.rpc.camera"
+    "_server.CaptureStatus.ImageStatus\022I\n\014vid"
+    "eo_status\030\005 \001(\01623.mavsdk.rpc.camera_serv"
+    "er.CaptureStatus.VideoStatus\022\023\n\013image_co"
+    "unt\030\006 \001(\005\"\221\001\n\013ImageStatus\022\025\n\021IMAGE_STATU"
+    "S_IDLE\020\000\022$\n IMAGE_STATUS_CAPTURE_IN_PROG"
+    "RESS\020\001\022\036\n\032IMAGE_STATUS_INTERVAL_IDLE\020\002\022%"
+    "\n!IMAGE_STATUS_INTERVAL_IN_PROGRESS\020\003\"J\n"
+    "\013VideoStatus\022\025\n\021VIDEO_STATUS_IDLE\020\000\022$\n V"
+    "IDEO_STATUS_CAPTURE_IN_PROGRESS\020\001\"\\\n\035Set"
+    "TrackingPointStatusRequest\022;\n\rtracked_po"
+    "int\030\001 \001(\0132$.mavsdk.rpc.camera_server.Tra"
+    "ckPoint\" \n\036SetTrackingPointStatusRespons"
+    "e\"h\n!SetTrackingRectangleStatusRequest\022C"
+    "\n\021tracked_rectangle\030\001 \001(\0132(.mavsdk.rpc.c"
+    "amera_server.TrackRectangle\"$\n\"SetTracki"
+    "ngRectangleStatusResponse\"\035\n\033SetTracking"
+    "OffStatusRequest\"\036\n\034SetTrackingOffStatus"
+    "Response\"&\n$SubscribeTrackingPointComman"
+    "dRequest\"Y\n\034TrackingPointCommandResponse"
+    "\0229\n\013track_point\030\001 \001(\0132$.mavsdk.rpc.camer"
+    "a_server.TrackPoint\"*\n(SubscribeTracking"
+    "RectangleCommandRequest\"e\n TrackingRecta"
+    "ngleCommandResponse\022A\n\017track_rectangle\030\001"
+    " \001(\0132(.mavsdk.rpc.camera_server.TrackRec"
+    "tangle\"$\n\"SubscribeTrackingOffCommandReq"
+    "uest\"+\n\032TrackingOffCommandResponse\022\r\n\005du"
+    "mmy\030\001 \001(\005\"k\n\"RespondTrackingPointCommand"
+    "Request\022E\n\023stop_video_feedback\030\001 \001(\0162(.m"
+    "avsdk.rpc.camera_server.CameraFeedback\"q"
+    "\n#RespondTrackingPointCommandResponse\022J\n"
+    "\024camera_server_result\030\001 \001(\0132,.mavsdk.rpc"
+    ".camera_server.CameraServerResult\"o\n&Res"
+    "pondTrackingRectangleCommandRequest\022E\n\023s"
+    "top_video_feedback\030\001 \001(\0162(.mavsdk.rpc.ca"
+    "mera_server.CameraFeedback\"u\n\'RespondTra"
+    "ckingRectangleCommandResponse\022J\n\024camera_"
+    "server_result\030\001 \001(\0132,.mavsdk.rpc.camera_"
+    "server.CameraServerResult\"i\n RespondTrac"
+    "kingOffCommandRequest\022E\n\023stop_video_feed"
+    "back\030\001 \001(\0162(.mavsdk.rpc.camera_server.Ca"
+    "meraFeedback\"o\n!RespondTrackingOffComman"
     "dResponse\022J\n\024camera_server_result\030\001 \001(\0132"
     ",.mavsdk.rpc.camera_server.CameraServerR"
-    "esult\"i\n RespondTrackingOffCommandReques"
-    "t\022E\n\023stop_video_feedback\030\001 \001(\0162(.mavsdk."
-    "rpc.camera_server.CameraFeedback\"o\n!Resp"
-    "ondTrackingOffCommandResponse\022J\n\024camera_"
-    "server_result\030\001 \001(\0132,.mavsdk.rpc.camera_"
-    "server.CameraServerResult\"J\n\022SetPosition"
-    "Request\0224\n\010position\030\001 \001(\0132\".mavsdk.rpc.c"
-    "amera_server.Position\"a\n\023SetPositionResp"
-    "onse\022J\n\024camera_server_result\030\001 \001(\0132,.mav"
-    "sdk.rpc.camera_server.CameraServerResult"
-    "\"a\n\034SetAttitudeQuaternionRequest\022A\n\023atti"
-    "tude_quaternion\030\001 \001(\0132$.mavsdk.rpc.camer"
-    "a_server.Quaternion\"k\n\035SetAttitudeQuater"
-    "nionResponse\022J\n\024camera_server_result\030\001 \001"
-    "(\0132,.mavsdk.rpc.camera_server.CameraServ"
-    "erResult\"+\n\024SetZoomFactorRequest\022\023\n\013zoom"
-    "_factor\030\001 \001(\002\"c\n\025SetZoomFactorResponse\022J"
-    "\n\024camera_server_result\030\001 \001(\0132,.mavsdk.rp"
-    "c.camera_server.CameraServerResult\"M\n\025Se"
-    "tFieldOfViewRequest\022\032\n\022horizontal_fov_de"
-    "g\030\001 \001(\002\022\030\n\020vertical_fov_deg\030\002 \001(\002\"d\n\026Set"
-    "FieldOfViewResponse\022J\n\024camera_server_res"
-    "ult\030\001 \001(\0132,.mavsdk.rpc.camera_server.Cam"
-    "eraServerResult\">\n\nTrackPoint\022\017\n\007point_x"
-    "\030\001 \001(\002\022\017\n\007point_y\030\002 \001(\002\022\016\n\006radius\030\003 \001(\002\""
-    "\204\001\n\016TrackRectangle\022\031\n\021top_left_corner_x\030"
-    "\001 \001(\002\022\031\n\021top_left_corner_y\030\002 \001(\002\022\035\n\025bott"
-    "om_right_corner_x\030\003 \001(\002\022\035\n\025bottom_right_"
-    "corner_y\030\004 \001(\002*{\n\016CameraFeedback\022\033\n\027CAME"
-    "RA_FEEDBACK_UNKNOWN\020\000\022\026\n\022CAMERA_FEEDBACK"
-    "_OK\020\001\022\030\n\024CAMERA_FEEDBACK_BUSY\020\002\022\032\n\026CAMER"
-    "A_FEEDBACK_FAILED\020\003*8\n\004Mode\022\020\n\014MODE_UNKN"
-    "OWN\020\000\022\016\n\nMODE_PHOTO\020\001\022\016\n\nMODE_VIDEO\020\0022\214<"
-    "\n\023CameraServerService\022y\n\016SetInformation\022"
-    "/.mavsdk.rpc.camera_server.SetInformatio"
-    "nRequest\0320.mavsdk.rpc.camera_server.SetI"
-    "nformationResponse\"\004\200\265\030\001\022\202\001\n\021SetVideoStr"
-    "eaming\0222.mavsdk.rpc.camera_server.SetVid"
-    "eoStreamingRequest\0323.mavsdk.rpc.camera_s"
-    "erver.SetVideoStreamingResponse\"\004\200\265\030\001\022v\n"
-    "\rSetInProgress\022..mavsdk.rpc.camera_serve"
-    "r.SetInProgressRequest\032/.mavsdk.rpc.came"
-    "ra_server.SetInProgressResponse\"\004\200\265\030\001\022~\n"
-    "\022SubscribeTakePhoto\0223.mavsdk.rpc.camera_"
-    "server.SubscribeTakePhotoRequest\032+.mavsd"
-    "k.rpc.camera_server.TakePhotoResponse\"\004\200"
-    "\265\030\0000\001\022\177\n\020RespondTakePhoto\0221.mavsdk.rpc.c"
-    "amera_server.RespondTakePhotoRequest\0322.m"
-    "avsdk.rpc.camera_server.RespondTakePhoto"
-    "Response\"\004\200\265\030\001\022\201\001\n\023SubscribeStartVideo\0224"
-    ".mavsdk.rpc.camera_server.SubscribeStart"
-    "VideoRequest\032,.mavsdk.rpc.camera_server."
-    "StartVideoResponse\"\004\200\265\030\0000\001\022\202\001\n\021RespondSt"
-    "artVideo\0222.mavsdk.rpc.camera_server.Resp"
-    "ondStartVideoRequest\0323.mavsdk.rpc.camera"
-    "_server.RespondStartVideoResponse\"\004\200\265\030\001\022"
-    "~\n\022SubscribeStopVideo\0223.mavsdk.rpc.camer"
-    "a_server.SubscribeStopVideoRequest\032+.mav"
-    "sdk.rpc.camera_server.StopVideoResponse\""
-    "\004\200\265\030\0000\001\022\177\n\020RespondStopVideo\0221.mavsdk.rpc"
-    ".camera_server.RespondStopVideoRequest\0322"
-    ".mavsdk.rpc.camera_server.RespondStopVid"
-    "eoResponse\"\004\200\265\030\001\022\234\001\n\034SubscribeStartVideo"
-    "Streaming\022=.mavsdk.rpc.camera_server.Sub"
-    "scribeStartVideoStreamingRequest\0325.mavsd"
-    "k.rpc.camera_server.StartVideoStreamingR"
-    "esponse\"\004\200\265\030\0000\001\022\235\001\n\032RespondStartVideoStr"
-    "eaming\022;.mavsdk.rpc.camera_server.Respon"
-    "dStartVideoStreamingRequest\032<.mavsdk.rpc"
-    ".camera_server.RespondStartVideoStreamin"
-    "gResponse\"\004\200\265\030\001\022\231\001\n\033SubscribeStopVideoSt"
-    "reaming\022<.mavsdk.rpc.camera_server.Subsc"
-    "ribeStopVideoStreamingRequest\0324.mavsdk.r"
-    "pc.camera_server.StopVideoStreamingRespo"
-    "nse\"\004\200\265\030\0000\001\022\232\001\n\031RespondStopVideoStreamin"
-    "g\022:.mavsdk.rpc.camera_server.RespondStop"
-    "VideoStreamingRequest\032;.mavsdk.rpc.camer"
-    "a_server.RespondStopVideoStreamingRespon"
-    "se\"\004\200\265\030\001\022x\n\020SubscribeSetMode\0221.mavsdk.rp"
-    "c.camera_server.SubscribeSetModeRequest\032"
-    ").mavsdk.rpc.camera_server.SetModeRespon"
-    "se\"\004\200\265\030\0000\001\022y\n\016RespondSetMode\022/.mavsdk.rp"
-    "c.camera_server.RespondSetModeRequest\0320."
-    "mavsdk.rpc.camera_server.RespondSetModeR"
-    "esponse\"\004\200\265\030\001\022\231\001\n\033SubscribeStorageInform"
-    "ation\022<.mavsdk.rpc.camera_server.Subscri"
-    "beStorageInformationRequest\0324.mavsdk.rpc"
-    ".camera_server.StorageInformationRespons"
-    "e\"\004\200\265\030\0000\001\022\232\001\n\031RespondStorageInformation\022"
-    ":.mavsdk.rpc.camera_server.RespondStorag"
-    "eInformationRequest\032;.mavsdk.rpc.camera_"
-    "server.RespondStorageInformationResponse"
-    "\"\004\200\265\030\001\022\212\001\n\026SubscribeCaptureStatus\0227.mavs"
-    "dk.rpc.camera_server.SubscribeCaptureSta"
-    "tusRequest\032/.mavsdk.rpc.camera_server.Ca"
-    "ptureStatusResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondC"
-    "aptureStatus\0225.mavsdk.rpc.camera_server."
-    "RespondCaptureStatusRequest\0326.mavsdk.rpc"
-    ".camera_server.RespondCaptureStatusRespo"
-    "nse\"\004\200\265\030\001\022\212\001\n\026SubscribeFormatStorage\0227.m"
-    "avsdk.rpc.camera_server.SubscribeFormatS"
-    "torageRequest\032/.mavsdk.rpc.camera_server"
-    ".FormatStorageResponse\"\004\200\265\030\0000\001\022\213\001\n\024Respo"
-    "ndFormatStorage\0225.mavsdk.rpc.camera_serv"
-    "er.RespondFormatStorageRequest\0326.mavsdk."
-    "rpc.camera_server.RespondFormatStorageRe"
-    "sponse\"\004\200\265\030\001\022\212\001\n\026SubscribeResetSettings\022"
-    "7.mavsdk.rpc.camera_server.SubscribeRese"
-    "tSettingsRequest\032/.mavsdk.rpc.camera_ser"
-    "ver.ResetSettingsResponse\"\004\200\265\030\0000\001\022\213\001\n\024Re"
-    "spondResetSettings\0225.mavsdk.rpc.camera_s"
-    "erver.RespondResetSettingsRequest\0326.mavs"
-    "dk.rpc.camera_server.RespondResetSetting"
-    "sResponse\"\004\200\265\030\001\022\204\001\n\024SubscribeZoomInStart"
-    "\0225.mavsdk.rpc.camera_server.SubscribeZoo"
-    "mInStartRequest\032-.mavsdk.rpc.camera_serv"
-    "er.ZoomInStartResponse\"\004\200\265\030\0000\001\022\205\001\n\022Respo"
-    "ndZoomInStart\0223.mavsdk.rpc.camera_server"
-    ".RespondZoomInStartRequest\0324.mavsdk.rpc."
-    "camera_server.RespondZoomInStartResponse"
-    "\"\004\200\265\030\001\022\207\001\n\025SubscribeZoomOutStart\0226.mavsd"
-    "k.rpc.camera_server.SubscribeZoomOutStar"
-    "tRequest\032..mavsdk.rpc.camera_server.Zoom"
-    "OutStartResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondZoom"
-    "OutStart\0224.mavsdk.rpc.camera_server.Resp"
-    "ondZoomOutStartRequest\0325.mavsdk.rpc.came"
-    "ra_server.RespondZoomOutStartResponse\"\004\200"
-    "\265\030\001\022{\n\021SubscribeZoomStop\0222.mavsdk.rpc.ca"
-    "mera_server.SubscribeZoomStopRequest\032*.m"
-    "avsdk.rpc.camera_server.ZoomStopResponse"
-    "\"\004\200\265\030\0000\001\022|\n\017RespondZoomStop\0220.mavsdk.rpc"
-    ".camera_server.RespondZoomStopRequest\0321."
-    "mavsdk.rpc.camera_server.RespondZoomStop"
-    "Response\"\004\200\265\030\001\022~\n\022SubscribeZoomRange\0223.m"
-    "avsdk.rpc.camera_server.SubscribeZoomRan"
-    "geRequest\032+.mavsdk.rpc.camera_server.Zoo"
-    "mRangeResponse\"\004\200\265\030\0000\001\022\177\n\020RespondZoomRan"
-    "ge\0221.mavsdk.rpc.camera_server.RespondZoo"
-    "mRangeRequest\0322.mavsdk.rpc.camera_server"
-    ".RespondZoomRangeResponse\"\004\200\265\030\001\022\204\001\n\024Subs"
-    "cribeFocusInStep\0225.mavsdk.rpc.camera_ser"
-    "ver.SubscribeFocusInStepRequest\032-.mavsdk"
-    ".rpc.camera_server.FocusInStepResponse\"\004"
-    "\200\265\030\0000\001\022\205\001\n\022RespondFocusInStep\0223.mavsdk.r"
-    "pc.camera_server.RespondFocusInStepReque"
-    "st\0324.mavsdk.rpc.camera_server.RespondFoc"
-    "usInStepResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeFocu"
-    "sOutStep\0226.mavsdk.rpc.camera_server.Subs"
-    "cribeFocusOutStepRequest\032..mavsdk.rpc.ca"
-    "mera_server.FocusOutStepResponse\"\004\200\265\030\0000\001"
-    "\022\210\001\n\023RespondFocusOutStep\0224.mavsdk.rpc.ca"
-    "mera_server.RespondFocusOutStepRequest\0325"
-    ".mavsdk.rpc.camera_server.RespondFocusOu"
-    "tStepResponse\"\004\200\265\030\001\022\207\001\n\025SubscribeFocusIn"
-    "Start\0226.mavsdk.rpc.camera_server.Subscri"
-    "beFocusInStartRequest\032..mavsdk.rpc.camer"
-    "a_server.FocusInStartResponse\"\004\200\265\030\0000\001\022\210\001"
-    "\n\023RespondFocusInStart\0224.mavsdk.rpc.camer"
-    "a_server.RespondFocusInStartRequest\0325.ma"
-    "vsdk.rpc.camera_server.RespondFocusInSta"
-    "rtResponse\"\004\200\265\030\001\022\212\001\n\026SubscribeFocusOutSt"
-    "art\0227.mavsdk.rpc.camera_server.Subscribe"
-    "FocusOutStartRequest\032/.mavsdk.rpc.camera"
-    "_server.FocusOutStartResponse\"\004\200\265\030\0000\001\022\213\001"
-    "\n\024RespondFocusOutStart\0225.mavsdk.rpc.came"
-    "ra_server.RespondFocusOutStartRequest\0326."
-    "mavsdk.rpc.camera_server.RespondFocusOut"
-    "StartResponse\"\004\200\265\030\001\022~\n\022SubscribeFocusSto"
-    "p\0223.mavsdk.rpc.camera_server.SubscribeFo"
-    "cusStopRequest\032+.mavsdk.rpc.camera_serve"
-    "r.FocusStopResponse\"\004\200\265\030\0000\001\022\177\n\020RespondFo"
-    "cusStop\0221.mavsdk.rpc.camera_server.Respo"
-    "ndFocusStopRequest\0322.mavsdk.rpc.camera_s"
-    "erver.RespondFocusStopResponse\"\004\200\265\030\001\022\201\001\n"
-    "\023SubscribeFocusRange\0224.mavsdk.rpc.camera"
-    "_server.SubscribeFocusRangeRequest\032,.mav"
-    "sdk.rpc.camera_server.FocusRangeResponse"
-    "\"\004\200\265\030\0000\001\022\202\001\n\021RespondFocusRange\0222.mavsdk."
-    "rpc.camera_server.RespondFocusRangeReque"
-    "st\0323.mavsdk.rpc.camera_server.RespondFoc"
-    "usRangeResponse\"\004\200\265\030\001\022\235\001\n\032SetTrackingRec"
-    "tangleStatus\022;.mavsdk.rpc.camera_server."
-    "SetTrackingRectangleStatusRequest\032<.mavs"
-    "dk.rpc.camera_server.SetTrackingRectangl"
-    "eStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTrackingOff"
-    "Status\0225.mavsdk.rpc.camera_server.SetTra"
-    "ckingOffStatusRequest\0326.mavsdk.rpc.camer"
-    "a_server.SetTrackingOffStatusResponse\"\004\200"
-    "\265\030\001\022\237\001\n\035SubscribeTrackingPointCommand\022>."
-    "mavsdk.rpc.camera_server.SubscribeTracki"
-    "ngPointCommandRequest\0326.mavsdk.rpc.camer"
-    "a_server.TrackingPointCommandResponse\"\004\200"
-    "\265\030\0000\001\022\253\001\n!SubscribeTrackingRectangleComm"
-    "and\022B.mavsdk.rpc.camera_server.Subscribe"
-    "TrackingRectangleCommandRequest\032:.mavsdk"
-    ".rpc.camera_server.TrackingRectangleComm"
-    "andResponse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrackin"
-    "gOffCommand\022<.mavsdk.rpc.camera_server.S"
-    "ubscribeTrackingOffCommandRequest\0324.mavs"
-    "dk.rpc.camera_server.TrackingOffCommandR"
-    "esponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPoint"
-    "Command\022<.mavsdk.rpc.camera_server.Respo"
-    "ndTrackingPointCommandRequest\032=.mavsdk.r"
-    "pc.camera_server.RespondTrackingPointCom"
-    "mandResponse\"\004\200\265\030\001\022\254\001\n\037RespondTrackingRe"
-    "ctangleCommand\022@.mavsdk.rpc.camera_serve"
-    "r.RespondTrackingRectangleCommandRequest"
-    "\032A.mavsdk.rpc.camera_server.RespondTrack"
-    "ingRectangleCommandResponse\"\004\200\265\030\001\022\232\001\n\031Re"
-    "spondTrackingOffCommand\022:.mavsdk.rpc.cam"
-    "era_server.RespondTrackingOffCommandRequ"
-    "est\032;.mavsdk.rpc.camera_server.RespondTr"
-    "ackingOffCommandResponse\"\004\200\265\030\001\022p\n\013SetPos"
-    "ition\022,.mavsdk.rpc.camera_server.SetPosi"
-    "tionRequest\032-.mavsdk.rpc.camera_server.S"
-    "etPositionResponse\"\004\200\265\030\001\022\216\001\n\025SetAttitude"
-    "Quaternion\0226.mavsdk.rpc.camera_server.Se"
-    "tAttitudeQuaternionRequest\0327.mavsdk.rpc."
-    "camera_server.SetAttitudeQuaternionRespo"
-    "nse\"\004\200\265\030\001\022v\n\rSetZoomFactor\022..mavsdk.rpc."
-    "camera_server.SetZoomFactorRequest\032/.mav"
-    "sdk.rpc.camera_server.SetZoomFactorRespo"
-    "nse\"\004\200\265\030\001\022y\n\016SetFieldOfView\022/.mavsdk.rpc"
-    ".camera_server.SetFieldOfViewRequest\0320.m"
-    "avsdk.rpc.camera_server.SetFieldOfViewRe"
-    "sponse\"\004\200\265\030\001B,\n\027io.mavsdk.camera_serverB"
-    "\021CameraServerProtob\006proto3"
+    "esult\"J\n\022SetPositionRequest\0224\n\010position\030"
+    "\001 \001(\0132\".mavsdk.rpc.camera_server.Positio"
+    "n\"a\n\023SetPositionResponse\022J\n\024camera_serve"
+    "r_result\030\001 \001(\0132,.mavsdk.rpc.camera_serve"
+    "r.CameraServerResult\"a\n\034SetAttitudeQuate"
+    "rnionRequest\022A\n\023attitude_quaternion\030\001 \001("
+    "\0132$.mavsdk.rpc.camera_server.Quaternion\""
+    "k\n\035SetAttitudeQuaternionResponse\022J\n\024came"
+    "ra_server_result\030\001 \001(\0132,.mavsdk.rpc.came"
+    "ra_server.CameraServerResult\"+\n\024SetZoomF"
+    "actorRequest\022\023\n\013zoom_factor\030\001 \001(\002\"c\n\025Set"
+    "ZoomFactorResponse\022J\n\024camera_server_resu"
+    "lt\030\001 \001(\0132,.mavsdk.rpc.camera_server.Came"
+    "raServerResult\"M\n\025SetFieldOfViewRequest\022"
+    "\032\n\022horizontal_fov_deg\030\001 \001(\002\022\030\n\020vertical_"
+    "fov_deg\030\002 \001(\002\"d\n\026SetFieldOfViewResponse\022"
+    "J\n\024camera_server_result\030\001 \001(\0132,.mavsdk.r"
+    "pc.camera_server.CameraServerResult\">\n\nT"
+    "rackPoint\022\017\n\007point_x\030\001 \001(\002\022\017\n\007point_y\030\002 "
+    "\001(\002\022\016\n\006radius\030\003 \001(\002\"\204\001\n\016TrackRectangle\022\031"
+    "\n\021top_left_corner_x\030\001 \001(\002\022\031\n\021top_left_co"
+    "rner_y\030\002 \001(\002\022\035\n\025bottom_right_corner_x\030\003 "
+    "\001(\002\022\035\n\025bottom_right_corner_y\030\004 \001(\002*{\n\016Ca"
+    "meraFeedback\022\033\n\027CAMERA_FEEDBACK_UNKNOWN\020"
+    "\000\022\026\n\022CAMERA_FEEDBACK_OK\020\001\022\030\n\024CAMERA_FEED"
+    "BACK_BUSY\020\002\022\032\n\026CAMERA_FEEDBACK_FAILED\020\003*"
+    "8\n\004Mode\022\020\n\014MODE_UNKNOWN\020\000\022\016\n\nMODE_PHOTO\020"
+    "\001\022\016\n\nMODE_VIDEO\020\0022\202E\n\023CameraServerServic"
+    "e\022y\n\016SetInformation\022/.mavsdk.rpc.camera_"
+    "server.SetInformationRequest\0320.mavsdk.rp"
+    "c.camera_server.SetInformationResponse\"\004"
+    "\200\265\030\001\022\202\001\n\021SetVideoStreaming\0222.mavsdk.rpc."
+    "camera_server.SetVideoStreamingRequest\0323"
+    ".mavsdk.rpc.camera_server.SetVideoStream"
+    "ingResponse\"\004\200\265\030\001\022v\n\rSetInProgress\022..mav"
+    "sdk.rpc.camera_server.SetInProgressReque"
+    "st\032/.mavsdk.rpc.camera_server.SetInProgr"
+    "essResponse\"\004\200\265\030\001\022~\n\022SubscribeTakePhoto\022"
+    "3.mavsdk.rpc.camera_server.SubscribeTake"
+    "PhotoRequest\032+.mavsdk.rpc.camera_server."
+    "TakePhotoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondTake"
+    "Photo\0221.mavsdk.rpc.camera_server.Respond"
+    "TakePhotoRequest\0322.mavsdk.rpc.camera_ser"
+    "ver.RespondTakePhotoResponse\"\004\200\265\030\001\022\201\001\n\023S"
+    "ubscribeStartVideo\0224.mavsdk.rpc.camera_s"
+    "erver.SubscribeStartVideoRequest\032,.mavsd"
+    "k.rpc.camera_server.StartVideoResponse\"\004"
+    "\200\265\030\0000\001\022\202\001\n\021RespondStartVideo\0222.mavsdk.rp"
+    "c.camera_server.RespondStartVideoRequest"
+    "\0323.mavsdk.rpc.camera_server.RespondStart"
+    "VideoResponse\"\004\200\265\030\001\022~\n\022SubscribeStopVide"
+    "o\0223.mavsdk.rpc.camera_server.SubscribeSt"
+    "opVideoRequest\032+.mavsdk.rpc.camera_serve"
+    "r.StopVideoResponse\"\004\200\265\030\0000\001\022\177\n\020RespondSt"
+    "opVideo\0221.mavsdk.rpc.camera_server.Respo"
+    "ndStopVideoRequest\0322.mavsdk.rpc.camera_s"
+    "erver.RespondStopVideoResponse\"\004\200\265\030\001\022\234\001\n"
+    "\034SubscribeStartVideoStreaming\022=.mavsdk.r"
+    "pc.camera_server.SubscribeStartVideoStre"
+    "amingRequest\0325.mavsdk.rpc.camera_server."
+    "StartVideoStreamingResponse\"\004\200\265\030\0000\001\022\235\001\n\032"
+    "RespondStartVideoStreaming\022;.mavsdk.rpc."
+    "camera_server.RespondStartVideoStreaming"
+    "Request\032<.mavsdk.rpc.camera_server.Respo"
+    "ndStartVideoStreamingResponse\"\004\200\265\030\001\022\231\001\n\033"
+    "SubscribeStopVideoStreaming\022<.mavsdk.rpc"
+    ".camera_server.SubscribeStopVideoStreami"
+    "ngRequest\0324.mavsdk.rpc.camera_server.Sto"
+    "pVideoStreamingResponse\"\004\200\265\030\0000\001\022\232\001\n\031Resp"
+    "ondStopVideoStreaming\022:.mavsdk.rpc.camer"
+    "a_server.RespondStopVideoStreamingReques"
+    "t\032;.mavsdk.rpc.camera_server.RespondStop"
+    "VideoStreamingResponse\"\004\200\265\030\001\022x\n\020Subscrib"
+    "eSetMode\0221.mavsdk.rpc.camera_server.Subs"
+    "cribeSetModeRequest\032).mavsdk.rpc.camera_"
+    "server.SetModeResponse\"\004\200\265\030\0000\001\022y\n\016Respon"
+    "dSetMode\022/.mavsdk.rpc.camera_server.Resp"
+    "ondSetModeRequest\0320.mavsdk.rpc.camera_se"
+    "rver.RespondSetModeResponse\"\004\200\265\030\001\022\231\001\n\033Su"
+    "bscribeStorageInformation\022<.mavsdk.rpc.c"
+    "amera_server.SubscribeStorageInformation"
+    "Request\0324.mavsdk.rpc.camera_server.Stora"
+    "geInformationResponse\"\004\200\265\030\0000\001\022\232\001\n\031Respon"
+    "dStorageInformation\022:.mavsdk.rpc.camera_"
+    "server.RespondStorageInformationRequest\032"
+    ";.mavsdk.rpc.camera_server.RespondStorag"
+    "eInformationResponse\"\004\200\265\030\001\022\212\001\n\026Subscribe"
+    "CaptureStatus\0227.mavsdk.rpc.camera_server"
+    ".SubscribeCaptureStatusRequest\032/.mavsdk."
+    "rpc.camera_server.CaptureStatusResponse\""
+    "\004\200\265\030\0000\001\022\213\001\n\024RespondCaptureStatus\0225.mavsd"
+    "k.rpc.camera_server.RespondCaptureStatus"
+    "Request\0326.mavsdk.rpc.camera_server.Respo"
+    "ndCaptureStatusResponse\"\004\200\265\030\001\022\212\001\n\026Subscr"
+    "ibeFormatStorage\0227.mavsdk.rpc.camera_ser"
+    "ver.SubscribeFormatStorageRequest\032/.mavs"
+    "dk.rpc.camera_server.FormatStorageRespon"
+    "se\"\004\200\265\030\0000\001\022\213\001\n\024RespondFormatStorage\0225.ma"
+    "vsdk.rpc.camera_server.RespondFormatStor"
+    "ageRequest\0326.mavsdk.rpc.camera_server.Re"
+    "spondFormatStorageResponse\"\004\200\265\030\001\022\212\001\n\026Sub"
+    "scribeResetSettings\0227.mavsdk.rpc.camera_"
+    "server.SubscribeResetSettingsRequest\032/.m"
+    "avsdk.rpc.camera_server.ResetSettingsRes"
+    "ponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondResetSettings\0225"
+    ".mavsdk.rpc.camera_server.RespondResetSe"
+    "ttingsRequest\0326.mavsdk.rpc.camera_server"
+    ".RespondResetSettingsResponse\"\004\200\265\030\001\022\204\001\n\024"
+    "SubscribeZoomInStart\0225.mavsdk.rpc.camera"
+    "_server.SubscribeZoomInStartRequest\032-.ma"
+    "vsdk.rpc.camera_server.ZoomInStartRespon"
+    "se\"\004\200\265\030\0000\001\022\205\001\n\022RespondZoomInStart\0223.mavs"
+    "dk.rpc.camera_server.RespondZoomInStartR"
+    "equest\0324.mavsdk.rpc.camera_server.Respon"
+    "dZoomInStartResponse\"\004\200\265\030\001\022\207\001\n\025Subscribe"
+    "ZoomOutStart\0226.mavsdk.rpc.camera_server."
+    "SubscribeZoomOutStartRequest\032..mavsdk.rp"
+    "c.camera_server.ZoomOutStartResponse\"\004\200\265"
+    "\030\0000\001\022\210\001\n\023RespondZoomOutStart\0224.mavsdk.rp"
+    "c.camera_server.RespondZoomOutStartReque"
+    "st\0325.mavsdk.rpc.camera_server.RespondZoo"
+    "mOutStartResponse\"\004\200\265\030\001\022{\n\021SubscribeZoom"
+    "Stop\0222.mavsdk.rpc.camera_server.Subscrib"
+    "eZoomStopRequest\032*.mavsdk.rpc.camera_ser"
+    "ver.ZoomStopResponse\"\004\200\265\030\0000\001\022|\n\017RespondZ"
+    "oomStop\0220.mavsdk.rpc.camera_server.Respo"
+    "ndZoomStopRequest\0321.mavsdk.rpc.camera_se"
+    "rver.RespondZoomStopResponse\"\004\200\265\030\001\022~\n\022Su"
+    "bscribeZoomRange\0223.mavsdk.rpc.camera_ser"
+    "ver.SubscribeZoomRangeRequest\032+.mavsdk.r"
+    "pc.camera_server.ZoomRangeResponse\"\004\200\265\030\000"
+    "0\001\022\177\n\020RespondZoomRange\0221.mavsdk.rpc.came"
+    "ra_server.RespondZoomRangeRequest\0322.mavs"
+    "dk.rpc.camera_server.RespondZoomRangeRes"
+    "ponse\"\004\200\265\030\001\022\204\001\n\024SubscribeFocusInStep\0225.m"
+    "avsdk.rpc.camera_server.SubscribeFocusIn"
+    "StepRequest\032-.mavsdk.rpc.camera_server.F"
+    "ocusInStepResponse\"\004\200\265\030\0000\001\022\205\001\n\022RespondFo"
+    "cusInStep\0223.mavsdk.rpc.camera_server.Res"
+    "pondFocusInStepRequest\0324.mavsdk.rpc.came"
+    "ra_server.RespondFocusInStepResponse\"\004\200\265"
+    "\030\001\022\207\001\n\025SubscribeFocusOutStep\0226.mavsdk.rp"
+    "c.camera_server.SubscribeFocusOutStepReq"
+    "uest\032..mavsdk.rpc.camera_server.FocusOut"
+    "StepResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondFocusOut"
+    "Step\0224.mavsdk.rpc.camera_server.RespondF"
+    "ocusOutStepRequest\0325.mavsdk.rpc.camera_s"
+    "erver.RespondFocusOutStepResponse\"\004\200\265\030\001\022"
+    "\207\001\n\025SubscribeFocusInStart\0226.mavsdk.rpc.c"
+    "amera_server.SubscribeFocusInStartReques"
+    "t\032..mavsdk.rpc.camera_server.FocusInStar"
+    "tResponse\"\004\200\265\030\0000\001\022\210\001\n\023RespondFocusInStar"
+    "t\0224.mavsdk.rpc.camera_server.RespondFocu"
+    "sInStartRequest\0325.mavsdk.rpc.camera_serv"
+    "er.RespondFocusInStartResponse\"\004\200\265\030\001\022\212\001\n"
+    "\026SubscribeFocusOutStart\0227.mavsdk.rpc.cam"
+    "era_server.SubscribeFocusOutStartRequest"
+    "\032/.mavsdk.rpc.camera_server.FocusOutStar"
+    "tResponse\"\004\200\265\030\0000\001\022\213\001\n\024RespondFocusOutSta"
+    "rt\0225.mavsdk.rpc.camera_server.RespondFoc"
+    "usOutStartRequest\0326.mavsdk.rpc.camera_se"
+    "rver.RespondFocusOutStartResponse\"\004\200\265\030\001\022"
+    "~\n\022SubscribeFocusStop\0223.mavsdk.rpc.camer"
+    "a_server.SubscribeFocusStopRequest\032+.mav"
+    "sdk.rpc.camera_server.FocusStopResponse\""
+    "\004\200\265\030\0000\001\022\177\n\020RespondFocusStop\0221.mavsdk.rpc"
+    ".camera_server.RespondFocusStopRequest\0322"
+    ".mavsdk.rpc.camera_server.RespondFocusSt"
+    "opResponse\"\004\200\265\030\001\022\201\001\n\023SubscribeFocusRange"
+    "\0224.mavsdk.rpc.camera_server.SubscribeFoc"
+    "usRangeRequest\032,.mavsdk.rpc.camera_serve"
+    "r.FocusRangeResponse\"\004\200\265\030\0000\001\022\202\001\n\021Respond"
+    "FocusRange\0222.mavsdk.rpc.camera_server.Re"
+    "spondFocusRangeRequest\0323.mavsdk.rpc.came"
+    "ra_server.RespondFocusRangeResponse\"\004\200\265\030"
+    "\001\022\204\001\n\024SubscribeFocusMeters\0225.mavsdk.rpc."
+    "camera_server.SubscribeFocusMetersReques"
+    "t\032-.mavsdk.rpc.camera_server.FocusMeters"
+    "Response\"\004\200\265\030\0000\001\022\205\001\n\022RespondFocusMeters\022"
+    "3.mavsdk.rpc.camera_server.RespondFocusM"
+    "etersRequest\0324.mavsdk.rpc.camera_server."
+    "RespondFocusMetersResponse\"\004\200\265\030\001\022~\n\022Subs"
+    "cribeFocusAuto\0223.mavsdk.rpc.camera_serve"
+    "r.SubscribeFocusAutoRequest\032+.mavsdk.rpc"
+    ".camera_server.FocusAutoResponse\"\004\200\265\030\0000\001"
+    "\022\177\n\020RespondFocusAuto\0221.mavsdk.rpc.camera"
+    "_server.RespondFocusAutoRequest\0322.mavsdk"
+    ".rpc.camera_server.RespondFocusAutoRespo"
+    "nse\"\004\200\265\030\001\022\220\001\n\030SubscribeFocusAutoSingle\0229"
+    ".mavsdk.rpc.camera_server.SubscribeFocus"
+    "AutoSingleRequest\0321.mavsdk.rpc.camera_se"
+    "rver.FocusAutoSingleResponse\"\004\200\265\030\0000\001\022\221\001\n"
+    "\026RespondFocusAutoSingle\0227.mavsdk.rpc.cam"
+    "era_server.RespondFocusAutoSingleRequest"
+    "\0328.mavsdk.rpc.camera_server.RespondFocus"
+    "AutoSingleResponse\"\004\200\265\030\001\022\234\001\n\034SubscribeFo"
+    "cusAutoContinuous\022=.mavsdk.rpc.camera_se"
+    "rver.SubscribeFocusAutoContinuousRequest"
+    "\0325.mavsdk.rpc.camera_server.FocusAutoCon"
+    "tinuousResponse\"\004\200\265\030\0000\001\022\235\001\n\032RespondFocus"
+    "AutoContinuous\022;.mavsdk.rpc.camera_serve"
+    "r.RespondFocusAutoContinuousRequest\032<.ma"
+    "vsdk.rpc.camera_server.RespondFocusAutoC"
+    "ontinuousResponse\"\004\200\265\030\001\022\235\001\n\032SetTrackingR"
+    "ectangleStatus\022;.mavsdk.rpc.camera_serve"
+    "r.SetTrackingRectangleStatusRequest\032<.ma"
+    "vsdk.rpc.camera_server.SetTrackingRectan"
+    "gleStatusResponse\"\004\200\265\030\001\022\213\001\n\024SetTrackingO"
+    "ffStatus\0225.mavsdk.rpc.camera_server.SetT"
+    "rackingOffStatusRequest\0326.mavsdk.rpc.cam"
+    "era_server.SetTrackingOffStatusResponse\""
+    "\004\200\265\030\001\022\237\001\n\035SubscribeTrackingPointCommand\022"
+    ">.mavsdk.rpc.camera_server.SubscribeTrac"
+    "kingPointCommandRequest\0326.mavsdk.rpc.cam"
+    "era_server.TrackingPointCommandResponse\""
+    "\004\200\265\030\0000\001\022\253\001\n!SubscribeTrackingRectangleCo"
+    "mmand\022B.mavsdk.rpc.camera_server.Subscri"
+    "beTrackingRectangleCommandRequest\032:.mavs"
+    "dk.rpc.camera_server.TrackingRectangleCo"
+    "mmandResponse\"\004\200\265\030\0000\001\022\231\001\n\033SubscribeTrack"
+    "ingOffCommand\022<.mavsdk.rpc.camera_server"
+    ".SubscribeTrackingOffCommandRequest\0324.ma"
+    "vsdk.rpc.camera_server.TrackingOffComman"
+    "dResponse\"\004\200\265\030\0000\001\022\240\001\n\033RespondTrackingPoi"
+    "ntCommand\022<.mavsdk.rpc.camera_server.Res"
+    "pondTrackingPointCommandRequest\032=.mavsdk"
+    ".rpc.camera_server.RespondTrackingPointC"
+    "ommandResponse\"\004\200\265\030\001\022\254\001\n\037RespondTracking"
+    "RectangleCommand\022@.mavsdk.rpc.camera_ser"
+    "ver.RespondTrackingRectangleCommandReque"
+    "st\032A.mavsdk.rpc.camera_server.RespondTra"
+    "ckingRectangleCommandResponse\"\004\200\265\030\001\022\232\001\n\031"
+    "RespondTrackingOffCommand\022:.mavsdk.rpc.c"
+    "amera_server.RespondTrackingOffCommandRe"
+    "quest\032;.mavsdk.rpc.camera_server.Respond"
+    "TrackingOffCommandResponse\"\004\200\265\030\001\022p\n\013SetP"
+    "osition\022,.mavsdk.rpc.camera_server.SetPo"
+    "sitionRequest\032-.mavsdk.rpc.camera_server"
+    ".SetPositionResponse\"\004\200\265\030\001\022\216\001\n\025SetAttitu"
+    "deQuaternion\0226.mavsdk.rpc.camera_server."
+    "SetAttitudeQuaternionRequest\0327.mavsdk.rp"
+    "c.camera_server.SetAttitudeQuaternionRes"
+    "ponse\"\004\200\265\030\001\022v\n\rSetZoomFactor\022..mavsdk.rp"
+    "c.camera_server.SetZoomFactorRequest\032/.m"
+    "avsdk.rpc.camera_server.SetZoomFactorRes"
+    "ponse\"\004\200\265\030\001\022y\n\016SetFieldOfView\022/.mavsdk.r"
+    "pc.camera_server.SetFieldOfViewRequest\0320"
+    ".mavsdk.rpc.camera_server.SetFieldOfView"
+    "Response\"\004\200\265\030\001B,\n\027io.mavsdk.camera_serve"
+    "rB\021CameraServerProtob\006proto3"
 };
 static const ::_pbi::DescriptorTable* const descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps[1] =
     {
@@ -4863,13 +5469,13 @@ static ::absl::once_flag descriptor_table_camera_5fserver_2fcamera_5fserver_2epr
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto = {
     false,
     false,
-    19066,
+    21388,
     descriptor_table_protodef_camera_5fserver_2fcamera_5fserver_2eproto,
     "camera_server/camera_server.proto",
     &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_once,
     descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto_deps,
     1,
-    122,
+    138,
     schemas,
     file_default_instances,
     TableStruct_camera_5fserver_2fcamera_5fserver_2eproto::offsets,
@@ -22041,6 +22647,3073 @@ void RespondFocusRangeResponse::InternalSwap(RespondFocusRangeResponse* PROTOBUF
 }
 
 ::google::protobuf::Metadata RespondFocusRangeResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusMetersRequest::_Internal {
+ public:
+};
+
+SubscribeFocusMetersRequest::SubscribeFocusMetersRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusMetersRequest)
+}
+SubscribeFocusMetersRequest::SubscribeFocusMetersRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusMetersRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusMetersRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusMetersRequest)
+}
+
+inline void* SubscribeFocusMetersRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusMetersRequest(arena);
+}
+constexpr auto SubscribeFocusMetersRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusMetersRequest),
+                                            alignof(SubscribeFocusMetersRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusMetersRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusMetersRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusMetersRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusMetersRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusMetersRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusMetersRequest>(), &SubscribeFocusMetersRequest::ByteSizeLong,
+            &SubscribeFocusMetersRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusMetersRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusMetersRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusMetersRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusMetersRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusMetersRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusMetersRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusMetersResponse::_Internal {
+ public:
+};
+
+FocusMetersResponse::FocusMetersResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusMetersResponse)
+}
+FocusMetersResponse::FocusMetersResponse(
+    ::google::protobuf::Arena* arena, const FocusMetersResponse& from)
+    : FocusMetersResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusMetersResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusMetersResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_distance_m_ = {};
+}
+FocusMetersResponse::~FocusMetersResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusMetersResponse)
+  SharedDtor(*this);
+}
+inline void FocusMetersResponse::SharedDtor(MessageLite& self) {
+  FocusMetersResponse& this_ = static_cast<FocusMetersResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusMetersResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusMetersResponse(arena);
+}
+constexpr auto FocusMetersResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusMetersResponse),
+                                            alignof(FocusMetersResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusMetersResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusMetersResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusMetersResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusMetersResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusMetersResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusMetersResponse>(), &FocusMetersResponse::ByteSizeLong,
+            &FocusMetersResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusMetersResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusMetersResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusMetersResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusMetersResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // float focus_distance_m = 1;
+    {::_pbi::TcParser::FastF32S1,
+     {13, 63, 0, PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_.focus_distance_m_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // float focus_distance_m = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusMetersResponse, _impl_.focus_distance_m_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusMetersResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusMetersResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_distance_m_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusMetersResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusMetersResponse& this_ = static_cast<const FocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusMetersResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusMetersResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // float focus_distance_m = 1;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_focus_distance_m()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                1, this_._internal_focus_distance_m(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusMetersResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusMetersResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusMetersResponse& this_ = static_cast<const FocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusMetersResponse::ByteSizeLong() const {
+          const FocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusMetersResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // float focus_distance_m = 1;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_focus_distance_m()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusMetersResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusMetersResponse*>(&to_msg);
+  auto& from = static_cast<const FocusMetersResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusMetersResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (::absl::bit_cast<::uint32_t>(from._internal_focus_distance_m()) != 0) {
+    _this->_impl_.focus_distance_m_ = from._impl_.focus_distance_m_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusMetersResponse::CopyFrom(const FocusMetersResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusMetersResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusMetersResponse::InternalSwap(FocusMetersResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.focus_distance_m_, other->_impl_.focus_distance_m_);
+}
+
+::google::protobuf::Metadata FocusMetersResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusMetersRequest::_Internal {
+ public:
+};
+
+RespondFocusMetersRequest::RespondFocusMetersRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+}
+RespondFocusMetersRequest::RespondFocusMetersRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusMetersRequest& from)
+    : RespondFocusMetersRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusMetersRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusMetersRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_meters_feedback_ = {};
+}
+RespondFocusMetersRequest::~RespondFocusMetersRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusMetersRequest::SharedDtor(MessageLite& self) {
+  RespondFocusMetersRequest& this_ = static_cast<RespondFocusMetersRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusMetersRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusMetersRequest(arena);
+}
+constexpr auto RespondFocusMetersRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusMetersRequest),
+                                            alignof(RespondFocusMetersRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusMetersRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusMetersRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusMetersRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusMetersRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusMetersRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusMetersRequest>(), &RespondFocusMetersRequest::ByteSizeLong,
+            &RespondFocusMetersRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusMetersRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusMetersRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusMetersRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusMetersRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusMetersRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusMetersRequest, _impl_.focus_meters_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusMetersRequest, _impl_.focus_meters_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusMetersRequest, _impl_.focus_meters_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusMetersRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_meters_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusMetersRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusMetersRequest& this_ = static_cast<const RespondFocusMetersRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusMetersRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusMetersRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+          if (this_._internal_focus_meters_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_meters_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusMetersRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusMetersRequest& this_ = static_cast<const RespondFocusMetersRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusMetersRequest::ByteSizeLong() const {
+          const RespondFocusMetersRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+            if (this_._internal_focus_meters_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_meters_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusMetersRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusMetersRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusMetersRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_meters_feedback() != 0) {
+    _this->_impl_.focus_meters_feedback_ = from._impl_.focus_meters_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusMetersRequest::CopyFrom(const RespondFocusMetersRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusMetersRequest::InternalSwap(RespondFocusMetersRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_meters_feedback_, other->_impl_.focus_meters_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusMetersRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusMetersResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusMetersResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusMetersResponse, _impl_._has_bits_);
+};
+
+RespondFocusMetersResponse::RespondFocusMetersResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusMetersResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusMetersResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusMetersResponse::RespondFocusMetersResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusMetersResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusMetersResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusMetersResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusMetersResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusMetersResponse::~RespondFocusMetersResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusMetersResponse::SharedDtor(MessageLite& self) {
+  RespondFocusMetersResponse& this_ = static_cast<RespondFocusMetersResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusMetersResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusMetersResponse(arena);
+}
+constexpr auto RespondFocusMetersResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusMetersResponse),
+                                            alignof(RespondFocusMetersResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusMetersResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusMetersResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusMetersResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusMetersResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusMetersResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusMetersResponse>(), &RespondFocusMetersResponse::ByteSizeLong,
+            &RespondFocusMetersResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusMetersResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusMetersResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusMetersResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusMetersResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusMetersResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusMetersResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusMetersResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusMetersResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusMetersResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusMetersResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusMetersResponse& this_ = static_cast<const RespondFocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusMetersResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusMetersResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusMetersResponse& this_ = static_cast<const RespondFocusMetersResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusMetersResponse::ByteSizeLong() const {
+          const RespondFocusMetersResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusMetersResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusMetersResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusMetersResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusMetersResponse::CopyFrom(const RespondFocusMetersResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusMetersResponse::InternalSwap(RespondFocusMetersResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusMetersResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusAutoRequest::_Internal {
+ public:
+};
+
+SubscribeFocusAutoRequest::SubscribeFocusAutoRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoRequest)
+}
+SubscribeFocusAutoRequest::SubscribeFocusAutoRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusAutoRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusAutoRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoRequest)
+}
+
+inline void* SubscribeFocusAutoRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusAutoRequest(arena);
+}
+constexpr auto SubscribeFocusAutoRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusAutoRequest),
+                                            alignof(SubscribeFocusAutoRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusAutoRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusAutoRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusAutoRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusAutoRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusAutoRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusAutoRequest>(), &SubscribeFocusAutoRequest::ByteSizeLong,
+            &SubscribeFocusAutoRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusAutoRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusAutoRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusAutoRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusAutoRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusAutoRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusAutoRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoResponse::_Internal {
+ public:
+};
+
+FocusAutoResponse::FocusAutoResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusAutoResponse)
+}
+FocusAutoResponse::FocusAutoResponse(
+    ::google::protobuf::Arena* arena, const FocusAutoResponse& from)
+    : FocusAutoResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusAutoResponse::~FocusAutoResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusAutoResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoResponse::SharedDtor(MessageLite& self) {
+  FocusAutoResponse& this_ = static_cast<FocusAutoResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoResponse(arena);
+}
+constexpr auto FocusAutoResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoResponse),
+                                            alignof(FocusAutoResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoResponse>(), &FocusAutoResponse::ByteSizeLong,
+            &FocusAutoResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusAutoResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusAutoResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoResponse& this_ = static_cast<const FocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusAutoResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusAutoResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoResponse& this_ = static_cast<const FocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoResponse::ByteSizeLong() const {
+          const FocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusAutoResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusAutoResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoResponse::CopyFrom(const FocusAutoResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusAutoResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoResponse::InternalSwap(FocusAutoResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusAutoResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoRequest::_Internal {
+ public:
+};
+
+RespondFocusAutoRequest::RespondFocusAutoRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+}
+RespondFocusAutoRequest::RespondFocusAutoRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusAutoRequest& from)
+    : RespondFocusAutoRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_auto_feedback_ = {};
+}
+RespondFocusAutoRequest::~RespondFocusAutoRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoRequest::SharedDtor(MessageLite& self) {
+  RespondFocusAutoRequest& this_ = static_cast<RespondFocusAutoRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoRequest(arena);
+}
+constexpr auto RespondFocusAutoRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoRequest),
+                                            alignof(RespondFocusAutoRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoRequest>(), &RespondFocusAutoRequest::ByteSizeLong,
+            &RespondFocusAutoRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusAutoRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusAutoRequest, _impl_.focus_auto_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoRequest, _impl_.focus_auto_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoRequest, _impl_.focus_auto_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_auto_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoRequest& this_ = static_cast<const RespondFocusAutoRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+          if (this_._internal_focus_auto_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_auto_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoRequest& this_ = static_cast<const RespondFocusAutoRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoRequest::ByteSizeLong() const {
+          const RespondFocusAutoRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+            if (this_._internal_focus_auto_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_auto_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_auto_feedback() != 0) {
+    _this->_impl_.focus_auto_feedback_ = from._impl_.focus_auto_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoRequest::CopyFrom(const RespondFocusAutoRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoRequest::InternalSwap(RespondFocusAutoRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_auto_feedback_, other->_impl_.focus_auto_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusAutoResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusAutoResponse, _impl_._has_bits_);
+};
+
+RespondFocusAutoResponse::RespondFocusAutoResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusAutoResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusAutoResponse::RespondFocusAutoResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusAutoResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusAutoResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusAutoResponse::~RespondFocusAutoResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoResponse::SharedDtor(MessageLite& self) {
+  RespondFocusAutoResponse& this_ = static_cast<RespondFocusAutoResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoResponse(arena);
+}
+constexpr auto RespondFocusAutoResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoResponse),
+                                            alignof(RespondFocusAutoResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoResponse>(), &RespondFocusAutoResponse::ByteSizeLong,
+            &RespondFocusAutoResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusAutoResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusAutoResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoResponse& this_ = static_cast<const RespondFocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoResponse& this_ = static_cast<const RespondFocusAutoResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoResponse::ByteSizeLong() const {
+          const RespondFocusAutoResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoResponse::CopyFrom(const RespondFocusAutoResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoResponse::InternalSwap(RespondFocusAutoResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusAutoSingleRequest::_Internal {
+ public:
+};
+
+SubscribeFocusAutoSingleRequest::SubscribeFocusAutoSingleRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoSingleRequest)
+}
+SubscribeFocusAutoSingleRequest::SubscribeFocusAutoSingleRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusAutoSingleRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusAutoSingleRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoSingleRequest)
+}
+
+inline void* SubscribeFocusAutoSingleRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusAutoSingleRequest(arena);
+}
+constexpr auto SubscribeFocusAutoSingleRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusAutoSingleRequest),
+                                            alignof(SubscribeFocusAutoSingleRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusAutoSingleRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusAutoSingleRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusAutoSingleRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusAutoSingleRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusAutoSingleRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusAutoSingleRequest>(), &SubscribeFocusAutoSingleRequest::ByteSizeLong,
+            &SubscribeFocusAutoSingleRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusAutoSingleRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusAutoSingleRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusAutoSingleRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusAutoSingleRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusAutoSingleRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoSingleResponse::_Internal {
+ public:
+};
+
+FocusAutoSingleResponse::FocusAutoSingleResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+}
+FocusAutoSingleResponse::FocusAutoSingleResponse(
+    ::google::protobuf::Arena* arena, const FocusAutoSingleResponse& from)
+    : FocusAutoSingleResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoSingleResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoSingleResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusAutoSingleResponse::~FocusAutoSingleResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoSingleResponse::SharedDtor(MessageLite& self) {
+  FocusAutoSingleResponse& this_ = static_cast<FocusAutoSingleResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoSingleResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoSingleResponse(arena);
+}
+constexpr auto FocusAutoSingleResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoSingleResponse),
+                                            alignof(FocusAutoSingleResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoSingleResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoSingleResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoSingleResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoSingleResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoSingleResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoSingleResponse>(), &FocusAutoSingleResponse::ByteSizeLong,
+            &FocusAutoSingleResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoSingleResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoSingleResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoSingleResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusAutoSingleResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoSingleResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoSingleResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoSingleResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoSingleResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoSingleResponse& this_ = static_cast<const FocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoSingleResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoSingleResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoSingleResponse& this_ = static_cast<const FocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoSingleResponse::ByteSizeLong() const {
+          const FocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoSingleResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoSingleResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoSingleResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoSingleResponse::CopyFrom(const FocusAutoSingleResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoSingleResponse::InternalSwap(FocusAutoSingleResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusAutoSingleResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoSingleRequest::_Internal {
+ public:
+};
+
+RespondFocusAutoSingleRequest::RespondFocusAutoSingleRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+}
+RespondFocusAutoSingleRequest::RespondFocusAutoSingleRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusAutoSingleRequest& from)
+    : RespondFocusAutoSingleRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoSingleRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoSingleRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_auto_single_feedback_ = {};
+}
+RespondFocusAutoSingleRequest::~RespondFocusAutoSingleRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoSingleRequest::SharedDtor(MessageLite& self) {
+  RespondFocusAutoSingleRequest& this_ = static_cast<RespondFocusAutoSingleRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoSingleRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoSingleRequest(arena);
+}
+constexpr auto RespondFocusAutoSingleRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoSingleRequest),
+                                            alignof(RespondFocusAutoSingleRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoSingleRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoSingleRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoSingleRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoSingleRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoSingleRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoSingleRequest>(), &RespondFocusAutoSingleRequest::ByteSizeLong,
+            &RespondFocusAutoSingleRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoSingleRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoSingleRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusAutoSingleRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoSingleRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusAutoSingleRequest, _impl_.focus_auto_single_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleRequest, _impl_.focus_auto_single_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleRequest, _impl_.focus_auto_single_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoSingleRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_auto_single_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoSingleRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoSingleRequest& this_ = static_cast<const RespondFocusAutoSingleRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoSingleRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoSingleRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+          if (this_._internal_focus_auto_single_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_auto_single_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoSingleRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoSingleRequest& this_ = static_cast<const RespondFocusAutoSingleRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoSingleRequest::ByteSizeLong() const {
+          const RespondFocusAutoSingleRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+            if (this_._internal_focus_auto_single_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_auto_single_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoSingleRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoSingleRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoSingleRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_auto_single_feedback() != 0) {
+    _this->_impl_.focus_auto_single_feedback_ = from._impl_.focus_auto_single_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoSingleRequest::CopyFrom(const RespondFocusAutoSingleRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoSingleRequest::InternalSwap(RespondFocusAutoSingleRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_auto_single_feedback_, other->_impl_.focus_auto_single_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoSingleRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoSingleResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusAutoSingleResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleResponse, _impl_._has_bits_);
+};
+
+RespondFocusAutoSingleResponse::RespondFocusAutoSingleResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoSingleResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusAutoSingleResponse::RespondFocusAutoSingleResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusAutoSingleResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusAutoSingleResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoSingleResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoSingleResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusAutoSingleResponse::~RespondFocusAutoSingleResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoSingleResponse::SharedDtor(MessageLite& self) {
+  RespondFocusAutoSingleResponse& this_ = static_cast<RespondFocusAutoSingleResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoSingleResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoSingleResponse(arena);
+}
+constexpr auto RespondFocusAutoSingleResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoSingleResponse),
+                                            alignof(RespondFocusAutoSingleResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoSingleResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoSingleResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoSingleResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoSingleResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoSingleResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoSingleResponse>(), &RespondFocusAutoSingleResponse::ByteSizeLong,
+            &RespondFocusAutoSingleResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoSingleResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoSingleResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusAutoSingleResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoSingleResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoSingleResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoSingleResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoSingleResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoSingleResponse& this_ = static_cast<const RespondFocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoSingleResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoSingleResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoSingleResponse& this_ = static_cast<const RespondFocusAutoSingleResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoSingleResponse::ByteSizeLong() const {
+          const RespondFocusAutoSingleResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoSingleResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoSingleResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoSingleResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoSingleResponse::CopyFrom(const RespondFocusAutoSingleResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoSingleResponse::InternalSwap(RespondFocusAutoSingleResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoSingleResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class SubscribeFocusAutoContinuousRequest::_Internal {
+ public:
+};
+
+SubscribeFocusAutoContinuousRequest::SubscribeFocusAutoContinuousRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoContinuousRequest)
+}
+SubscribeFocusAutoContinuousRequest::SubscribeFocusAutoContinuousRequest(
+    ::google::protobuf::Arena* arena,
+    const SubscribeFocusAutoContinuousRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::internal::ZeroFieldsBase(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::internal::ZeroFieldsBase(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SubscribeFocusAutoContinuousRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.SubscribeFocusAutoContinuousRequest)
+}
+
+inline void* SubscribeFocusAutoContinuousRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) SubscribeFocusAutoContinuousRequest(arena);
+}
+constexpr auto SubscribeFocusAutoContinuousRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(SubscribeFocusAutoContinuousRequest),
+                                            alignof(SubscribeFocusAutoContinuousRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull SubscribeFocusAutoContinuousRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_SubscribeFocusAutoContinuousRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &SubscribeFocusAutoContinuousRequest::MergeImpl,
+        ::google::protobuf::internal::ZeroFieldsBase::GetNewImpl<SubscribeFocusAutoContinuousRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &SubscribeFocusAutoContinuousRequest::SharedDtor,
+        ::google::protobuf::internal::ZeroFieldsBase::GetClearImpl<SubscribeFocusAutoContinuousRequest>(), &SubscribeFocusAutoContinuousRequest::ByteSizeLong,
+            &SubscribeFocusAutoContinuousRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(SubscribeFocusAutoContinuousRequest, _impl_._cached_size_),
+        false,
+    },
+    &SubscribeFocusAutoContinuousRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* SubscribeFocusAutoContinuousRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 0, 0, 0, 2> SubscribeFocusAutoContinuousRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    0, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967295,  // skipmap
+    offsetof(decltype(_table_), field_names),  // no field_entries
+    0,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }},
+  // no field_entries, or aux_entries
+  {{
+  }},
+};
+
+
+
+
+
+
+
+
+::google::protobuf::Metadata SubscribeFocusAutoContinuousRequest::GetMetadata() const {
+  return ::google::protobuf::internal::ZeroFieldsBase::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class FocusAutoContinuousResponse::_Internal {
+ public:
+};
+
+FocusAutoContinuousResponse::FocusAutoContinuousResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+}
+FocusAutoContinuousResponse::FocusAutoContinuousResponse(
+    ::google::protobuf::Arena* arena, const FocusAutoContinuousResponse& from)
+    : FocusAutoContinuousResponse(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE FocusAutoContinuousResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void FocusAutoContinuousResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.reserved_ = {};
+}
+FocusAutoContinuousResponse::~FocusAutoContinuousResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+  SharedDtor(*this);
+}
+inline void FocusAutoContinuousResponse::SharedDtor(MessageLite& self) {
+  FocusAutoContinuousResponse& this_ = static_cast<FocusAutoContinuousResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* FocusAutoContinuousResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) FocusAutoContinuousResponse(arena);
+}
+constexpr auto FocusAutoContinuousResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(FocusAutoContinuousResponse),
+                                            alignof(FocusAutoContinuousResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull FocusAutoContinuousResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_FocusAutoContinuousResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &FocusAutoContinuousResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<FocusAutoContinuousResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &FocusAutoContinuousResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<FocusAutoContinuousResponse>(), &FocusAutoContinuousResponse::ByteSizeLong,
+            &FocusAutoContinuousResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_._cached_size_),
+        false,
+    },
+    &FocusAutoContinuousResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* FocusAutoContinuousResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> FocusAutoContinuousResponse::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::FocusAutoContinuousResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // int32 reserved = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(FocusAutoContinuousResponse, _impl_.reserved_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_.reserved_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // int32 reserved = 1;
+    {PROTOBUF_FIELD_OFFSET(FocusAutoContinuousResponse, _impl_.reserved_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void FocusAutoContinuousResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.reserved_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* FocusAutoContinuousResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const FocusAutoContinuousResponse& this_ = static_cast<const FocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* FocusAutoContinuousResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const FocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // int32 reserved = 1;
+          if (this_._internal_reserved() != 0) {
+            target = ::google::protobuf::internal::WireFormatLite::
+                WriteInt32ToArrayWithField<1>(
+                    stream, this_._internal_reserved(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t FocusAutoContinuousResponse::ByteSizeLong(const MessageLite& base) {
+          const FocusAutoContinuousResponse& this_ = static_cast<const FocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t FocusAutoContinuousResponse::ByteSizeLong() const {
+          const FocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // int32 reserved = 1;
+            if (this_._internal_reserved() != 0) {
+              total_size += ::_pbi::WireFormatLite::Int32SizePlusOne(
+                  this_._internal_reserved());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void FocusAutoContinuousResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<FocusAutoContinuousResponse*>(&to_msg);
+  auto& from = static_cast<const FocusAutoContinuousResponse&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_reserved() != 0) {
+    _this->_impl_.reserved_ = from._impl_.reserved_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void FocusAutoContinuousResponse::CopyFrom(const FocusAutoContinuousResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void FocusAutoContinuousResponse::InternalSwap(FocusAutoContinuousResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.reserved_, other->_impl_.reserved_);
+}
+
+::google::protobuf::Metadata FocusAutoContinuousResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoContinuousRequest::_Internal {
+ public:
+};
+
+RespondFocusAutoContinuousRequest::RespondFocusAutoContinuousRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+}
+RespondFocusAutoContinuousRequest::RespondFocusAutoContinuousRequest(
+    ::google::protobuf::Arena* arena, const RespondFocusAutoContinuousRequest& from)
+    : RespondFocusAutoContinuousRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoContinuousRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoContinuousRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.focus_auto_continuous_feedback_ = {};
+}
+RespondFocusAutoContinuousRequest::~RespondFocusAutoContinuousRequest() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoContinuousRequest::SharedDtor(MessageLite& self) {
+  RespondFocusAutoContinuousRequest& this_ = static_cast<RespondFocusAutoContinuousRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoContinuousRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoContinuousRequest(arena);
+}
+constexpr auto RespondFocusAutoContinuousRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoContinuousRequest),
+                                            alignof(RespondFocusAutoContinuousRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoContinuousRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoContinuousRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoContinuousRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoContinuousRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoContinuousRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoContinuousRequest>(), &RespondFocusAutoContinuousRequest::ByteSizeLong,
+            &RespondFocusAutoContinuousRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousRequest, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoContinuousRequest::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoContinuousRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> RespondFocusAutoContinuousRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoContinuousRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(RespondFocusAutoContinuousRequest, _impl_.focus_auto_continuous_feedback_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousRequest, _impl_.focus_auto_continuous_feedback_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousRequest, _impl_.focus_auto_continuous_feedback_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoContinuousRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.focus_auto_continuous_feedback_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoContinuousRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoContinuousRequest& this_ = static_cast<const RespondFocusAutoContinuousRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoContinuousRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoContinuousRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+          if (this_._internal_focus_auto_continuous_feedback() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_focus_auto_continuous_feedback(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoContinuousRequest::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoContinuousRequest& this_ = static_cast<const RespondFocusAutoContinuousRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoContinuousRequest::ByteSizeLong() const {
+          const RespondFocusAutoContinuousRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+            if (this_._internal_focus_auto_continuous_feedback() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_focus_auto_continuous_feedback());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoContinuousRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoContinuousRequest*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoContinuousRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_focus_auto_continuous_feedback() != 0) {
+    _this->_impl_.focus_auto_continuous_feedback_ = from._impl_.focus_auto_continuous_feedback_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoContinuousRequest::CopyFrom(const RespondFocusAutoContinuousRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoContinuousRequest::InternalSwap(RespondFocusAutoContinuousRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.focus_auto_continuous_feedback_, other->_impl_.focus_auto_continuous_feedback_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoContinuousRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class RespondFocusAutoContinuousResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<RespondFocusAutoContinuousResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousResponse, _impl_._has_bits_);
+};
+
+RespondFocusAutoContinuousResponse::RespondFocusAutoContinuousResponse(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoContinuousResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+RespondFocusAutoContinuousResponse::RespondFocusAutoContinuousResponse(
+    ::google::protobuf::Arena* arena,
+    const RespondFocusAutoContinuousResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  RespondFocusAutoContinuousResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.camera_server_result_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(
+                              arena, *from._impl_.camera_server_result_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+}
+inline PROTOBUF_NDEBUG_INLINE RespondFocusAutoContinuousResponse::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void RespondFocusAutoContinuousResponse::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.camera_server_result_ = {};
+}
+RespondFocusAutoContinuousResponse::~RespondFocusAutoContinuousResponse() {
+  // @@protoc_insertion_point(destructor:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+  SharedDtor(*this);
+}
+inline void RespondFocusAutoContinuousResponse::SharedDtor(MessageLite& self) {
+  RespondFocusAutoContinuousResponse& this_ = static_cast<RespondFocusAutoContinuousResponse&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.camera_server_result_;
+  this_._impl_.~Impl_();
+}
+
+inline void* RespondFocusAutoContinuousResponse::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) RespondFocusAutoContinuousResponse(arena);
+}
+constexpr auto RespondFocusAutoContinuousResponse::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(RespondFocusAutoContinuousResponse),
+                                            alignof(RespondFocusAutoContinuousResponse));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull RespondFocusAutoContinuousResponse::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_RespondFocusAutoContinuousResponse_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &RespondFocusAutoContinuousResponse::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<RespondFocusAutoContinuousResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &RespondFocusAutoContinuousResponse::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<RespondFocusAutoContinuousResponse>(), &RespondFocusAutoContinuousResponse::ByteSizeLong,
+            &RespondFocusAutoContinuousResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousResponse, _impl_._cached_size_),
+        false,
+    },
+    &RespondFocusAutoContinuousResponse::kDescriptorMethods,
+    &descriptor_table_camera_5fserver_2fcamera_5fserver_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* RespondFocusAutoContinuousResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> RespondFocusAutoContinuousResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::RespondFocusAutoContinuousResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousResponse, _impl_.camera_server_result_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+    {PROTOBUF_FIELD_OFFSET(RespondFocusAutoContinuousResponse, _impl_.camera_server_result_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::mavsdk::rpc::camera_server::CameraServerResult>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void RespondFocusAutoContinuousResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.camera_server_result_ != nullptr);
+    _impl_.camera_server_result_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* RespondFocusAutoContinuousResponse::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const RespondFocusAutoContinuousResponse& this_ = static_cast<const RespondFocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* RespondFocusAutoContinuousResponse::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const RespondFocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.camera_server_result_, this_._impl_.camera_server_result_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t RespondFocusAutoContinuousResponse::ByteSizeLong(const MessageLite& base) {
+          const RespondFocusAutoContinuousResponse& this_ = static_cast<const RespondFocusAutoContinuousResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t RespondFocusAutoContinuousResponse::ByteSizeLong() const {
+          const RespondFocusAutoContinuousResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.camera_server_result_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void RespondFocusAutoContinuousResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<RespondFocusAutoContinuousResponse*>(&to_msg);
+  auto& from = static_cast<const RespondFocusAutoContinuousResponse&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.camera_server_result_ != nullptr);
+    if (_this->_impl_.camera_server_result_ == nullptr) {
+      _this->_impl_.camera_server_result_ =
+          ::google::protobuf::Message::CopyConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(arena, *from._impl_.camera_server_result_);
+    } else {
+      _this->_impl_.camera_server_result_->MergeFrom(*from._impl_.camera_server_result_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void RespondFocusAutoContinuousResponse::CopyFrom(const RespondFocusAutoContinuousResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void RespondFocusAutoContinuousResponse::InternalSwap(RespondFocusAutoContinuousResponse* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.camera_server_result_, other->_impl_.camera_server_result_);
+}
+
+::google::protobuf::Metadata RespondFocusAutoContinuousResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
@@ -69,12 +69,24 @@ extern CaptureStatusDefaultTypeInternal _CaptureStatus_default_instance_;
 class CaptureStatusResponse;
 struct CaptureStatusResponseDefaultTypeInternal;
 extern CaptureStatusResponseDefaultTypeInternal _CaptureStatusResponse_default_instance_;
+class FocusAutoContinuousResponse;
+struct FocusAutoContinuousResponseDefaultTypeInternal;
+extern FocusAutoContinuousResponseDefaultTypeInternal _FocusAutoContinuousResponse_default_instance_;
+class FocusAutoResponse;
+struct FocusAutoResponseDefaultTypeInternal;
+extern FocusAutoResponseDefaultTypeInternal _FocusAutoResponse_default_instance_;
+class FocusAutoSingleResponse;
+struct FocusAutoSingleResponseDefaultTypeInternal;
+extern FocusAutoSingleResponseDefaultTypeInternal _FocusAutoSingleResponse_default_instance_;
 class FocusInStartResponse;
 struct FocusInStartResponseDefaultTypeInternal;
 extern FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
 class FocusInStepResponse;
 struct FocusInStepResponseDefaultTypeInternal;
 extern FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
+class FocusMetersResponse;
+struct FocusMetersResponseDefaultTypeInternal;
+extern FocusMetersResponseDefaultTypeInternal _FocusMetersResponse_default_instance_;
 class FocusOutStartResponse;
 struct FocusOutStartResponseDefaultTypeInternal;
 extern FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
@@ -108,6 +120,24 @@ extern RespondCaptureStatusRequestDefaultTypeInternal _RespondCaptureStatusReque
 class RespondCaptureStatusResponse;
 struct RespondCaptureStatusResponseDefaultTypeInternal;
 extern RespondCaptureStatusResponseDefaultTypeInternal _RespondCaptureStatusResponse_default_instance_;
+class RespondFocusAutoContinuousRequest;
+struct RespondFocusAutoContinuousRequestDefaultTypeInternal;
+extern RespondFocusAutoContinuousRequestDefaultTypeInternal _RespondFocusAutoContinuousRequest_default_instance_;
+class RespondFocusAutoContinuousResponse;
+struct RespondFocusAutoContinuousResponseDefaultTypeInternal;
+extern RespondFocusAutoContinuousResponseDefaultTypeInternal _RespondFocusAutoContinuousResponse_default_instance_;
+class RespondFocusAutoRequest;
+struct RespondFocusAutoRequestDefaultTypeInternal;
+extern RespondFocusAutoRequestDefaultTypeInternal _RespondFocusAutoRequest_default_instance_;
+class RespondFocusAutoResponse;
+struct RespondFocusAutoResponseDefaultTypeInternal;
+extern RespondFocusAutoResponseDefaultTypeInternal _RespondFocusAutoResponse_default_instance_;
+class RespondFocusAutoSingleRequest;
+struct RespondFocusAutoSingleRequestDefaultTypeInternal;
+extern RespondFocusAutoSingleRequestDefaultTypeInternal _RespondFocusAutoSingleRequest_default_instance_;
+class RespondFocusAutoSingleResponse;
+struct RespondFocusAutoSingleResponseDefaultTypeInternal;
+extern RespondFocusAutoSingleResponseDefaultTypeInternal _RespondFocusAutoSingleResponse_default_instance_;
 class RespondFocusInStartRequest;
 struct RespondFocusInStartRequestDefaultTypeInternal;
 extern RespondFocusInStartRequestDefaultTypeInternal _RespondFocusInStartRequest_default_instance_;
@@ -120,6 +150,12 @@ extern RespondFocusInStepRequestDefaultTypeInternal _RespondFocusInStepRequest_d
 class RespondFocusInStepResponse;
 struct RespondFocusInStepResponseDefaultTypeInternal;
 extern RespondFocusInStepResponseDefaultTypeInternal _RespondFocusInStepResponse_default_instance_;
+class RespondFocusMetersRequest;
+struct RespondFocusMetersRequestDefaultTypeInternal;
+extern RespondFocusMetersRequestDefaultTypeInternal _RespondFocusMetersRequest_default_instance_;
+class RespondFocusMetersResponse;
+struct RespondFocusMetersResponseDefaultTypeInternal;
+extern RespondFocusMetersResponseDefaultTypeInternal _RespondFocusMetersResponse_default_instance_;
 class RespondFocusOutStartRequest;
 struct RespondFocusOutStartRequestDefaultTypeInternal;
 extern RespondFocusOutStartRequestDefaultTypeInternal _RespondFocusOutStartRequest_default_instance_;
@@ -324,12 +360,24 @@ extern StorageInformationResponseDefaultTypeInternal _StorageInformationResponse
 class SubscribeCaptureStatusRequest;
 struct SubscribeCaptureStatusRequestDefaultTypeInternal;
 extern SubscribeCaptureStatusRequestDefaultTypeInternal _SubscribeCaptureStatusRequest_default_instance_;
+class SubscribeFocusAutoContinuousRequest;
+struct SubscribeFocusAutoContinuousRequestDefaultTypeInternal;
+extern SubscribeFocusAutoContinuousRequestDefaultTypeInternal _SubscribeFocusAutoContinuousRequest_default_instance_;
+class SubscribeFocusAutoRequest;
+struct SubscribeFocusAutoRequestDefaultTypeInternal;
+extern SubscribeFocusAutoRequestDefaultTypeInternal _SubscribeFocusAutoRequest_default_instance_;
+class SubscribeFocusAutoSingleRequest;
+struct SubscribeFocusAutoSingleRequestDefaultTypeInternal;
+extern SubscribeFocusAutoSingleRequestDefaultTypeInternal _SubscribeFocusAutoSingleRequest_default_instance_;
 class SubscribeFocusInStartRequest;
 struct SubscribeFocusInStartRequestDefaultTypeInternal;
 extern SubscribeFocusInStartRequestDefaultTypeInternal _SubscribeFocusInStartRequest_default_instance_;
 class SubscribeFocusInStepRequest;
 struct SubscribeFocusInStepRequestDefaultTypeInternal;
 extern SubscribeFocusInStepRequestDefaultTypeInternal _SubscribeFocusInStepRequest_default_instance_;
+class SubscribeFocusMetersRequest;
+struct SubscribeFocusMetersRequestDefaultTypeInternal;
+extern SubscribeFocusMetersRequestDefaultTypeInternal _SubscribeFocusMetersRequest_default_instance_;
 class SubscribeFocusOutStartRequest;
 struct SubscribeFocusOutStartRequestDefaultTypeInternal;
 extern SubscribeFocusOutStartRequestDefaultTypeInternal _SubscribeFocusOutStartRequest_default_instance_;
@@ -1507,7 +1555,7 @@ class VideoStreaming final
     return reinterpret_cast<const VideoStreaming*>(
         &_VideoStreaming_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 87;
+  static constexpr int kIndexInFileMessages = 103;
   friend void swap(VideoStreaming& a, VideoStreaming& b) { a.Swap(&b); }
   inline void Swap(VideoStreaming* other) {
     if (other == this) return;
@@ -1716,7 +1764,7 @@ class TrackingOffCommandResponse final
     return reinterpret_cast<const TrackingOffCommandResponse*>(
         &_TrackingOffCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 105;
+  static constexpr int kIndexInFileMessages = 121;
   friend void swap(TrackingOffCommandResponse& a, TrackingOffCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingOffCommandResponse* other) {
     if (other == this) return;
@@ -1907,7 +1955,7 @@ class TrackRectangle final
     return reinterpret_cast<const TrackRectangle*>(
         &_TrackRectangle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 121;
+  static constexpr int kIndexInFileMessages = 137;
   friend void swap(TrackRectangle& a, TrackRectangle& b) { a.Swap(&b); }
   inline void Swap(TrackRectangle* other) {
     if (other == this) return;
@@ -2134,7 +2182,7 @@ class TrackPoint final
     return reinterpret_cast<const TrackPoint*>(
         &_TrackPoint_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 120;
+  static constexpr int kIndexInFileMessages = 136;
   friend void swap(TrackPoint& a, TrackPoint& b) { a.Swap(&b); }
   inline void Swap(TrackPoint* other) {
     if (other == this) return;
@@ -3123,7 +3171,7 @@ class SubscribeTrackingRectangleCommandRequest final
     return reinterpret_cast<const SubscribeTrackingRectangleCommandRequest*>(
         &_SubscribeTrackingRectangleCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 102;
+  static constexpr int kIndexInFileMessages = 118;
   friend void swap(SubscribeTrackingRectangleCommandRequest& a, SubscribeTrackingRectangleCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingRectangleCommandRequest* other) {
     if (other == this) return;
@@ -3269,7 +3317,7 @@ class SubscribeTrackingPointCommandRequest final
     return reinterpret_cast<const SubscribeTrackingPointCommandRequest*>(
         &_SubscribeTrackingPointCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 100;
+  static constexpr int kIndexInFileMessages = 116;
   friend void swap(SubscribeTrackingPointCommandRequest& a, SubscribeTrackingPointCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingPointCommandRequest* other) {
     if (other == this) return;
@@ -3415,7 +3463,7 @@ class SubscribeTrackingOffCommandRequest final
     return reinterpret_cast<const SubscribeTrackingOffCommandRequest*>(
         &_SubscribeTrackingOffCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 104;
+  static constexpr int kIndexInFileMessages = 120;
   friend void swap(SubscribeTrackingOffCommandRequest& a, SubscribeTrackingOffCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingOffCommandRequest* other) {
     if (other == this) return;
@@ -5400,6 +5448,152 @@ class SubscribeFocusOutStartRequest final
 };
 // -------------------------------------------------------------------
 
+class SubscribeFocusMetersRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusMetersRequest) */ {
+ public:
+  inline SubscribeFocusMetersRequest() : SubscribeFocusMetersRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusMetersRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusMetersRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusMetersRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusMetersRequest(const SubscribeFocusMetersRequest& from) : SubscribeFocusMetersRequest(nullptr, from) {}
+  inline SubscribeFocusMetersRequest(SubscribeFocusMetersRequest&& from) noexcept
+      : SubscribeFocusMetersRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusMetersRequest& operator=(const SubscribeFocusMetersRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusMetersRequest& operator=(SubscribeFocusMetersRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusMetersRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusMetersRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusMetersRequest*>(
+        &_SubscribeFocusMetersRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 86;
+  friend void swap(SubscribeFocusMetersRequest& a, SubscribeFocusMetersRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusMetersRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusMetersRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusMetersRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusMetersRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusMetersRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusMetersRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusMetersRequest"; }
+
+ protected:
+  explicit SubscribeFocusMetersRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusMetersRequest(::google::protobuf::Arena* arena, const SubscribeFocusMetersRequest& from);
+  SubscribeFocusMetersRequest(::google::protobuf::Arena* arena, SubscribeFocusMetersRequest&& from) noexcept
+      : SubscribeFocusMetersRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusMetersRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusMetersRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SubscribeFocusInStepRequest final
     : public ::google::protobuf::internal::ZeroFieldsBase
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusInStepRequest) */ {
@@ -5686,6 +5880,444 @@ class SubscribeFocusInStartRequest final
     inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const SubscribeFocusInStartRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusAutoSingleRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusAutoSingleRequest) */ {
+ public:
+  inline SubscribeFocusAutoSingleRequest() : SubscribeFocusAutoSingleRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusAutoSingleRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusAutoSingleRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusAutoSingleRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusAutoSingleRequest(const SubscribeFocusAutoSingleRequest& from) : SubscribeFocusAutoSingleRequest(nullptr, from) {}
+  inline SubscribeFocusAutoSingleRequest(SubscribeFocusAutoSingleRequest&& from) noexcept
+      : SubscribeFocusAutoSingleRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusAutoSingleRequest& operator=(const SubscribeFocusAutoSingleRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusAutoSingleRequest& operator=(SubscribeFocusAutoSingleRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusAutoSingleRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusAutoSingleRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusAutoSingleRequest*>(
+        &_SubscribeFocusAutoSingleRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 94;
+  friend void swap(SubscribeFocusAutoSingleRequest& a, SubscribeFocusAutoSingleRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusAutoSingleRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusAutoSingleRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusAutoSingleRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusAutoSingleRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusAutoSingleRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusAutoSingleRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusAutoSingleRequest"; }
+
+ protected:
+  explicit SubscribeFocusAutoSingleRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusAutoSingleRequest(::google::protobuf::Arena* arena, const SubscribeFocusAutoSingleRequest& from);
+  SubscribeFocusAutoSingleRequest(::google::protobuf::Arena* arena, SubscribeFocusAutoSingleRequest&& from) noexcept
+      : SubscribeFocusAutoSingleRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusAutoSingleRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusAutoSingleRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusAutoRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusAutoRequest) */ {
+ public:
+  inline SubscribeFocusAutoRequest() : SubscribeFocusAutoRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusAutoRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusAutoRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusAutoRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusAutoRequest(const SubscribeFocusAutoRequest& from) : SubscribeFocusAutoRequest(nullptr, from) {}
+  inline SubscribeFocusAutoRequest(SubscribeFocusAutoRequest&& from) noexcept
+      : SubscribeFocusAutoRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusAutoRequest& operator=(const SubscribeFocusAutoRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusAutoRequest& operator=(SubscribeFocusAutoRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusAutoRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusAutoRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusAutoRequest*>(
+        &_SubscribeFocusAutoRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 90;
+  friend void swap(SubscribeFocusAutoRequest& a, SubscribeFocusAutoRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusAutoRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusAutoRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusAutoRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusAutoRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusAutoRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusAutoRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusAutoRequest"; }
+
+ protected:
+  explicit SubscribeFocusAutoRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusAutoRequest(::google::protobuf::Arena* arena, const SubscribeFocusAutoRequest& from);
+  SubscribeFocusAutoRequest(::google::protobuf::Arena* arena, SubscribeFocusAutoRequest&& from) noexcept
+      : SubscribeFocusAutoRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusAutoRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusAutoRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusAutoContinuousRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusAutoContinuousRequest) */ {
+ public:
+  inline SubscribeFocusAutoContinuousRequest() : SubscribeFocusAutoContinuousRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusAutoContinuousRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusAutoContinuousRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusAutoContinuousRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusAutoContinuousRequest(const SubscribeFocusAutoContinuousRequest& from) : SubscribeFocusAutoContinuousRequest(nullptr, from) {}
+  inline SubscribeFocusAutoContinuousRequest(SubscribeFocusAutoContinuousRequest&& from) noexcept
+      : SubscribeFocusAutoContinuousRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusAutoContinuousRequest& operator=(const SubscribeFocusAutoContinuousRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusAutoContinuousRequest& operator=(SubscribeFocusAutoContinuousRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusAutoContinuousRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusAutoContinuousRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusAutoContinuousRequest*>(
+        &_SubscribeFocusAutoContinuousRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 98;
+  friend void swap(SubscribeFocusAutoContinuousRequest& a, SubscribeFocusAutoContinuousRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusAutoContinuousRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusAutoContinuousRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusAutoContinuousRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusAutoContinuousRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusAutoContinuousRequest"; }
+
+ protected:
+  explicit SubscribeFocusAutoContinuousRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusAutoContinuousRequest(::google::protobuf::Arena* arena, const SubscribeFocusAutoContinuousRequest& from);
+  SubscribeFocusAutoContinuousRequest(::google::protobuf::Arena* arena, SubscribeFocusAutoContinuousRequest&& from) noexcept
+      : SubscribeFocusAutoContinuousRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusAutoContinuousRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusAutoContinuousRequest& from_msg);
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
@@ -6089,7 +6721,7 @@ class StorageInformation final
     return reinterpret_cast<const StorageInformation*>(
         &_StorageInformation_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 92;
+  static constexpr int kIndexInFileMessages = 108;
   friend void swap(StorageInformation& a, StorageInformation& b) { a.Swap(&b); }
   inline void Swap(StorageInformation* other) {
     if (other == this) return;
@@ -7172,7 +7804,7 @@ class SetZoomFactorRequest final
     return reinterpret_cast<const SetZoomFactorRequest*>(
         &_SetZoomFactorRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 116;
+  static constexpr int kIndexInFileMessages = 132;
   friend void swap(SetZoomFactorRequest& a, SetZoomFactorRequest& b) { a.Swap(&b); }
   inline void Swap(SetZoomFactorRequest* other) {
     if (other == this) return;
@@ -7362,7 +7994,7 @@ class SetTrackingRectangleStatusResponse final
     return reinterpret_cast<const SetTrackingRectangleStatusResponse*>(
         &_SetTrackingRectangleStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 97;
+  static constexpr int kIndexInFileMessages = 113;
   friend void swap(SetTrackingRectangleStatusResponse& a, SetTrackingRectangleStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingRectangleStatusResponse* other) {
     if (other == this) return;
@@ -7508,7 +8140,7 @@ class SetTrackingPointStatusResponse final
     return reinterpret_cast<const SetTrackingPointStatusResponse*>(
         &_SetTrackingPointStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 95;
+  static constexpr int kIndexInFileMessages = 111;
   friend void swap(SetTrackingPointStatusResponse& a, SetTrackingPointStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingPointStatusResponse* other) {
     if (other == this) return;
@@ -7654,7 +8286,7 @@ class SetTrackingOffStatusResponse final
     return reinterpret_cast<const SetTrackingOffStatusResponse*>(
         &_SetTrackingOffStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 99;
+  static constexpr int kIndexInFileMessages = 115;
   friend void swap(SetTrackingOffStatusResponse& a, SetTrackingOffStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingOffStatusResponse* other) {
     if (other == this) return;
@@ -7800,7 +8432,7 @@ class SetTrackingOffStatusRequest final
     return reinterpret_cast<const SetTrackingOffStatusRequest*>(
         &_SetTrackingOffStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 98;
+  static constexpr int kIndexInFileMessages = 114;
   friend void swap(SetTrackingOffStatusRequest& a, SetTrackingOffStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingOffStatusRequest* other) {
     if (other == this) return;
@@ -8329,7 +8961,7 @@ class SetFieldOfViewRequest final
     return reinterpret_cast<const SetFieldOfViewRequest*>(
         &_SetFieldOfViewRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 118;
+  static constexpr int kIndexInFileMessages = 134;
   friend void swap(SetFieldOfViewRequest& a, SetFieldOfViewRequest& b) { a.Swap(&b); }
   inline void Swap(SetFieldOfViewRequest* other) {
     if (other == this) return;
@@ -9296,7 +9928,7 @@ class RespondTrackingRectangleCommandRequest final
     return reinterpret_cast<const RespondTrackingRectangleCommandRequest*>(
         &_RespondTrackingRectangleCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 108;
+  static constexpr int kIndexInFileMessages = 124;
   friend void swap(RespondTrackingRectangleCommandRequest& a, RespondTrackingRectangleCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingRectangleCommandRequest* other) {
     if (other == this) return;
@@ -9487,7 +10119,7 @@ class RespondTrackingPointCommandRequest final
     return reinterpret_cast<const RespondTrackingPointCommandRequest*>(
         &_RespondTrackingPointCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 106;
+  static constexpr int kIndexInFileMessages = 122;
   friend void swap(RespondTrackingPointCommandRequest& a, RespondTrackingPointCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingPointCommandRequest* other) {
     if (other == this) return;
@@ -9678,7 +10310,7 @@ class RespondTrackingOffCommandRequest final
     return reinterpret_cast<const RespondTrackingOffCommandRequest*>(
         &_RespondTrackingOffCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 110;
+  static constexpr int kIndexInFileMessages = 126;
   friend void swap(RespondTrackingOffCommandRequest& a, RespondTrackingOffCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingOffCommandRequest* other) {
     if (other == this) return;
@@ -11910,6 +12542,197 @@ class RespondFocusOutStartRequest final
 };
 // -------------------------------------------------------------------
 
+class RespondFocusMetersRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusMetersRequest) */ {
+ public:
+  inline RespondFocusMetersRequest() : RespondFocusMetersRequest(nullptr) {}
+  ~RespondFocusMetersRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusMetersRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusMetersRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusMetersRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusMetersRequest(const RespondFocusMetersRequest& from) : RespondFocusMetersRequest(nullptr, from) {}
+  inline RespondFocusMetersRequest(RespondFocusMetersRequest&& from) noexcept
+      : RespondFocusMetersRequest(nullptr, std::move(from)) {}
+  inline RespondFocusMetersRequest& operator=(const RespondFocusMetersRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusMetersRequest& operator=(RespondFocusMetersRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusMetersRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusMetersRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusMetersRequest*>(
+        &_RespondFocusMetersRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 88;
+  friend void swap(RespondFocusMetersRequest& a, RespondFocusMetersRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusMetersRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusMetersRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusMetersRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusMetersRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusMetersRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusMetersRequest& from) { RespondFocusMetersRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusMetersRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusMetersRequest"; }
+
+ protected:
+  explicit RespondFocusMetersRequest(::google::protobuf::Arena* arena);
+  RespondFocusMetersRequest(::google::protobuf::Arena* arena, const RespondFocusMetersRequest& from);
+  RespondFocusMetersRequest(::google::protobuf::Arena* arena, RespondFocusMetersRequest&& from) noexcept
+      : RespondFocusMetersRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusMetersFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+  void clear_focus_meters_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_meters_feedback() const;
+  void set_focus_meters_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_meters_feedback() const;
+  void _internal_set_focus_meters_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusMetersRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusMetersRequest& from_msg);
+    int focus_meters_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class RespondFocusInStepRequest final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStepRequest) */ {
@@ -12292,6 +13115,579 @@ class RespondFocusInStartRequest final
 };
 // -------------------------------------------------------------------
 
+class RespondFocusAutoSingleRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest) */ {
+ public:
+  inline RespondFocusAutoSingleRequest() : RespondFocusAutoSingleRequest(nullptr) {}
+  ~RespondFocusAutoSingleRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoSingleRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoSingleRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoSingleRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoSingleRequest(const RespondFocusAutoSingleRequest& from) : RespondFocusAutoSingleRequest(nullptr, from) {}
+  inline RespondFocusAutoSingleRequest(RespondFocusAutoSingleRequest&& from) noexcept
+      : RespondFocusAutoSingleRequest(nullptr, std::move(from)) {}
+  inline RespondFocusAutoSingleRequest& operator=(const RespondFocusAutoSingleRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoSingleRequest& operator=(RespondFocusAutoSingleRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoSingleRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoSingleRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoSingleRequest*>(
+        &_RespondFocusAutoSingleRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 96;
+  friend void swap(RespondFocusAutoSingleRequest& a, RespondFocusAutoSingleRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoSingleRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoSingleRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoSingleRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoSingleRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoSingleRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoSingleRequest& from) { RespondFocusAutoSingleRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoSingleRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest"; }
+
+ protected:
+  explicit RespondFocusAutoSingleRequest(::google::protobuf::Arena* arena);
+  RespondFocusAutoSingleRequest(::google::protobuf::Arena* arena, const RespondFocusAutoSingleRequest& from);
+  RespondFocusAutoSingleRequest(::google::protobuf::Arena* arena, RespondFocusAutoSingleRequest&& from) noexcept
+      : RespondFocusAutoSingleRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusAutoSingleFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+  void clear_focus_auto_single_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_auto_single_feedback() const;
+  void set_focus_auto_single_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_auto_single_feedback() const;
+  void _internal_set_focus_auto_single_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoSingleRequest& from_msg);
+    int focus_auto_single_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusAutoRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoRequest) */ {
+ public:
+  inline RespondFocusAutoRequest() : RespondFocusAutoRequest(nullptr) {}
+  ~RespondFocusAutoRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoRequest(const RespondFocusAutoRequest& from) : RespondFocusAutoRequest(nullptr, from) {}
+  inline RespondFocusAutoRequest(RespondFocusAutoRequest&& from) noexcept
+      : RespondFocusAutoRequest(nullptr, std::move(from)) {}
+  inline RespondFocusAutoRequest& operator=(const RespondFocusAutoRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoRequest& operator=(RespondFocusAutoRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoRequest*>(
+        &_RespondFocusAutoRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 92;
+  friend void swap(RespondFocusAutoRequest& a, RespondFocusAutoRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoRequest& from) { RespondFocusAutoRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoRequest"; }
+
+ protected:
+  explicit RespondFocusAutoRequest(::google::protobuf::Arena* arena);
+  RespondFocusAutoRequest(::google::protobuf::Arena* arena, const RespondFocusAutoRequest& from);
+  RespondFocusAutoRequest(::google::protobuf::Arena* arena, RespondFocusAutoRequest&& from) noexcept
+      : RespondFocusAutoRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusAutoFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+  void clear_focus_auto_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_auto_feedback() const;
+  void set_focus_auto_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_auto_feedback() const;
+  void _internal_set_focus_auto_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoRequest& from_msg);
+    int focus_auto_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusAutoContinuousRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest) */ {
+ public:
+  inline RespondFocusAutoContinuousRequest() : RespondFocusAutoContinuousRequest(nullptr) {}
+  ~RespondFocusAutoContinuousRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoContinuousRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoContinuousRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoContinuousRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoContinuousRequest(const RespondFocusAutoContinuousRequest& from) : RespondFocusAutoContinuousRequest(nullptr, from) {}
+  inline RespondFocusAutoContinuousRequest(RespondFocusAutoContinuousRequest&& from) noexcept
+      : RespondFocusAutoContinuousRequest(nullptr, std::move(from)) {}
+  inline RespondFocusAutoContinuousRequest& operator=(const RespondFocusAutoContinuousRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoContinuousRequest& operator=(RespondFocusAutoContinuousRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoContinuousRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoContinuousRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoContinuousRequest*>(
+        &_RespondFocusAutoContinuousRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 100;
+  friend void swap(RespondFocusAutoContinuousRequest& a, RespondFocusAutoContinuousRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoContinuousRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoContinuousRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoContinuousRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoContinuousRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoContinuousRequest& from) { RespondFocusAutoContinuousRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoContinuousRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest"; }
+
+ protected:
+  explicit RespondFocusAutoContinuousRequest(::google::protobuf::Arena* arena);
+  RespondFocusAutoContinuousRequest(::google::protobuf::Arena* arena, const RespondFocusAutoContinuousRequest& from);
+  RespondFocusAutoContinuousRequest(::google::protobuf::Arena* arena, RespondFocusAutoContinuousRequest&& from) noexcept
+      : RespondFocusAutoContinuousRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusAutoContinuousFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+  void clear_focus_auto_continuous_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_auto_continuous_feedback() const;
+  void set_focus_auto_continuous_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_auto_continuous_feedback() const;
+  void _internal_set_focus_auto_continuous_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoContinuousRequest& from_msg);
+    int focus_auto_continuous_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ResetSettingsResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.ResetSettingsResponse) */ {
@@ -12543,7 +13939,7 @@ class Quaternion final
     return reinterpret_cast<const Quaternion*>(
         &_Quaternion_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 105;
   friend void swap(Quaternion& a, Quaternion& b) { a.Swap(&b); }
   inline void Swap(Quaternion* other) {
     if (other == this) return;
@@ -12770,7 +14166,7 @@ class Position final
     return reinterpret_cast<const Position*>(
         &_Position_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 104;
   friend void swap(Position& a, Position& b) { a.Swap(&b); }
   inline void Swap(Position* other) {
     if (other == this) return;
@@ -12997,7 +14393,7 @@ class Information final
     return reinterpret_cast<const Information*>(
         &_Information_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 86;
+  static constexpr int kIndexInFileMessages = 102;
   friend void swap(Information& a, Information& b) { a.Swap(&b); }
   inline void Swap(Information* other) {
     if (other == this) return;
@@ -14251,6 +15647,197 @@ class FocusOutStartResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusMetersResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusMetersResponse) */ {
+ public:
+  inline FocusMetersResponse() : FocusMetersResponse(nullptr) {}
+  ~FocusMetersResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusMetersResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusMetersResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusMetersResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusMetersResponse(const FocusMetersResponse& from) : FocusMetersResponse(nullptr, from) {}
+  inline FocusMetersResponse(FocusMetersResponse&& from) noexcept
+      : FocusMetersResponse(nullptr, std::move(from)) {}
+  inline FocusMetersResponse& operator=(const FocusMetersResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusMetersResponse& operator=(FocusMetersResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusMetersResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusMetersResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusMetersResponse*>(
+        &_FocusMetersResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 87;
+  friend void swap(FocusMetersResponse& a, FocusMetersResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusMetersResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusMetersResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusMetersResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusMetersResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusMetersResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusMetersResponse& from) { FocusMetersResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusMetersResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusMetersResponse"; }
+
+ protected:
+  explicit FocusMetersResponse(::google::protobuf::Arena* arena);
+  FocusMetersResponse(::google::protobuf::Arena* arena, const FocusMetersResponse& from);
+  FocusMetersResponse(::google::protobuf::Arena* arena, FocusMetersResponse&& from) noexcept
+      : FocusMetersResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusDistanceMFieldNumber = 1,
+  };
+  // float focus_distance_m = 1;
+  void clear_focus_distance_m() ;
+  float focus_distance_m() const;
+  void set_focus_distance_m(float value);
+
+  private:
+  float _internal_focus_distance_m() const;
+  void _internal_set_focus_distance_m(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusMetersResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusMetersResponse& from_msg);
+    float focus_distance_m_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class FocusInStepResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusInStepResponse) */ {
@@ -14633,6 +16220,579 @@ class FocusInStartResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusAutoSingleResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusAutoSingleResponse) */ {
+ public:
+  inline FocusAutoSingleResponse() : FocusAutoSingleResponse(nullptr) {}
+  ~FocusAutoSingleResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoSingleResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoSingleResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoSingleResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoSingleResponse(const FocusAutoSingleResponse& from) : FocusAutoSingleResponse(nullptr, from) {}
+  inline FocusAutoSingleResponse(FocusAutoSingleResponse&& from) noexcept
+      : FocusAutoSingleResponse(nullptr, std::move(from)) {}
+  inline FocusAutoSingleResponse& operator=(const FocusAutoSingleResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoSingleResponse& operator=(FocusAutoSingleResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoSingleResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoSingleResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoSingleResponse*>(
+        &_FocusAutoSingleResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 95;
+  friend void swap(FocusAutoSingleResponse& a, FocusAutoSingleResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoSingleResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoSingleResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoSingleResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoSingleResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoSingleResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoSingleResponse& from) { FocusAutoSingleResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoSingleResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusAutoSingleResponse"; }
+
+ protected:
+  explicit FocusAutoSingleResponse(::google::protobuf::Arena* arena);
+  FocusAutoSingleResponse(::google::protobuf::Arena* arena, const FocusAutoSingleResponse& from);
+  FocusAutoSingleResponse(::google::protobuf::Arena* arena, FocusAutoSingleResponse&& from) noexcept
+      : FocusAutoSingleResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusAutoSingleResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoSingleResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusAutoResponse) */ {
+ public:
+  inline FocusAutoResponse() : FocusAutoResponse(nullptr) {}
+  ~FocusAutoResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoResponse(const FocusAutoResponse& from) : FocusAutoResponse(nullptr, from) {}
+  inline FocusAutoResponse(FocusAutoResponse&& from) noexcept
+      : FocusAutoResponse(nullptr, std::move(from)) {}
+  inline FocusAutoResponse& operator=(const FocusAutoResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoResponse& operator=(FocusAutoResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoResponse*>(
+        &_FocusAutoResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 91;
+  friend void swap(FocusAutoResponse& a, FocusAutoResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoResponse& from) { FocusAutoResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusAutoResponse"; }
+
+ protected:
+  explicit FocusAutoResponse(::google::protobuf::Arena* arena);
+  FocusAutoResponse(::google::protobuf::Arena* arena, const FocusAutoResponse& from);
+  FocusAutoResponse(::google::protobuf::Arena* arena, FocusAutoResponse&& from) noexcept
+      : FocusAutoResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusAutoResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusAutoContinuousResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusAutoContinuousResponse) */ {
+ public:
+  inline FocusAutoContinuousResponse() : FocusAutoContinuousResponse(nullptr) {}
+  ~FocusAutoContinuousResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusAutoContinuousResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusAutoContinuousResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusAutoContinuousResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusAutoContinuousResponse(const FocusAutoContinuousResponse& from) : FocusAutoContinuousResponse(nullptr, from) {}
+  inline FocusAutoContinuousResponse(FocusAutoContinuousResponse&& from) noexcept
+      : FocusAutoContinuousResponse(nullptr, std::move(from)) {}
+  inline FocusAutoContinuousResponse& operator=(const FocusAutoContinuousResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusAutoContinuousResponse& operator=(FocusAutoContinuousResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusAutoContinuousResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusAutoContinuousResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusAutoContinuousResponse*>(
+        &_FocusAutoContinuousResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 99;
+  friend void swap(FocusAutoContinuousResponse& a, FocusAutoContinuousResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusAutoContinuousResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusAutoContinuousResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusAutoContinuousResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusAutoContinuousResponse& from) { FocusAutoContinuousResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusAutoContinuousResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusAutoContinuousResponse"; }
+
+ protected:
+  explicit FocusAutoContinuousResponse(::google::protobuf::Arena* arena);
+  FocusAutoContinuousResponse(::google::protobuf::Arena* arena, const FocusAutoContinuousResponse& from);
+  FocusAutoContinuousResponse(::google::protobuf::Arena* arena, FocusAutoContinuousResponse&& from) noexcept
+      : FocusAutoContinuousResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusAutoContinuousResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusAutoContinuousResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CaptureStatusResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.CaptureStatusResponse) */ {
@@ -14884,7 +17044,7 @@ class CaptureStatus final
     return reinterpret_cast<const CaptureStatus*>(
         &_CaptureStatus_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 93;
+  static constexpr int kIndexInFileMessages = 109;
   friend void swap(CaptureStatus& a, CaptureStatus& b) { a.Swap(&b); }
   inline void Swap(CaptureStatus* other) {
     if (other == this) return;
@@ -15175,7 +17335,7 @@ class CameraServerResult final
     return reinterpret_cast<const CameraServerResult*>(
         &_CameraServerResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 91;
+  static constexpr int kIndexInFileMessages = 107;
   friend void swap(CameraServerResult& a, CameraServerResult& b) { a.Swap(&b); }
   inline void Swap(CameraServerResult* other) {
     if (other == this) return;
@@ -15410,7 +17570,7 @@ class TrackingRectangleCommandResponse final
     return reinterpret_cast<const TrackingRectangleCommandResponse*>(
         &_TrackingRectangleCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 103;
+  static constexpr int kIndexInFileMessages = 119;
   friend void swap(TrackingRectangleCommandResponse& a, TrackingRectangleCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingRectangleCommandResponse* other) {
     if (other == this) return;
@@ -15607,7 +17767,7 @@ class TrackingPointCommandResponse final
     return reinterpret_cast<const TrackingPointCommandResponse*>(
         &_TrackingPointCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 101;
+  static constexpr int kIndexInFileMessages = 117;
   friend void swap(TrackingPointCommandResponse& a, TrackingPointCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingPointCommandResponse* other) {
     if (other == this) return;
@@ -15804,7 +17964,7 @@ class SetZoomFactorResponse final
     return reinterpret_cast<const SetZoomFactorResponse*>(
         &_SetZoomFactorResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 117;
+  static constexpr int kIndexInFileMessages = 133;
   friend void swap(SetZoomFactorResponse& a, SetZoomFactorResponse& b) { a.Swap(&b); }
   inline void Swap(SetZoomFactorResponse* other) {
     if (other == this) return;
@@ -16395,7 +18555,7 @@ class SetTrackingRectangleStatusRequest final
     return reinterpret_cast<const SetTrackingRectangleStatusRequest*>(
         &_SetTrackingRectangleStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 96;
+  static constexpr int kIndexInFileMessages = 112;
   friend void swap(SetTrackingRectangleStatusRequest& a, SetTrackingRectangleStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingRectangleStatusRequest* other) {
     if (other == this) return;
@@ -16592,7 +18752,7 @@ class SetTrackingPointStatusRequest final
     return reinterpret_cast<const SetTrackingPointStatusRequest*>(
         &_SetTrackingPointStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 94;
+  static constexpr int kIndexInFileMessages = 110;
   friend void swap(SetTrackingPointStatusRequest& a, SetTrackingPointStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingPointStatusRequest* other) {
     if (other == this) return;
@@ -16789,7 +18949,7 @@ class SetPositionResponse final
     return reinterpret_cast<const SetPositionResponse*>(
         &_SetPositionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 113;
+  static constexpr int kIndexInFileMessages = 129;
   friend void swap(SetPositionResponse& a, SetPositionResponse& b) { a.Swap(&b); }
   inline void Swap(SetPositionResponse* other) {
     if (other == this) return;
@@ -16986,7 +19146,7 @@ class SetPositionRequest final
     return reinterpret_cast<const SetPositionRequest*>(
         &_SetPositionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 112;
+  static constexpr int kIndexInFileMessages = 128;
   friend void swap(SetPositionRequest& a, SetPositionRequest& b) { a.Swap(&b); }
   inline void Swap(SetPositionRequest* other) {
     if (other == this) return;
@@ -17774,7 +19934,7 @@ class SetFieldOfViewResponse final
     return reinterpret_cast<const SetFieldOfViewResponse*>(
         &_SetFieldOfViewResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 119;
+  static constexpr int kIndexInFileMessages = 135;
   friend void swap(SetFieldOfViewResponse& a, SetFieldOfViewResponse& b) { a.Swap(&b); }
   inline void Swap(SetFieldOfViewResponse* other) {
     if (other == this) return;
@@ -17971,7 +20131,7 @@ class SetAttitudeQuaternionResponse final
     return reinterpret_cast<const SetAttitudeQuaternionResponse*>(
         &_SetAttitudeQuaternionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 115;
+  static constexpr int kIndexInFileMessages = 131;
   friend void swap(SetAttitudeQuaternionResponse& a, SetAttitudeQuaternionResponse& b) { a.Swap(&b); }
   inline void Swap(SetAttitudeQuaternionResponse* other) {
     if (other == this) return;
@@ -18168,7 +20328,7 @@ class SetAttitudeQuaternionRequest final
     return reinterpret_cast<const SetAttitudeQuaternionRequest*>(
         &_SetAttitudeQuaternionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 114;
+  static constexpr int kIndexInFileMessages = 130;
   friend void swap(SetAttitudeQuaternionRequest& a, SetAttitudeQuaternionRequest& b) { a.Swap(&b); }
   inline void Swap(SetAttitudeQuaternionRequest* other) {
     if (other == this) return;
@@ -19153,7 +21313,7 @@ class RespondTrackingRectangleCommandResponse final
     return reinterpret_cast<const RespondTrackingRectangleCommandResponse*>(
         &_RespondTrackingRectangleCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 109;
+  static constexpr int kIndexInFileMessages = 125;
   friend void swap(RespondTrackingRectangleCommandResponse& a, RespondTrackingRectangleCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingRectangleCommandResponse* other) {
     if (other == this) return;
@@ -19350,7 +21510,7 @@ class RespondTrackingPointCommandResponse final
     return reinterpret_cast<const RespondTrackingPointCommandResponse*>(
         &_RespondTrackingPointCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 107;
+  static constexpr int kIndexInFileMessages = 123;
   friend void swap(RespondTrackingPointCommandResponse& a, RespondTrackingPointCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingPointCommandResponse* other) {
     if (other == this) return;
@@ -19547,7 +21707,7 @@ class RespondTrackingOffCommandResponse final
     return reinterpret_cast<const RespondTrackingOffCommandResponse*>(
         &_RespondTrackingOffCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 111;
+  static constexpr int kIndexInFileMessages = 127;
   friend void swap(RespondTrackingOffCommandResponse& a, RespondTrackingOffCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingOffCommandResponse* other) {
     if (other == this) return;
@@ -22454,6 +24614,203 @@ class RespondFocusOutStartResponse final
 };
 // -------------------------------------------------------------------
 
+class RespondFocusMetersResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusMetersResponse) */ {
+ public:
+  inline RespondFocusMetersResponse() : RespondFocusMetersResponse(nullptr) {}
+  ~RespondFocusMetersResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusMetersResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusMetersResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusMetersResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusMetersResponse(const RespondFocusMetersResponse& from) : RespondFocusMetersResponse(nullptr, from) {}
+  inline RespondFocusMetersResponse(RespondFocusMetersResponse&& from) noexcept
+      : RespondFocusMetersResponse(nullptr, std::move(from)) {}
+  inline RespondFocusMetersResponse& operator=(const RespondFocusMetersResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusMetersResponse& operator=(RespondFocusMetersResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusMetersResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusMetersResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusMetersResponse*>(
+        &_RespondFocusMetersResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 89;
+  friend void swap(RespondFocusMetersResponse& a, RespondFocusMetersResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusMetersResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusMetersResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusMetersResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusMetersResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusMetersResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusMetersResponse& from) { RespondFocusMetersResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusMetersResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusMetersResponse"; }
+
+ protected:
+  explicit RespondFocusMetersResponse(::google::protobuf::Arena* arena);
+  RespondFocusMetersResponse(::google::protobuf::Arena* arena, const RespondFocusMetersResponse& from);
+  RespondFocusMetersResponse(::google::protobuf::Arena* arena, RespondFocusMetersResponse&& from) noexcept
+      : RespondFocusMetersResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusMetersResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusMetersResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class RespondFocusInStepResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStepResponse) */ {
@@ -22838,6 +25195,597 @@ class RespondFocusInStartResponse final
     inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                           ::google::protobuf::Arena* arena, const Impl_& from,
                           const RespondFocusInStartResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusAutoSingleResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse) */ {
+ public:
+  inline RespondFocusAutoSingleResponse() : RespondFocusAutoSingleResponse(nullptr) {}
+  ~RespondFocusAutoSingleResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoSingleResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoSingleResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoSingleResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoSingleResponse(const RespondFocusAutoSingleResponse& from) : RespondFocusAutoSingleResponse(nullptr, from) {}
+  inline RespondFocusAutoSingleResponse(RespondFocusAutoSingleResponse&& from) noexcept
+      : RespondFocusAutoSingleResponse(nullptr, std::move(from)) {}
+  inline RespondFocusAutoSingleResponse& operator=(const RespondFocusAutoSingleResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoSingleResponse& operator=(RespondFocusAutoSingleResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoSingleResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoSingleResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoSingleResponse*>(
+        &_RespondFocusAutoSingleResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 97;
+  friend void swap(RespondFocusAutoSingleResponse& a, RespondFocusAutoSingleResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoSingleResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoSingleResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoSingleResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoSingleResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoSingleResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoSingleResponse& from) { RespondFocusAutoSingleResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoSingleResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse"; }
+
+ protected:
+  explicit RespondFocusAutoSingleResponse(::google::protobuf::Arena* arena);
+  RespondFocusAutoSingleResponse(::google::protobuf::Arena* arena, const RespondFocusAutoSingleResponse& from);
+  RespondFocusAutoSingleResponse(::google::protobuf::Arena* arena, RespondFocusAutoSingleResponse&& from) noexcept
+      : RespondFocusAutoSingleResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoSingleResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusAutoResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoResponse) */ {
+ public:
+  inline RespondFocusAutoResponse() : RespondFocusAutoResponse(nullptr) {}
+  ~RespondFocusAutoResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoResponse(const RespondFocusAutoResponse& from) : RespondFocusAutoResponse(nullptr, from) {}
+  inline RespondFocusAutoResponse(RespondFocusAutoResponse&& from) noexcept
+      : RespondFocusAutoResponse(nullptr, std::move(from)) {}
+  inline RespondFocusAutoResponse& operator=(const RespondFocusAutoResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoResponse& operator=(RespondFocusAutoResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoResponse*>(
+        &_RespondFocusAutoResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 93;
+  friend void swap(RespondFocusAutoResponse& a, RespondFocusAutoResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoResponse& from) { RespondFocusAutoResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoResponse"; }
+
+ protected:
+  explicit RespondFocusAutoResponse(::google::protobuf::Arena* arena);
+  RespondFocusAutoResponse(::google::protobuf::Arena* arena, const RespondFocusAutoResponse& from);
+  RespondFocusAutoResponse(::google::protobuf::Arena* arena, RespondFocusAutoResponse&& from) noexcept
+      : RespondFocusAutoResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusAutoContinuousResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse) */ {
+ public:
+  inline RespondFocusAutoContinuousResponse() : RespondFocusAutoContinuousResponse(nullptr) {}
+  ~RespondFocusAutoContinuousResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusAutoContinuousResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusAutoContinuousResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusAutoContinuousResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusAutoContinuousResponse(const RespondFocusAutoContinuousResponse& from) : RespondFocusAutoContinuousResponse(nullptr, from) {}
+  inline RespondFocusAutoContinuousResponse(RespondFocusAutoContinuousResponse&& from) noexcept
+      : RespondFocusAutoContinuousResponse(nullptr, std::move(from)) {}
+  inline RespondFocusAutoContinuousResponse& operator=(const RespondFocusAutoContinuousResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusAutoContinuousResponse& operator=(RespondFocusAutoContinuousResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusAutoContinuousResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusAutoContinuousResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusAutoContinuousResponse*>(
+        &_RespondFocusAutoContinuousResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 101;
+  friend void swap(RespondFocusAutoContinuousResponse& a, RespondFocusAutoContinuousResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusAutoContinuousResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusAutoContinuousResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusAutoContinuousResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusAutoContinuousResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusAutoContinuousResponse& from) { RespondFocusAutoContinuousResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusAutoContinuousResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse"; }
+
+ protected:
+  explicit RespondFocusAutoContinuousResponse(::google::protobuf::Arena* arena);
+  RespondFocusAutoContinuousResponse(::google::protobuf::Arena* arena, const RespondFocusAutoContinuousResponse& from);
+  RespondFocusAutoContinuousResponse(::google::protobuf::Arena* arena, RespondFocusAutoContinuousResponse&& from) noexcept
+      : RespondFocusAutoContinuousResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusAutoContinuousResponse& from_msg);
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
@@ -23314,7 +26262,7 @@ class CaptureInfo final
     return reinterpret_cast<const CaptureInfo*>(
         &_CaptureInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 90;
+  static constexpr int kIndexInFileMessages = 106;
   friend void swap(CaptureInfo& a, CaptureInfo& b) { a.Swap(&b); }
   inline void Swap(CaptureInfo* other) {
     if (other == this) return;
@@ -27674,6 +30622,630 @@ inline void RespondFocusRangeResponse::set_allocated_camera_server_result(::mavs
 
   _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusMetersRequest
+
+// -------------------------------------------------------------------
+
+// FocusMetersResponse
+
+// float focus_distance_m = 1;
+inline void FocusMetersResponse::clear_focus_distance_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_distance_m_ = 0;
+}
+inline float FocusMetersResponse::focus_distance_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusMetersResponse.focus_distance_m)
+  return _internal_focus_distance_m();
+}
+inline void FocusMetersResponse::set_focus_distance_m(float value) {
+  _internal_set_focus_distance_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusMetersResponse.focus_distance_m)
+}
+inline float FocusMetersResponse::_internal_focus_distance_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.focus_distance_m_;
+}
+inline void FocusMetersResponse::_internal_set_focus_distance_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_distance_m_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusMetersRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_meters_feedback = 1;
+inline void RespondFocusMetersRequest::clear_focus_meters_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_meters_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusMetersRequest::focus_meters_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusMetersRequest.focus_meters_feedback)
+  return _internal_focus_meters_feedback();
+}
+inline void RespondFocusMetersRequest::set_focus_meters_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_meters_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusMetersRequest.focus_meters_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusMetersRequest::_internal_focus_meters_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_meters_feedback_);
+}
+inline void RespondFocusMetersRequest::_internal_set_focus_meters_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_meters_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusMetersResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusMetersResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusMetersResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusMetersResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusMetersResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusMetersResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusMetersResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusMetersResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusMetersResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusMetersResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusMetersResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusMetersResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusMetersResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusMetersResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusMetersResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusMetersResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusAutoRequest
+
+// -------------------------------------------------------------------
+
+// FocusAutoResponse
+
+// int32 reserved = 1;
+inline void FocusAutoResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusAutoResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusAutoResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusAutoResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusAutoResponse.reserved)
+}
+inline ::int32_t FocusAutoResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusAutoResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_auto_feedback = 1;
+inline void RespondFocusAutoRequest::clear_focus_auto_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoRequest::focus_auto_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoRequest.focus_auto_feedback)
+  return _internal_focus_auto_feedback();
+}
+inline void RespondFocusAutoRequest::set_focus_auto_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_auto_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusAutoRequest.focus_auto_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoRequest::_internal_focus_auto_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_auto_feedback_);
+}
+inline void RespondFocusAutoRequest::_internal_set_focus_auto_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusAutoResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusAutoResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusAutoResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusAutoResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusAutoResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusAutoResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusAutoSingleRequest
+
+// -------------------------------------------------------------------
+
+// FocusAutoSingleResponse
+
+// int32 reserved = 1;
+inline void FocusAutoSingleResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusAutoSingleResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusAutoSingleResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusAutoSingleResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusAutoSingleResponse.reserved)
+}
+inline ::int32_t FocusAutoSingleResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusAutoSingleResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoSingleRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_auto_single_feedback = 1;
+inline void RespondFocusAutoSingleRequest::clear_focus_auto_single_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_single_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoSingleRequest::focus_auto_single_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest.focus_auto_single_feedback)
+  return _internal_focus_auto_single_feedback();
+}
+inline void RespondFocusAutoSingleRequest::set_focus_auto_single_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_auto_single_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusAutoSingleRequest.focus_auto_single_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoSingleRequest::_internal_focus_auto_single_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_auto_single_feedback_);
+}
+inline void RespondFocusAutoSingleRequest::_internal_set_focus_auto_single_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_single_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoSingleResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusAutoSingleResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusAutoSingleResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoSingleResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoSingleResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusAutoSingleResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoSingleResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoSingleResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoSingleResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoSingleResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusAutoSingleResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoSingleResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusAutoContinuousRequest
+
+// -------------------------------------------------------------------
+
+// FocusAutoContinuousResponse
+
+// int32 reserved = 1;
+inline void FocusAutoContinuousResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusAutoContinuousResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusAutoContinuousResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusAutoContinuousResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusAutoContinuousResponse.reserved)
+}
+inline ::int32_t FocusAutoContinuousResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusAutoContinuousResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoContinuousRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_auto_continuous_feedback = 1;
+inline void RespondFocusAutoContinuousRequest::clear_focus_auto_continuous_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_continuous_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoContinuousRequest::focus_auto_continuous_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest.focus_auto_continuous_feedback)
+  return _internal_focus_auto_continuous_feedback();
+}
+inline void RespondFocusAutoContinuousRequest::set_focus_auto_continuous_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_auto_continuous_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusAutoContinuousRequest.focus_auto_continuous_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusAutoContinuousRequest::_internal_focus_auto_continuous_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_auto_continuous_feedback_);
+}
+inline void RespondFocusAutoContinuousRequest::_internal_set_focus_auto_continuous_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_auto_continuous_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusAutoContinuousResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusAutoContinuousResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusAutoContinuousResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoContinuousResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusAutoContinuousResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusAutoContinuousResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoContinuousResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoContinuousResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoContinuousResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusAutoContinuousResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusAutoContinuousResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusAutoContinuousResponse.camera_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
+++ b/cpp/src/mavsdk_server/src/generated/camera_server/camera_server.pb.h
@@ -69,6 +69,24 @@ extern CaptureStatusDefaultTypeInternal _CaptureStatus_default_instance_;
 class CaptureStatusResponse;
 struct CaptureStatusResponseDefaultTypeInternal;
 extern CaptureStatusResponseDefaultTypeInternal _CaptureStatusResponse_default_instance_;
+class FocusInStartResponse;
+struct FocusInStartResponseDefaultTypeInternal;
+extern FocusInStartResponseDefaultTypeInternal _FocusInStartResponse_default_instance_;
+class FocusInStepResponse;
+struct FocusInStepResponseDefaultTypeInternal;
+extern FocusInStepResponseDefaultTypeInternal _FocusInStepResponse_default_instance_;
+class FocusOutStartResponse;
+struct FocusOutStartResponseDefaultTypeInternal;
+extern FocusOutStartResponseDefaultTypeInternal _FocusOutStartResponse_default_instance_;
+class FocusOutStepResponse;
+struct FocusOutStepResponseDefaultTypeInternal;
+extern FocusOutStepResponseDefaultTypeInternal _FocusOutStepResponse_default_instance_;
+class FocusRangeResponse;
+struct FocusRangeResponseDefaultTypeInternal;
+extern FocusRangeResponseDefaultTypeInternal _FocusRangeResponse_default_instance_;
+class FocusStopResponse;
+struct FocusStopResponseDefaultTypeInternal;
+extern FocusStopResponseDefaultTypeInternal _FocusStopResponse_default_instance_;
 class FormatStorageResponse;
 struct FormatStorageResponseDefaultTypeInternal;
 extern FormatStorageResponseDefaultTypeInternal _FormatStorageResponse_default_instance_;
@@ -90,6 +108,42 @@ extern RespondCaptureStatusRequestDefaultTypeInternal _RespondCaptureStatusReque
 class RespondCaptureStatusResponse;
 struct RespondCaptureStatusResponseDefaultTypeInternal;
 extern RespondCaptureStatusResponseDefaultTypeInternal _RespondCaptureStatusResponse_default_instance_;
+class RespondFocusInStartRequest;
+struct RespondFocusInStartRequestDefaultTypeInternal;
+extern RespondFocusInStartRequestDefaultTypeInternal _RespondFocusInStartRequest_default_instance_;
+class RespondFocusInStartResponse;
+struct RespondFocusInStartResponseDefaultTypeInternal;
+extern RespondFocusInStartResponseDefaultTypeInternal _RespondFocusInStartResponse_default_instance_;
+class RespondFocusInStepRequest;
+struct RespondFocusInStepRequestDefaultTypeInternal;
+extern RespondFocusInStepRequestDefaultTypeInternal _RespondFocusInStepRequest_default_instance_;
+class RespondFocusInStepResponse;
+struct RespondFocusInStepResponseDefaultTypeInternal;
+extern RespondFocusInStepResponseDefaultTypeInternal _RespondFocusInStepResponse_default_instance_;
+class RespondFocusOutStartRequest;
+struct RespondFocusOutStartRequestDefaultTypeInternal;
+extern RespondFocusOutStartRequestDefaultTypeInternal _RespondFocusOutStartRequest_default_instance_;
+class RespondFocusOutStartResponse;
+struct RespondFocusOutStartResponseDefaultTypeInternal;
+extern RespondFocusOutStartResponseDefaultTypeInternal _RespondFocusOutStartResponse_default_instance_;
+class RespondFocusOutStepRequest;
+struct RespondFocusOutStepRequestDefaultTypeInternal;
+extern RespondFocusOutStepRequestDefaultTypeInternal _RespondFocusOutStepRequest_default_instance_;
+class RespondFocusOutStepResponse;
+struct RespondFocusOutStepResponseDefaultTypeInternal;
+extern RespondFocusOutStepResponseDefaultTypeInternal _RespondFocusOutStepResponse_default_instance_;
+class RespondFocusRangeRequest;
+struct RespondFocusRangeRequestDefaultTypeInternal;
+extern RespondFocusRangeRequestDefaultTypeInternal _RespondFocusRangeRequest_default_instance_;
+class RespondFocusRangeResponse;
+struct RespondFocusRangeResponseDefaultTypeInternal;
+extern RespondFocusRangeResponseDefaultTypeInternal _RespondFocusRangeResponse_default_instance_;
+class RespondFocusStopRequest;
+struct RespondFocusStopRequestDefaultTypeInternal;
+extern RespondFocusStopRequestDefaultTypeInternal _RespondFocusStopRequest_default_instance_;
+class RespondFocusStopResponse;
+struct RespondFocusStopResponseDefaultTypeInternal;
+extern RespondFocusStopResponseDefaultTypeInternal _RespondFocusStopResponse_default_instance_;
 class RespondFormatStorageRequest;
 struct RespondFormatStorageRequestDefaultTypeInternal;
 extern RespondFormatStorageRequestDefaultTypeInternal _RespondFormatStorageRequest_default_instance_;
@@ -270,6 +324,24 @@ extern StorageInformationResponseDefaultTypeInternal _StorageInformationResponse
 class SubscribeCaptureStatusRequest;
 struct SubscribeCaptureStatusRequestDefaultTypeInternal;
 extern SubscribeCaptureStatusRequestDefaultTypeInternal _SubscribeCaptureStatusRequest_default_instance_;
+class SubscribeFocusInStartRequest;
+struct SubscribeFocusInStartRequestDefaultTypeInternal;
+extern SubscribeFocusInStartRequestDefaultTypeInternal _SubscribeFocusInStartRequest_default_instance_;
+class SubscribeFocusInStepRequest;
+struct SubscribeFocusInStepRequestDefaultTypeInternal;
+extern SubscribeFocusInStepRequestDefaultTypeInternal _SubscribeFocusInStepRequest_default_instance_;
+class SubscribeFocusOutStartRequest;
+struct SubscribeFocusOutStartRequestDefaultTypeInternal;
+extern SubscribeFocusOutStartRequestDefaultTypeInternal _SubscribeFocusOutStartRequest_default_instance_;
+class SubscribeFocusOutStepRequest;
+struct SubscribeFocusOutStepRequestDefaultTypeInternal;
+extern SubscribeFocusOutStepRequestDefaultTypeInternal _SubscribeFocusOutStepRequest_default_instance_;
+class SubscribeFocusRangeRequest;
+struct SubscribeFocusRangeRequestDefaultTypeInternal;
+extern SubscribeFocusRangeRequestDefaultTypeInternal _SubscribeFocusRangeRequest_default_instance_;
+class SubscribeFocusStopRequest;
+struct SubscribeFocusStopRequestDefaultTypeInternal;
+extern SubscribeFocusStopRequestDefaultTypeInternal _SubscribeFocusStopRequest_default_instance_;
 class SubscribeFormatStorageRequest;
 struct SubscribeFormatStorageRequestDefaultTypeInternal;
 extern SubscribeFormatStorageRequestDefaultTypeInternal _SubscribeFormatStorageRequest_default_instance_;
@@ -1435,7 +1507,7 @@ class VideoStreaming final
     return reinterpret_cast<const VideoStreaming*>(
         &_VideoStreaming_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 63;
+  static constexpr int kIndexInFileMessages = 87;
   friend void swap(VideoStreaming& a, VideoStreaming& b) { a.Swap(&b); }
   inline void Swap(VideoStreaming* other) {
     if (other == this) return;
@@ -1644,7 +1716,7 @@ class TrackingOffCommandResponse final
     return reinterpret_cast<const TrackingOffCommandResponse*>(
         &_TrackingOffCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 81;
+  static constexpr int kIndexInFileMessages = 105;
   friend void swap(TrackingOffCommandResponse& a, TrackingOffCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingOffCommandResponse* other) {
     if (other == this) return;
@@ -1835,7 +1907,7 @@ class TrackRectangle final
     return reinterpret_cast<const TrackRectangle*>(
         &_TrackRectangle_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 97;
+  static constexpr int kIndexInFileMessages = 121;
   friend void swap(TrackRectangle& a, TrackRectangle& b) { a.Swap(&b); }
   inline void Swap(TrackRectangle* other) {
     if (other == this) return;
@@ -2062,7 +2134,7 @@ class TrackPoint final
     return reinterpret_cast<const TrackPoint*>(
         &_TrackPoint_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 96;
+  static constexpr int kIndexInFileMessages = 120;
   friend void swap(TrackPoint& a, TrackPoint& b) { a.Swap(&b); }
   inline void Swap(TrackPoint* other) {
     if (other == this) return;
@@ -3051,7 +3123,7 @@ class SubscribeTrackingRectangleCommandRequest final
     return reinterpret_cast<const SubscribeTrackingRectangleCommandRequest*>(
         &_SubscribeTrackingRectangleCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 78;
+  static constexpr int kIndexInFileMessages = 102;
   friend void swap(SubscribeTrackingRectangleCommandRequest& a, SubscribeTrackingRectangleCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingRectangleCommandRequest* other) {
     if (other == this) return;
@@ -3197,7 +3269,7 @@ class SubscribeTrackingPointCommandRequest final
     return reinterpret_cast<const SubscribeTrackingPointCommandRequest*>(
         &_SubscribeTrackingPointCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 76;
+  static constexpr int kIndexInFileMessages = 100;
   friend void swap(SubscribeTrackingPointCommandRequest& a, SubscribeTrackingPointCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingPointCommandRequest* other) {
     if (other == this) return;
@@ -3343,7 +3415,7 @@ class SubscribeTrackingOffCommandRequest final
     return reinterpret_cast<const SubscribeTrackingOffCommandRequest*>(
         &_SubscribeTrackingOffCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 80;
+  static constexpr int kIndexInFileMessages = 104;
   friend void swap(SubscribeTrackingOffCommandRequest& a, SubscribeTrackingOffCommandRequest& b) { a.Swap(&b); }
   inline void Swap(SubscribeTrackingOffCommandRequest* other) {
     if (other == this) return;
@@ -4744,6 +4816,882 @@ class SubscribeFormatStorageRequest final
 };
 // -------------------------------------------------------------------
 
+class SubscribeFocusStopRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusStopRequest) */ {
+ public:
+  inline SubscribeFocusStopRequest() : SubscribeFocusStopRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusStopRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusStopRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusStopRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusStopRequest(const SubscribeFocusStopRequest& from) : SubscribeFocusStopRequest(nullptr, from) {}
+  inline SubscribeFocusStopRequest(SubscribeFocusStopRequest&& from) noexcept
+      : SubscribeFocusStopRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusStopRequest& operator=(const SubscribeFocusStopRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusStopRequest& operator=(SubscribeFocusStopRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusStopRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusStopRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusStopRequest*>(
+        &_SubscribeFocusStopRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 78;
+  friend void swap(SubscribeFocusStopRequest& a, SubscribeFocusStopRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusStopRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusStopRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusStopRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusStopRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusStopRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusStopRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusStopRequest"; }
+
+ protected:
+  explicit SubscribeFocusStopRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusStopRequest(::google::protobuf::Arena* arena, const SubscribeFocusStopRequest& from);
+  SubscribeFocusStopRequest(::google::protobuf::Arena* arena, SubscribeFocusStopRequest&& from) noexcept
+      : SubscribeFocusStopRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusStopRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusStopRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusRangeRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusRangeRequest) */ {
+ public:
+  inline SubscribeFocusRangeRequest() : SubscribeFocusRangeRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusRangeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusRangeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusRangeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusRangeRequest(const SubscribeFocusRangeRequest& from) : SubscribeFocusRangeRequest(nullptr, from) {}
+  inline SubscribeFocusRangeRequest(SubscribeFocusRangeRequest&& from) noexcept
+      : SubscribeFocusRangeRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusRangeRequest& operator=(const SubscribeFocusRangeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusRangeRequest& operator=(SubscribeFocusRangeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusRangeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusRangeRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusRangeRequest*>(
+        &_SubscribeFocusRangeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 82;
+  friend void swap(SubscribeFocusRangeRequest& a, SubscribeFocusRangeRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusRangeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusRangeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusRangeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusRangeRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusRangeRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusRangeRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusRangeRequest"; }
+
+ protected:
+  explicit SubscribeFocusRangeRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusRangeRequest(::google::protobuf::Arena* arena, const SubscribeFocusRangeRequest& from);
+  SubscribeFocusRangeRequest(::google::protobuf::Arena* arena, SubscribeFocusRangeRequest&& from) noexcept
+      : SubscribeFocusRangeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusRangeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusRangeRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusOutStepRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusOutStepRequest) */ {
+ public:
+  inline SubscribeFocusOutStepRequest() : SubscribeFocusOutStepRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusOutStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusOutStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusOutStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusOutStepRequest(const SubscribeFocusOutStepRequest& from) : SubscribeFocusOutStepRequest(nullptr, from) {}
+  inline SubscribeFocusOutStepRequest(SubscribeFocusOutStepRequest&& from) noexcept
+      : SubscribeFocusOutStepRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusOutStepRequest& operator=(const SubscribeFocusOutStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusOutStepRequest& operator=(SubscribeFocusOutStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusOutStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusOutStepRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusOutStepRequest*>(
+        &_SubscribeFocusOutStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 66;
+  friend void swap(SubscribeFocusOutStepRequest& a, SubscribeFocusOutStepRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusOutStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusOutStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusOutStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusOutStepRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusOutStepRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusOutStepRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusOutStepRequest"; }
+
+ protected:
+  explicit SubscribeFocusOutStepRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusOutStepRequest(::google::protobuf::Arena* arena, const SubscribeFocusOutStepRequest& from);
+  SubscribeFocusOutStepRequest(::google::protobuf::Arena* arena, SubscribeFocusOutStepRequest&& from) noexcept
+      : SubscribeFocusOutStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusOutStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusOutStepRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusOutStartRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusOutStartRequest) */ {
+ public:
+  inline SubscribeFocusOutStartRequest() : SubscribeFocusOutStartRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusOutStartRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusOutStartRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusOutStartRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusOutStartRequest(const SubscribeFocusOutStartRequest& from) : SubscribeFocusOutStartRequest(nullptr, from) {}
+  inline SubscribeFocusOutStartRequest(SubscribeFocusOutStartRequest&& from) noexcept
+      : SubscribeFocusOutStartRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusOutStartRequest& operator=(const SubscribeFocusOutStartRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusOutStartRequest& operator=(SubscribeFocusOutStartRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusOutStartRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusOutStartRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusOutStartRequest*>(
+        &_SubscribeFocusOutStartRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 74;
+  friend void swap(SubscribeFocusOutStartRequest& a, SubscribeFocusOutStartRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusOutStartRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusOutStartRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusOutStartRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusOutStartRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusOutStartRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusOutStartRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusOutStartRequest"; }
+
+ protected:
+  explicit SubscribeFocusOutStartRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusOutStartRequest(::google::protobuf::Arena* arena, const SubscribeFocusOutStartRequest& from);
+  SubscribeFocusOutStartRequest(::google::protobuf::Arena* arena, SubscribeFocusOutStartRequest&& from) noexcept
+      : SubscribeFocusOutStartRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusOutStartRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusOutStartRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusInStepRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusInStepRequest) */ {
+ public:
+  inline SubscribeFocusInStepRequest() : SubscribeFocusInStepRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusInStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusInStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusInStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusInStepRequest(const SubscribeFocusInStepRequest& from) : SubscribeFocusInStepRequest(nullptr, from) {}
+  inline SubscribeFocusInStepRequest(SubscribeFocusInStepRequest&& from) noexcept
+      : SubscribeFocusInStepRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusInStepRequest& operator=(const SubscribeFocusInStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusInStepRequest& operator=(SubscribeFocusInStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusInStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusInStepRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusInStepRequest*>(
+        &_SubscribeFocusInStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 62;
+  friend void swap(SubscribeFocusInStepRequest& a, SubscribeFocusInStepRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusInStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusInStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusInStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusInStepRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusInStepRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusInStepRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusInStepRequest"; }
+
+ protected:
+  explicit SubscribeFocusInStepRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusInStepRequest(::google::protobuf::Arena* arena, const SubscribeFocusInStepRequest& from);
+  SubscribeFocusInStepRequest(::google::protobuf::Arena* arena, SubscribeFocusInStepRequest&& from) noexcept
+      : SubscribeFocusInStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusInStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusInStepRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SubscribeFocusInStartRequest final
+    : public ::google::protobuf::internal::ZeroFieldsBase
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeFocusInStartRequest) */ {
+ public:
+  inline SubscribeFocusInStartRequest() : SubscribeFocusInStartRequest(nullptr) {}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(SubscribeFocusInStartRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(SubscribeFocusInStartRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR SubscribeFocusInStartRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline SubscribeFocusInStartRequest(const SubscribeFocusInStartRequest& from) : SubscribeFocusInStartRequest(nullptr, from) {}
+  inline SubscribeFocusInStartRequest(SubscribeFocusInStartRequest&& from) noexcept
+      : SubscribeFocusInStartRequest(nullptr, std::move(from)) {}
+  inline SubscribeFocusInStartRequest& operator=(const SubscribeFocusInStartRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SubscribeFocusInStartRequest& operator=(SubscribeFocusInStartRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const SubscribeFocusInStartRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SubscribeFocusInStartRequest* internal_default_instance() {
+    return reinterpret_cast<const SubscribeFocusInStartRequest*>(
+        &_SubscribeFocusInStartRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 70;
+  friend void swap(SubscribeFocusInStartRequest& a, SubscribeFocusInStartRequest& b) { a.Swap(&b); }
+  inline void Swap(SubscribeFocusInStartRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SubscribeFocusInStartRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  SubscribeFocusInStartRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::internal::ZeroFieldsBase::DefaultConstruct<SubscribeFocusInStartRequest>(arena);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::CopyFrom;
+  inline void CopyFrom(const SubscribeFocusInStartRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::CopyImpl(*this, from);
+  }
+  using ::google::protobuf::internal::ZeroFieldsBase::MergeFrom;
+  void MergeFrom(const SubscribeFocusInStartRequest& from) {
+    ::google::protobuf::internal::ZeroFieldsBase::MergeImpl(*this, from);
+  }
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.SubscribeFocusInStartRequest"; }
+
+ protected:
+  explicit SubscribeFocusInStartRequest(::google::protobuf::Arena* arena);
+  SubscribeFocusInStartRequest(::google::protobuf::Arena* arena, const SubscribeFocusInStartRequest& from);
+  SubscribeFocusInStartRequest(::google::protobuf::Arena* arena, SubscribeFocusInStartRequest&& from) noexcept
+      : SubscribeFocusInStartRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.SubscribeFocusInStartRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 0, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const SubscribeFocusInStartRequest& from_msg);
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SubscribeCaptureStatusRequest final
     : public ::google::protobuf::internal::ZeroFieldsBase
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.SubscribeCaptureStatusRequest) */ {
@@ -5141,7 +6089,7 @@ class StorageInformation final
     return reinterpret_cast<const StorageInformation*>(
         &_StorageInformation_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 68;
+  static constexpr int kIndexInFileMessages = 92;
   friend void swap(StorageInformation& a, StorageInformation& b) { a.Swap(&b); }
   inline void Swap(StorageInformation* other) {
     if (other == this) return;
@@ -6224,7 +7172,7 @@ class SetZoomFactorRequest final
     return reinterpret_cast<const SetZoomFactorRequest*>(
         &_SetZoomFactorRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 92;
+  static constexpr int kIndexInFileMessages = 116;
   friend void swap(SetZoomFactorRequest& a, SetZoomFactorRequest& b) { a.Swap(&b); }
   inline void Swap(SetZoomFactorRequest* other) {
     if (other == this) return;
@@ -6414,7 +7362,7 @@ class SetTrackingRectangleStatusResponse final
     return reinterpret_cast<const SetTrackingRectangleStatusResponse*>(
         &_SetTrackingRectangleStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 73;
+  static constexpr int kIndexInFileMessages = 97;
   friend void swap(SetTrackingRectangleStatusResponse& a, SetTrackingRectangleStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingRectangleStatusResponse* other) {
     if (other == this) return;
@@ -6560,7 +7508,7 @@ class SetTrackingPointStatusResponse final
     return reinterpret_cast<const SetTrackingPointStatusResponse*>(
         &_SetTrackingPointStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 71;
+  static constexpr int kIndexInFileMessages = 95;
   friend void swap(SetTrackingPointStatusResponse& a, SetTrackingPointStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingPointStatusResponse* other) {
     if (other == this) return;
@@ -6706,7 +7654,7 @@ class SetTrackingOffStatusResponse final
     return reinterpret_cast<const SetTrackingOffStatusResponse*>(
         &_SetTrackingOffStatusResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 75;
+  static constexpr int kIndexInFileMessages = 99;
   friend void swap(SetTrackingOffStatusResponse& a, SetTrackingOffStatusResponse& b) { a.Swap(&b); }
   inline void Swap(SetTrackingOffStatusResponse* other) {
     if (other == this) return;
@@ -6852,7 +7800,7 @@ class SetTrackingOffStatusRequest final
     return reinterpret_cast<const SetTrackingOffStatusRequest*>(
         &_SetTrackingOffStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 74;
+  static constexpr int kIndexInFileMessages = 98;
   friend void swap(SetTrackingOffStatusRequest& a, SetTrackingOffStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingOffStatusRequest* other) {
     if (other == this) return;
@@ -7381,7 +8329,7 @@ class SetFieldOfViewRequest final
     return reinterpret_cast<const SetFieldOfViewRequest*>(
         &_SetFieldOfViewRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 94;
+  static constexpr int kIndexInFileMessages = 118;
   friend void swap(SetFieldOfViewRequest& a, SetFieldOfViewRequest& b) { a.Swap(&b); }
   inline void Swap(SetFieldOfViewRequest* other) {
     if (other == this) return;
@@ -8348,7 +9296,7 @@ class RespondTrackingRectangleCommandRequest final
     return reinterpret_cast<const RespondTrackingRectangleCommandRequest*>(
         &_RespondTrackingRectangleCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 84;
+  static constexpr int kIndexInFileMessages = 108;
   friend void swap(RespondTrackingRectangleCommandRequest& a, RespondTrackingRectangleCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingRectangleCommandRequest* other) {
     if (other == this) return;
@@ -8539,7 +9487,7 @@ class RespondTrackingPointCommandRequest final
     return reinterpret_cast<const RespondTrackingPointCommandRequest*>(
         &_RespondTrackingPointCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 82;
+  static constexpr int kIndexInFileMessages = 106;
   friend void swap(RespondTrackingPointCommandRequest& a, RespondTrackingPointCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingPointCommandRequest* other) {
     if (other == this) return;
@@ -8730,7 +9678,7 @@ class RespondTrackingOffCommandRequest final
     return reinterpret_cast<const RespondTrackingOffCommandRequest*>(
         &_RespondTrackingOffCommandRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 86;
+  static constexpr int kIndexInFileMessages = 110;
   friend void swap(RespondTrackingOffCommandRequest& a, RespondTrackingOffCommandRequest& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingOffCommandRequest* other) {
     if (other == this) return;
@@ -10198,6 +11146,1152 @@ class RespondFormatStorageRequest final
 };
 // -------------------------------------------------------------------
 
+class RespondFocusStopRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusStopRequest) */ {
+ public:
+  inline RespondFocusStopRequest() : RespondFocusStopRequest(nullptr) {}
+  ~RespondFocusStopRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusStopRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusStopRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusStopRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusStopRequest(const RespondFocusStopRequest& from) : RespondFocusStopRequest(nullptr, from) {}
+  inline RespondFocusStopRequest(RespondFocusStopRequest&& from) noexcept
+      : RespondFocusStopRequest(nullptr, std::move(from)) {}
+  inline RespondFocusStopRequest& operator=(const RespondFocusStopRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusStopRequest& operator=(RespondFocusStopRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusStopRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusStopRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusStopRequest*>(
+        &_RespondFocusStopRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 80;
+  friend void swap(RespondFocusStopRequest& a, RespondFocusStopRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusStopRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusStopRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusStopRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusStopRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusStopRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusStopRequest& from) { RespondFocusStopRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusStopRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusStopRequest"; }
+
+ protected:
+  explicit RespondFocusStopRequest(::google::protobuf::Arena* arena);
+  RespondFocusStopRequest(::google::protobuf::Arena* arena, const RespondFocusStopRequest& from);
+  RespondFocusStopRequest(::google::protobuf::Arena* arena, RespondFocusStopRequest&& from) noexcept
+      : RespondFocusStopRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusStopFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+  void clear_focus_stop_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_stop_feedback() const;
+  void set_focus_stop_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_stop_feedback() const;
+  void _internal_set_focus_stop_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusStopRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusStopRequest& from_msg);
+    int focus_stop_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusRangeRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusRangeRequest) */ {
+ public:
+  inline RespondFocusRangeRequest() : RespondFocusRangeRequest(nullptr) {}
+  ~RespondFocusRangeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusRangeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusRangeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusRangeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusRangeRequest(const RespondFocusRangeRequest& from) : RespondFocusRangeRequest(nullptr, from) {}
+  inline RespondFocusRangeRequest(RespondFocusRangeRequest&& from) noexcept
+      : RespondFocusRangeRequest(nullptr, std::move(from)) {}
+  inline RespondFocusRangeRequest& operator=(const RespondFocusRangeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusRangeRequest& operator=(RespondFocusRangeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusRangeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusRangeRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusRangeRequest*>(
+        &_RespondFocusRangeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 84;
+  friend void swap(RespondFocusRangeRequest& a, RespondFocusRangeRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusRangeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusRangeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusRangeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusRangeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusRangeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusRangeRequest& from) { RespondFocusRangeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusRangeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusRangeRequest"; }
+
+ protected:
+  explicit RespondFocusRangeRequest(::google::protobuf::Arena* arena);
+  RespondFocusRangeRequest(::google::protobuf::Arena* arena, const RespondFocusRangeRequest& from);
+  RespondFocusRangeRequest(::google::protobuf::Arena* arena, RespondFocusRangeRequest&& from) noexcept
+      : RespondFocusRangeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusRangeFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+  void clear_focus_range_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_range_feedback() const;
+  void set_focus_range_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_range_feedback() const;
+  void _internal_set_focus_range_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusRangeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusRangeRequest& from_msg);
+    int focus_range_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusOutStepRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusOutStepRequest) */ {
+ public:
+  inline RespondFocusOutStepRequest() : RespondFocusOutStepRequest(nullptr) {}
+  ~RespondFocusOutStepRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusOutStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusOutStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusOutStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusOutStepRequest(const RespondFocusOutStepRequest& from) : RespondFocusOutStepRequest(nullptr, from) {}
+  inline RespondFocusOutStepRequest(RespondFocusOutStepRequest&& from) noexcept
+      : RespondFocusOutStepRequest(nullptr, std::move(from)) {}
+  inline RespondFocusOutStepRequest& operator=(const RespondFocusOutStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusOutStepRequest& operator=(RespondFocusOutStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusOutStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusOutStepRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusOutStepRequest*>(
+        &_RespondFocusOutStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 68;
+  friend void swap(RespondFocusOutStepRequest& a, RespondFocusOutStepRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusOutStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusOutStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusOutStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusOutStepRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusOutStepRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusOutStepRequest& from) { RespondFocusOutStepRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusOutStepRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusOutStepRequest"; }
+
+ protected:
+  explicit RespondFocusOutStepRequest(::google::protobuf::Arena* arena);
+  RespondFocusOutStepRequest(::google::protobuf::Arena* arena, const RespondFocusOutStepRequest& from);
+  RespondFocusOutStepRequest(::google::protobuf::Arena* arena, RespondFocusOutStepRequest&& from) noexcept
+      : RespondFocusOutStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusOutStepFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+  void clear_focus_out_step_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_out_step_feedback() const;
+  void set_focus_out_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_out_step_feedback() const;
+  void _internal_set_focus_out_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusOutStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusOutStepRequest& from_msg);
+    int focus_out_step_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusOutStartRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusOutStartRequest) */ {
+ public:
+  inline RespondFocusOutStartRequest() : RespondFocusOutStartRequest(nullptr) {}
+  ~RespondFocusOutStartRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusOutStartRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusOutStartRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusOutStartRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusOutStartRequest(const RespondFocusOutStartRequest& from) : RespondFocusOutStartRequest(nullptr, from) {}
+  inline RespondFocusOutStartRequest(RespondFocusOutStartRequest&& from) noexcept
+      : RespondFocusOutStartRequest(nullptr, std::move(from)) {}
+  inline RespondFocusOutStartRequest& operator=(const RespondFocusOutStartRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusOutStartRequest& operator=(RespondFocusOutStartRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusOutStartRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusOutStartRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusOutStartRequest*>(
+        &_RespondFocusOutStartRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 76;
+  friend void swap(RespondFocusOutStartRequest& a, RespondFocusOutStartRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusOutStartRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusOutStartRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusOutStartRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusOutStartRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusOutStartRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusOutStartRequest& from) { RespondFocusOutStartRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusOutStartRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusOutStartRequest"; }
+
+ protected:
+  explicit RespondFocusOutStartRequest(::google::protobuf::Arena* arena);
+  RespondFocusOutStartRequest(::google::protobuf::Arena* arena, const RespondFocusOutStartRequest& from);
+  RespondFocusOutStartRequest(::google::protobuf::Arena* arena, RespondFocusOutStartRequest&& from) noexcept
+      : RespondFocusOutStartRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusOutStartFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+  void clear_focus_out_start_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_out_start_feedback() const;
+  void set_focus_out_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_out_start_feedback() const;
+  void _internal_set_focus_out_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusOutStartRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusOutStartRequest& from_msg);
+    int focus_out_start_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusInStepRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStepRequest) */ {
+ public:
+  inline RespondFocusInStepRequest() : RespondFocusInStepRequest(nullptr) {}
+  ~RespondFocusInStepRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusInStepRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusInStepRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusInStepRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusInStepRequest(const RespondFocusInStepRequest& from) : RespondFocusInStepRequest(nullptr, from) {}
+  inline RespondFocusInStepRequest(RespondFocusInStepRequest&& from) noexcept
+      : RespondFocusInStepRequest(nullptr, std::move(from)) {}
+  inline RespondFocusInStepRequest& operator=(const RespondFocusInStepRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusInStepRequest& operator=(RespondFocusInStepRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusInStepRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusInStepRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusInStepRequest*>(
+        &_RespondFocusInStepRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 64;
+  friend void swap(RespondFocusInStepRequest& a, RespondFocusInStepRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusInStepRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusInStepRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusInStepRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusInStepRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusInStepRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusInStepRequest& from) { RespondFocusInStepRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusInStepRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusInStepRequest"; }
+
+ protected:
+  explicit RespondFocusInStepRequest(::google::protobuf::Arena* arena);
+  RespondFocusInStepRequest(::google::protobuf::Arena* arena, const RespondFocusInStepRequest& from);
+  RespondFocusInStepRequest(::google::protobuf::Arena* arena, RespondFocusInStepRequest&& from) noexcept
+      : RespondFocusInStepRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusInStepFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+  void clear_focus_in_step_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_in_step_feedback() const;
+  void set_focus_in_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_in_step_feedback() const;
+  void _internal_set_focus_in_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusInStepRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusInStepRequest& from_msg);
+    int focus_in_step_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusInStartRequest final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStartRequest) */ {
+ public:
+  inline RespondFocusInStartRequest() : RespondFocusInStartRequest(nullptr) {}
+  ~RespondFocusInStartRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusInStartRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusInStartRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusInStartRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusInStartRequest(const RespondFocusInStartRequest& from) : RespondFocusInStartRequest(nullptr, from) {}
+  inline RespondFocusInStartRequest(RespondFocusInStartRequest&& from) noexcept
+      : RespondFocusInStartRequest(nullptr, std::move(from)) {}
+  inline RespondFocusInStartRequest& operator=(const RespondFocusInStartRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusInStartRequest& operator=(RespondFocusInStartRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusInStartRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusInStartRequest* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusInStartRequest*>(
+        &_RespondFocusInStartRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 72;
+  friend void swap(RespondFocusInStartRequest& a, RespondFocusInStartRequest& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusInStartRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusInStartRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusInStartRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusInStartRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusInStartRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusInStartRequest& from) { RespondFocusInStartRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusInStartRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusInStartRequest"; }
+
+ protected:
+  explicit RespondFocusInStartRequest(::google::protobuf::Arena* arena);
+  RespondFocusInStartRequest(::google::protobuf::Arena* arena, const RespondFocusInStartRequest& from);
+  RespondFocusInStartRequest(::google::protobuf::Arena* arena, RespondFocusInStartRequest&& from) noexcept
+      : RespondFocusInStartRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusInStartFeedbackFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+  void clear_focus_in_start_feedback() ;
+  ::mavsdk::rpc::camera_server::CameraFeedback focus_in_start_feedback() const;
+  void set_focus_in_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  private:
+  ::mavsdk::rpc::camera_server::CameraFeedback _internal_focus_in_start_feedback() const;
+  void _internal_set_focus_in_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusInStartRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusInStartRequest& from_msg);
+    int focus_in_start_feedback_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ResetSettingsResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.ResetSettingsResponse) */ {
@@ -10449,7 +12543,7 @@ class Quaternion final
     return reinterpret_cast<const Quaternion*>(
         &_Quaternion_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 65;
+  static constexpr int kIndexInFileMessages = 89;
   friend void swap(Quaternion& a, Quaternion& b) { a.Swap(&b); }
   inline void Swap(Quaternion* other) {
     if (other == this) return;
@@ -10676,7 +12770,7 @@ class Position final
     return reinterpret_cast<const Position*>(
         &_Position_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 64;
+  static constexpr int kIndexInFileMessages = 88;
   friend void swap(Position& a, Position& b) { a.Swap(&b); }
   inline void Swap(Position* other) {
     if (other == this) return;
@@ -10903,7 +12997,7 @@ class Information final
     return reinterpret_cast<const Information*>(
         &_Information_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 62;
+  static constexpr int kIndexInFileMessages = 86;
   friend void swap(Information& a, Information& b) { a.Swap(&b); }
   inline void Swap(Information* other) {
     if (other == this) return;
@@ -11393,6 +13487,1152 @@ class FormatStorageResponse final
 };
 // -------------------------------------------------------------------
 
+class FocusStopResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusStopResponse) */ {
+ public:
+  inline FocusStopResponse() : FocusStopResponse(nullptr) {}
+  ~FocusStopResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusStopResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusStopResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusStopResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusStopResponse(const FocusStopResponse& from) : FocusStopResponse(nullptr, from) {}
+  inline FocusStopResponse(FocusStopResponse&& from) noexcept
+      : FocusStopResponse(nullptr, std::move(from)) {}
+  inline FocusStopResponse& operator=(const FocusStopResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusStopResponse& operator=(FocusStopResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusStopResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusStopResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusStopResponse*>(
+        &_FocusStopResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 79;
+  friend void swap(FocusStopResponse& a, FocusStopResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusStopResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusStopResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusStopResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusStopResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusStopResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusStopResponse& from) { FocusStopResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusStopResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusStopResponse"; }
+
+ protected:
+  explicit FocusStopResponse(::google::protobuf::Arena* arena);
+  FocusStopResponse(::google::protobuf::Arena* arena, const FocusStopResponse& from);
+  FocusStopResponse(::google::protobuf::Arena* arena, FocusStopResponse&& from) noexcept
+      : FocusStopResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusStopResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusStopResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusRangeResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusRangeResponse) */ {
+ public:
+  inline FocusRangeResponse() : FocusRangeResponse(nullptr) {}
+  ~FocusRangeResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusRangeResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusRangeResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusRangeResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusRangeResponse(const FocusRangeResponse& from) : FocusRangeResponse(nullptr, from) {}
+  inline FocusRangeResponse(FocusRangeResponse&& from) noexcept
+      : FocusRangeResponse(nullptr, std::move(from)) {}
+  inline FocusRangeResponse& operator=(const FocusRangeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusRangeResponse& operator=(FocusRangeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusRangeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusRangeResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusRangeResponse*>(
+        &_FocusRangeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 83;
+  friend void swap(FocusRangeResponse& a, FocusRangeResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusRangeResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusRangeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusRangeResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusRangeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusRangeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusRangeResponse& from) { FocusRangeResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusRangeResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusRangeResponse"; }
+
+ protected:
+  explicit FocusRangeResponse(::google::protobuf::Arena* arena);
+  FocusRangeResponse(::google::protobuf::Arena* arena, const FocusRangeResponse& from);
+  FocusRangeResponse(::google::protobuf::Arena* arena, FocusRangeResponse&& from) noexcept
+      : FocusRangeResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFocusDistanceMFieldNumber = 1,
+  };
+  // float focus_distance_m = 1;
+  void clear_focus_distance_m() ;
+  float focus_distance_m() const;
+  void set_focus_distance_m(float value);
+
+  private:
+  float _internal_focus_distance_m() const;
+  void _internal_set_focus_distance_m(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusRangeResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusRangeResponse& from_msg);
+    float focus_distance_m_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusOutStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusOutStepResponse) */ {
+ public:
+  inline FocusOutStepResponse() : FocusOutStepResponse(nullptr) {}
+  ~FocusOutStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusOutStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusOutStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusOutStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusOutStepResponse(const FocusOutStepResponse& from) : FocusOutStepResponse(nullptr, from) {}
+  inline FocusOutStepResponse(FocusOutStepResponse&& from) noexcept
+      : FocusOutStepResponse(nullptr, std::move(from)) {}
+  inline FocusOutStepResponse& operator=(const FocusOutStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusOutStepResponse& operator=(FocusOutStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusOutStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusOutStepResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusOutStepResponse*>(
+        &_FocusOutStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 67;
+  friend void swap(FocusOutStepResponse& a, FocusOutStepResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusOutStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusOutStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusOutStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusOutStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusOutStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusOutStepResponse& from) { FocusOutStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusOutStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusOutStepResponse"; }
+
+ protected:
+  explicit FocusOutStepResponse(::google::protobuf::Arena* arena);
+  FocusOutStepResponse(::google::protobuf::Arena* arena, const FocusOutStepResponse& from);
+  FocusOutStepResponse(::google::protobuf::Arena* arena, FocusOutStepResponse&& from) noexcept
+      : FocusOutStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusOutStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusOutStepResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusOutStartResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusOutStartResponse) */ {
+ public:
+  inline FocusOutStartResponse() : FocusOutStartResponse(nullptr) {}
+  ~FocusOutStartResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusOutStartResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusOutStartResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusOutStartResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusOutStartResponse(const FocusOutStartResponse& from) : FocusOutStartResponse(nullptr, from) {}
+  inline FocusOutStartResponse(FocusOutStartResponse&& from) noexcept
+      : FocusOutStartResponse(nullptr, std::move(from)) {}
+  inline FocusOutStartResponse& operator=(const FocusOutStartResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusOutStartResponse& operator=(FocusOutStartResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusOutStartResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusOutStartResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusOutStartResponse*>(
+        &_FocusOutStartResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 75;
+  friend void swap(FocusOutStartResponse& a, FocusOutStartResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusOutStartResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusOutStartResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusOutStartResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusOutStartResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusOutStartResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusOutStartResponse& from) { FocusOutStartResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusOutStartResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusOutStartResponse"; }
+
+ protected:
+  explicit FocusOutStartResponse(::google::protobuf::Arena* arena);
+  FocusOutStartResponse(::google::protobuf::Arena* arena, const FocusOutStartResponse& from);
+  FocusOutStartResponse(::google::protobuf::Arena* arena, FocusOutStartResponse&& from) noexcept
+      : FocusOutStartResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusOutStartResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusOutStartResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusInStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusInStepResponse) */ {
+ public:
+  inline FocusInStepResponse() : FocusInStepResponse(nullptr) {}
+  ~FocusInStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusInStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusInStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusInStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusInStepResponse(const FocusInStepResponse& from) : FocusInStepResponse(nullptr, from) {}
+  inline FocusInStepResponse(FocusInStepResponse&& from) noexcept
+      : FocusInStepResponse(nullptr, std::move(from)) {}
+  inline FocusInStepResponse& operator=(const FocusInStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusInStepResponse& operator=(FocusInStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusInStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusInStepResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusInStepResponse*>(
+        &_FocusInStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 63;
+  friend void swap(FocusInStepResponse& a, FocusInStepResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusInStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusInStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusInStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusInStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusInStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusInStepResponse& from) { FocusInStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusInStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusInStepResponse"; }
+
+ protected:
+  explicit FocusInStepResponse(::google::protobuf::Arena* arena);
+  FocusInStepResponse(::google::protobuf::Arena* arena, const FocusInStepResponse& from);
+  FocusInStepResponse(::google::protobuf::Arena* arena, FocusInStepResponse&& from) noexcept
+      : FocusInStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusInStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusInStepResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class FocusInStartResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.FocusInStartResponse) */ {
+ public:
+  inline FocusInStartResponse() : FocusInStartResponse(nullptr) {}
+  ~FocusInStartResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(FocusInStartResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(FocusInStartResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR FocusInStartResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline FocusInStartResponse(const FocusInStartResponse& from) : FocusInStartResponse(nullptr, from) {}
+  inline FocusInStartResponse(FocusInStartResponse&& from) noexcept
+      : FocusInStartResponse(nullptr, std::move(from)) {}
+  inline FocusInStartResponse& operator=(const FocusInStartResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline FocusInStartResponse& operator=(FocusInStartResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const FocusInStartResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const FocusInStartResponse* internal_default_instance() {
+    return reinterpret_cast<const FocusInStartResponse*>(
+        &_FocusInStartResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 71;
+  friend void swap(FocusInStartResponse& a, FocusInStartResponse& b) { a.Swap(&b); }
+  inline void Swap(FocusInStartResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(FocusInStartResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  FocusInStartResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<FocusInStartResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const FocusInStartResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const FocusInStartResponse& from) { FocusInStartResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(FocusInStartResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.FocusInStartResponse"; }
+
+ protected:
+  explicit FocusInStartResponse(::google::protobuf::Arena* arena);
+  FocusInStartResponse(::google::protobuf::Arena* arena, const FocusInStartResponse& from);
+  FocusInStartResponse(::google::protobuf::Arena* arena, FocusInStartResponse&& from) noexcept
+      : FocusInStartResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kReservedFieldNumber = 1,
+  };
+  // int32 reserved = 1;
+  void clear_reserved() ;
+  ::int32_t reserved() const;
+  void set_reserved(::int32_t value);
+
+  private:
+  ::int32_t _internal_reserved() const;
+  void _internal_set_reserved(::int32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.FocusInStartResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const FocusInStartResponse& from_msg);
+    ::int32_t reserved_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CaptureStatusResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.CaptureStatusResponse) */ {
@@ -11644,7 +14884,7 @@ class CaptureStatus final
     return reinterpret_cast<const CaptureStatus*>(
         &_CaptureStatus_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 69;
+  static constexpr int kIndexInFileMessages = 93;
   friend void swap(CaptureStatus& a, CaptureStatus& b) { a.Swap(&b); }
   inline void Swap(CaptureStatus* other) {
     if (other == this) return;
@@ -11935,7 +15175,7 @@ class CameraServerResult final
     return reinterpret_cast<const CameraServerResult*>(
         &_CameraServerResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 67;
+  static constexpr int kIndexInFileMessages = 91;
   friend void swap(CameraServerResult& a, CameraServerResult& b) { a.Swap(&b); }
   inline void Swap(CameraServerResult* other) {
     if (other == this) return;
@@ -12170,7 +15410,7 @@ class TrackingRectangleCommandResponse final
     return reinterpret_cast<const TrackingRectangleCommandResponse*>(
         &_TrackingRectangleCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 79;
+  static constexpr int kIndexInFileMessages = 103;
   friend void swap(TrackingRectangleCommandResponse& a, TrackingRectangleCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingRectangleCommandResponse* other) {
     if (other == this) return;
@@ -12367,7 +15607,7 @@ class TrackingPointCommandResponse final
     return reinterpret_cast<const TrackingPointCommandResponse*>(
         &_TrackingPointCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 77;
+  static constexpr int kIndexInFileMessages = 101;
   friend void swap(TrackingPointCommandResponse& a, TrackingPointCommandResponse& b) { a.Swap(&b); }
   inline void Swap(TrackingPointCommandResponse* other) {
     if (other == this) return;
@@ -12564,7 +15804,7 @@ class SetZoomFactorResponse final
     return reinterpret_cast<const SetZoomFactorResponse*>(
         &_SetZoomFactorResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 93;
+  static constexpr int kIndexInFileMessages = 117;
   friend void swap(SetZoomFactorResponse& a, SetZoomFactorResponse& b) { a.Swap(&b); }
   inline void Swap(SetZoomFactorResponse* other) {
     if (other == this) return;
@@ -13155,7 +16395,7 @@ class SetTrackingRectangleStatusRequest final
     return reinterpret_cast<const SetTrackingRectangleStatusRequest*>(
         &_SetTrackingRectangleStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 72;
+  static constexpr int kIndexInFileMessages = 96;
   friend void swap(SetTrackingRectangleStatusRequest& a, SetTrackingRectangleStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingRectangleStatusRequest* other) {
     if (other == this) return;
@@ -13352,7 +16592,7 @@ class SetTrackingPointStatusRequest final
     return reinterpret_cast<const SetTrackingPointStatusRequest*>(
         &_SetTrackingPointStatusRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 70;
+  static constexpr int kIndexInFileMessages = 94;
   friend void swap(SetTrackingPointStatusRequest& a, SetTrackingPointStatusRequest& b) { a.Swap(&b); }
   inline void Swap(SetTrackingPointStatusRequest* other) {
     if (other == this) return;
@@ -13549,7 +16789,7 @@ class SetPositionResponse final
     return reinterpret_cast<const SetPositionResponse*>(
         &_SetPositionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 113;
   friend void swap(SetPositionResponse& a, SetPositionResponse& b) { a.Swap(&b); }
   inline void Swap(SetPositionResponse* other) {
     if (other == this) return;
@@ -13746,7 +16986,7 @@ class SetPositionRequest final
     return reinterpret_cast<const SetPositionRequest*>(
         &_SetPositionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 112;
   friend void swap(SetPositionRequest& a, SetPositionRequest& b) { a.Swap(&b); }
   inline void Swap(SetPositionRequest* other) {
     if (other == this) return;
@@ -14534,7 +17774,7 @@ class SetFieldOfViewResponse final
     return reinterpret_cast<const SetFieldOfViewResponse*>(
         &_SetFieldOfViewResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 95;
+  static constexpr int kIndexInFileMessages = 119;
   friend void swap(SetFieldOfViewResponse& a, SetFieldOfViewResponse& b) { a.Swap(&b); }
   inline void Swap(SetFieldOfViewResponse* other) {
     if (other == this) return;
@@ -14731,7 +17971,7 @@ class SetAttitudeQuaternionResponse final
     return reinterpret_cast<const SetAttitudeQuaternionResponse*>(
         &_SetAttitudeQuaternionResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 91;
+  static constexpr int kIndexInFileMessages = 115;
   friend void swap(SetAttitudeQuaternionResponse& a, SetAttitudeQuaternionResponse& b) { a.Swap(&b); }
   inline void Swap(SetAttitudeQuaternionResponse* other) {
     if (other == this) return;
@@ -14928,7 +18168,7 @@ class SetAttitudeQuaternionRequest final
     return reinterpret_cast<const SetAttitudeQuaternionRequest*>(
         &_SetAttitudeQuaternionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 90;
+  static constexpr int kIndexInFileMessages = 114;
   friend void swap(SetAttitudeQuaternionRequest& a, SetAttitudeQuaternionRequest& b) { a.Swap(&b); }
   inline void Swap(SetAttitudeQuaternionRequest* other) {
     if (other == this) return;
@@ -15913,7 +19153,7 @@ class RespondTrackingRectangleCommandResponse final
     return reinterpret_cast<const RespondTrackingRectangleCommandResponse*>(
         &_RespondTrackingRectangleCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 85;
+  static constexpr int kIndexInFileMessages = 109;
   friend void swap(RespondTrackingRectangleCommandResponse& a, RespondTrackingRectangleCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingRectangleCommandResponse* other) {
     if (other == this) return;
@@ -16110,7 +19350,7 @@ class RespondTrackingPointCommandResponse final
     return reinterpret_cast<const RespondTrackingPointCommandResponse*>(
         &_RespondTrackingPointCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 83;
+  static constexpr int kIndexInFileMessages = 107;
   friend void swap(RespondTrackingPointCommandResponse& a, RespondTrackingPointCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingPointCommandResponse* other) {
     if (other == this) return;
@@ -16307,7 +19547,7 @@ class RespondTrackingOffCommandResponse final
     return reinterpret_cast<const RespondTrackingOffCommandResponse*>(
         &_RespondTrackingOffCommandResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 87;
+  static constexpr int kIndexInFileMessages = 111;
   friend void swap(RespondTrackingOffCommandResponse& a, RespondTrackingOffCommandResponse& b) { a.Swap(&b); }
   inline void Swap(RespondTrackingOffCommandResponse* other) {
     if (other == this) return;
@@ -18426,6 +21666,1188 @@ class RespondFormatStorageResponse final
 };
 // -------------------------------------------------------------------
 
+class RespondFocusStopResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusStopResponse) */ {
+ public:
+  inline RespondFocusStopResponse() : RespondFocusStopResponse(nullptr) {}
+  ~RespondFocusStopResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusStopResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusStopResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusStopResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusStopResponse(const RespondFocusStopResponse& from) : RespondFocusStopResponse(nullptr, from) {}
+  inline RespondFocusStopResponse(RespondFocusStopResponse&& from) noexcept
+      : RespondFocusStopResponse(nullptr, std::move(from)) {}
+  inline RespondFocusStopResponse& operator=(const RespondFocusStopResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusStopResponse& operator=(RespondFocusStopResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusStopResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusStopResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusStopResponse*>(
+        &_RespondFocusStopResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 81;
+  friend void swap(RespondFocusStopResponse& a, RespondFocusStopResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusStopResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusStopResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusStopResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusStopResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusStopResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusStopResponse& from) { RespondFocusStopResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusStopResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusStopResponse"; }
+
+ protected:
+  explicit RespondFocusStopResponse(::google::protobuf::Arena* arena);
+  RespondFocusStopResponse(::google::protobuf::Arena* arena, const RespondFocusStopResponse& from);
+  RespondFocusStopResponse(::google::protobuf::Arena* arena, RespondFocusStopResponse&& from) noexcept
+      : RespondFocusStopResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusStopResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusStopResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusRangeResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusRangeResponse) */ {
+ public:
+  inline RespondFocusRangeResponse() : RespondFocusRangeResponse(nullptr) {}
+  ~RespondFocusRangeResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusRangeResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusRangeResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusRangeResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusRangeResponse(const RespondFocusRangeResponse& from) : RespondFocusRangeResponse(nullptr, from) {}
+  inline RespondFocusRangeResponse(RespondFocusRangeResponse&& from) noexcept
+      : RespondFocusRangeResponse(nullptr, std::move(from)) {}
+  inline RespondFocusRangeResponse& operator=(const RespondFocusRangeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusRangeResponse& operator=(RespondFocusRangeResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusRangeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusRangeResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusRangeResponse*>(
+        &_RespondFocusRangeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 85;
+  friend void swap(RespondFocusRangeResponse& a, RespondFocusRangeResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusRangeResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusRangeResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusRangeResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusRangeResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusRangeResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusRangeResponse& from) { RespondFocusRangeResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusRangeResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusRangeResponse"; }
+
+ protected:
+  explicit RespondFocusRangeResponse(::google::protobuf::Arena* arena);
+  RespondFocusRangeResponse(::google::protobuf::Arena* arena, const RespondFocusRangeResponse& from);
+  RespondFocusRangeResponse(::google::protobuf::Arena* arena, RespondFocusRangeResponse&& from) noexcept
+      : RespondFocusRangeResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusRangeResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusRangeResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusOutStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusOutStepResponse) */ {
+ public:
+  inline RespondFocusOutStepResponse() : RespondFocusOutStepResponse(nullptr) {}
+  ~RespondFocusOutStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusOutStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusOutStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusOutStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusOutStepResponse(const RespondFocusOutStepResponse& from) : RespondFocusOutStepResponse(nullptr, from) {}
+  inline RespondFocusOutStepResponse(RespondFocusOutStepResponse&& from) noexcept
+      : RespondFocusOutStepResponse(nullptr, std::move(from)) {}
+  inline RespondFocusOutStepResponse& operator=(const RespondFocusOutStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusOutStepResponse& operator=(RespondFocusOutStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusOutStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusOutStepResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusOutStepResponse*>(
+        &_RespondFocusOutStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 69;
+  friend void swap(RespondFocusOutStepResponse& a, RespondFocusOutStepResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusOutStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusOutStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusOutStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusOutStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusOutStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusOutStepResponse& from) { RespondFocusOutStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusOutStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusOutStepResponse"; }
+
+ protected:
+  explicit RespondFocusOutStepResponse(::google::protobuf::Arena* arena);
+  RespondFocusOutStepResponse(::google::protobuf::Arena* arena, const RespondFocusOutStepResponse& from);
+  RespondFocusOutStepResponse(::google::protobuf::Arena* arena, RespondFocusOutStepResponse&& from) noexcept
+      : RespondFocusOutStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusOutStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusOutStepResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusOutStartResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusOutStartResponse) */ {
+ public:
+  inline RespondFocusOutStartResponse() : RespondFocusOutStartResponse(nullptr) {}
+  ~RespondFocusOutStartResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusOutStartResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusOutStartResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusOutStartResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusOutStartResponse(const RespondFocusOutStartResponse& from) : RespondFocusOutStartResponse(nullptr, from) {}
+  inline RespondFocusOutStartResponse(RespondFocusOutStartResponse&& from) noexcept
+      : RespondFocusOutStartResponse(nullptr, std::move(from)) {}
+  inline RespondFocusOutStartResponse& operator=(const RespondFocusOutStartResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusOutStartResponse& operator=(RespondFocusOutStartResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusOutStartResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusOutStartResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusOutStartResponse*>(
+        &_RespondFocusOutStartResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 77;
+  friend void swap(RespondFocusOutStartResponse& a, RespondFocusOutStartResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusOutStartResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusOutStartResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusOutStartResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusOutStartResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusOutStartResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusOutStartResponse& from) { RespondFocusOutStartResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusOutStartResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusOutStartResponse"; }
+
+ protected:
+  explicit RespondFocusOutStartResponse(::google::protobuf::Arena* arena);
+  RespondFocusOutStartResponse(::google::protobuf::Arena* arena, const RespondFocusOutStartResponse& from);
+  RespondFocusOutStartResponse(::google::protobuf::Arena* arena, RespondFocusOutStartResponse&& from) noexcept
+      : RespondFocusOutStartResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusOutStartResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusOutStartResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusInStepResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStepResponse) */ {
+ public:
+  inline RespondFocusInStepResponse() : RespondFocusInStepResponse(nullptr) {}
+  ~RespondFocusInStepResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusInStepResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusInStepResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusInStepResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusInStepResponse(const RespondFocusInStepResponse& from) : RespondFocusInStepResponse(nullptr, from) {}
+  inline RespondFocusInStepResponse(RespondFocusInStepResponse&& from) noexcept
+      : RespondFocusInStepResponse(nullptr, std::move(from)) {}
+  inline RespondFocusInStepResponse& operator=(const RespondFocusInStepResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusInStepResponse& operator=(RespondFocusInStepResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusInStepResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusInStepResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusInStepResponse*>(
+        &_RespondFocusInStepResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 65;
+  friend void swap(RespondFocusInStepResponse& a, RespondFocusInStepResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusInStepResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusInStepResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusInStepResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusInStepResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusInStepResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusInStepResponse& from) { RespondFocusInStepResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusInStepResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusInStepResponse"; }
+
+ protected:
+  explicit RespondFocusInStepResponse(::google::protobuf::Arena* arena);
+  RespondFocusInStepResponse(::google::protobuf::Arena* arena, const RespondFocusInStepResponse& from);
+  RespondFocusInStepResponse(::google::protobuf::Arena* arena, RespondFocusInStepResponse&& from) noexcept
+      : RespondFocusInStepResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusInStepResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusInStepResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RespondFocusInStartResponse final
+    : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondFocusInStartResponse) */ {
+ public:
+  inline RespondFocusInStartResponse() : RespondFocusInStartResponse(nullptr) {}
+  ~RespondFocusInStartResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(RespondFocusInStartResponse* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(RespondFocusInStartResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR RespondFocusInStartResponse(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline RespondFocusInStartResponse(const RespondFocusInStartResponse& from) : RespondFocusInStartResponse(nullptr, from) {}
+  inline RespondFocusInStartResponse(RespondFocusInStartResponse&& from) noexcept
+      : RespondFocusInStartResponse(nullptr, std::move(from)) {}
+  inline RespondFocusInStartResponse& operator=(const RespondFocusInStartResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RespondFocusInStartResponse& operator=(RespondFocusInStartResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const RespondFocusInStartResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const RespondFocusInStartResponse* internal_default_instance() {
+    return reinterpret_cast<const RespondFocusInStartResponse*>(
+        &_RespondFocusInStartResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 73;
+  friend void swap(RespondFocusInStartResponse& a, RespondFocusInStartResponse& b) { a.Swap(&b); }
+  inline void Swap(RespondFocusInStartResponse* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RespondFocusInStartResponse* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  RespondFocusInStartResponse* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<RespondFocusInStartResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const RespondFocusInStartResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const RespondFocusInStartResponse& from) { RespondFocusInStartResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(RespondFocusInStartResponse* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "mavsdk.rpc.camera_server.RespondFocusInStartResponse"; }
+
+ protected:
+  explicit RespondFocusInStartResponse(::google::protobuf::Arena* arena);
+  RespondFocusInStartResponse(::google::protobuf::Arena* arena, const RespondFocusInStartResponse& from);
+  RespondFocusInStartResponse(::google::protobuf::Arena* arena, RespondFocusInStartResponse&& from) noexcept
+      : RespondFocusInStartResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kCameraServerResultFieldNumber = 1,
+  };
+  // .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+  bool has_camera_server_result() const;
+  void clear_camera_server_result() ;
+  const ::mavsdk::rpc::camera_server::CameraServerResult& camera_server_result() const;
+  PROTOBUF_NODISCARD ::mavsdk::rpc::camera_server::CameraServerResult* release_camera_server_result();
+  ::mavsdk::rpc::camera_server::CameraServerResult* mutable_camera_server_result();
+  void set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  void unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value);
+  ::mavsdk::rpc::camera_server::CameraServerResult* unsafe_arena_release_camera_server_result();
+
+  private:
+  const ::mavsdk::rpc::camera_server::CameraServerResult& _internal_camera_server_result() const;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _internal_mutable_camera_server_result();
+
+  public:
+  // @@protoc_insertion_point(class_scope:mavsdk.rpc.camera_server.RespondFocusInStartResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const RespondFocusInStartResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::mavsdk::rpc::camera_server::CameraServerResult* camera_server_result_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_camera_5fserver_2fcamera_5fserver_2eproto;
+};
+// -------------------------------------------------------------------
+
 class RespondCaptureStatusResponse final
     : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:mavsdk.rpc.camera_server.RespondCaptureStatusResponse) */ {
@@ -18892,7 +23314,7 @@ class CaptureInfo final
     return reinterpret_cast<const CaptureInfo*>(
         &_CaptureInfo_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 66;
+  static constexpr int kIndexInFileMessages = 90;
   friend void swap(CaptureInfo& a, CaptureInfo& b) { a.Swap(&b); }
   inline void Swap(CaptureInfo* other) {
     if (other == this) return;
@@ -22316,6 +26738,942 @@ inline void RespondZoomRangeResponse::set_allocated_camera_server_result(::mavsd
 
   _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
   // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondZoomRangeResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusInStepRequest
+
+// -------------------------------------------------------------------
+
+// FocusInStepResponse
+
+// int32 reserved = 1;
+inline void FocusInStepResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusInStepResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusInStepResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusInStepResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusInStepResponse.reserved)
+}
+inline ::int32_t FocusInStepResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusInStepResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusInStepRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_in_step_feedback = 1;
+inline void RespondFocusInStepRequest::clear_focus_in_step_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_in_step_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusInStepRequest::focus_in_step_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusInStepRequest.focus_in_step_feedback)
+  return _internal_focus_in_step_feedback();
+}
+inline void RespondFocusInStepRequest::set_focus_in_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_in_step_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusInStepRequest.focus_in_step_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusInStepRequest::_internal_focus_in_step_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_in_step_feedback_);
+}
+inline void RespondFocusInStepRequest::_internal_set_focus_in_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_in_step_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusInStepResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusInStepResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusInStepResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusInStepResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusInStepResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusInStepResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusInStepResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusInStepResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStepResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStepResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusInStepResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStepResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStepResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusInStepResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusInStepResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusInStepResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusOutStepRequest
+
+// -------------------------------------------------------------------
+
+// FocusOutStepResponse
+
+// int32 reserved = 1;
+inline void FocusOutStepResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusOutStepResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusOutStepResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusOutStepResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusOutStepResponse.reserved)
+}
+inline ::int32_t FocusOutStepResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusOutStepResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusOutStepRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_out_step_feedback = 1;
+inline void RespondFocusOutStepRequest::clear_focus_out_step_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_out_step_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusOutStepRequest::focus_out_step_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusOutStepRequest.focus_out_step_feedback)
+  return _internal_focus_out_step_feedback();
+}
+inline void RespondFocusOutStepRequest::set_focus_out_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_out_step_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusOutStepRequest.focus_out_step_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusOutStepRequest::_internal_focus_out_step_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_out_step_feedback_);
+}
+inline void RespondFocusOutStepRequest::_internal_set_focus_out_step_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_out_step_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusOutStepResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusOutStepResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusOutStepResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusOutStepResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusOutStepResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusOutStepResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusOutStepResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusOutStepResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStepResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStepResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusOutStepResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStepResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStepResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusOutStepResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusOutStepResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusOutStepResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusInStartRequest
+
+// -------------------------------------------------------------------
+
+// FocusInStartResponse
+
+// int32 reserved = 1;
+inline void FocusInStartResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusInStartResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusInStartResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusInStartResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusInStartResponse.reserved)
+}
+inline ::int32_t FocusInStartResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusInStartResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusInStartRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_in_start_feedback = 1;
+inline void RespondFocusInStartRequest::clear_focus_in_start_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_in_start_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusInStartRequest::focus_in_start_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusInStartRequest.focus_in_start_feedback)
+  return _internal_focus_in_start_feedback();
+}
+inline void RespondFocusInStartRequest::set_focus_in_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_in_start_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusInStartRequest.focus_in_start_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusInStartRequest::_internal_focus_in_start_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_in_start_feedback_);
+}
+inline void RespondFocusInStartRequest::_internal_set_focus_in_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_in_start_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusInStartResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusInStartResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusInStartResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusInStartResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusInStartResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusInStartResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusInStartResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusInStartResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStartResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStartResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusInStartResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStartResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusInStartResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusInStartResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusInStartResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusInStartResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusOutStartRequest
+
+// -------------------------------------------------------------------
+
+// FocusOutStartResponse
+
+// int32 reserved = 1;
+inline void FocusOutStartResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusOutStartResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusOutStartResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusOutStartResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusOutStartResponse.reserved)
+}
+inline ::int32_t FocusOutStartResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusOutStartResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusOutStartRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_out_start_feedback = 1;
+inline void RespondFocusOutStartRequest::clear_focus_out_start_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_out_start_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusOutStartRequest::focus_out_start_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusOutStartRequest.focus_out_start_feedback)
+  return _internal_focus_out_start_feedback();
+}
+inline void RespondFocusOutStartRequest::set_focus_out_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_out_start_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusOutStartRequest.focus_out_start_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusOutStartRequest::_internal_focus_out_start_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_out_start_feedback_);
+}
+inline void RespondFocusOutStartRequest::_internal_set_focus_out_start_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_out_start_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusOutStartResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusOutStartResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusOutStartResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusOutStartResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusOutStartResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusOutStartResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusOutStartResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusOutStartResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStartResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStartResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusOutStartResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStartResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusOutStartResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusOutStartResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusOutStartResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusOutStartResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusStopRequest
+
+// -------------------------------------------------------------------
+
+// FocusStopResponse
+
+// int32 reserved = 1;
+inline void FocusStopResponse::clear_reserved() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = 0;
+}
+inline ::int32_t FocusStopResponse::reserved() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusStopResponse.reserved)
+  return _internal_reserved();
+}
+inline void FocusStopResponse::set_reserved(::int32_t value) {
+  _internal_set_reserved(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusStopResponse.reserved)
+}
+inline ::int32_t FocusStopResponse::_internal_reserved() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.reserved_;
+}
+inline void FocusStopResponse::_internal_set_reserved(::int32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.reserved_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusStopRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_stop_feedback = 1;
+inline void RespondFocusStopRequest::clear_focus_stop_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_stop_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusStopRequest::focus_stop_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusStopRequest.focus_stop_feedback)
+  return _internal_focus_stop_feedback();
+}
+inline void RespondFocusStopRequest::set_focus_stop_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_stop_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusStopRequest.focus_stop_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusStopRequest::_internal_focus_stop_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_stop_feedback_);
+}
+inline void RespondFocusStopRequest::_internal_set_focus_stop_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_stop_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusStopResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusStopResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusStopResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusStopResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusStopResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusStopResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusStopResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusStopResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusStopResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusStopResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusStopResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusStopResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusStopResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusStopResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusStopResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusStopResponse.camera_server_result)
+}
+
+// -------------------------------------------------------------------
+
+// SubscribeFocusRangeRequest
+
+// -------------------------------------------------------------------
+
+// FocusRangeResponse
+
+// float focus_distance_m = 1;
+inline void FocusRangeResponse::clear_focus_distance_m() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_distance_m_ = 0;
+}
+inline float FocusRangeResponse::focus_distance_m() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.FocusRangeResponse.focus_distance_m)
+  return _internal_focus_distance_m();
+}
+inline void FocusRangeResponse::set_focus_distance_m(float value) {
+  _internal_set_focus_distance_m(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.FocusRangeResponse.focus_distance_m)
+}
+inline float FocusRangeResponse::_internal_focus_distance_m() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.focus_distance_m_;
+}
+inline void FocusRangeResponse::_internal_set_focus_distance_m(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_distance_m_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusRangeRequest
+
+// .mavsdk.rpc.camera_server.CameraFeedback focus_range_feedback = 1;
+inline void RespondFocusRangeRequest::clear_focus_range_feedback() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_range_feedback_ = 0;
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusRangeRequest::focus_range_feedback() const {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusRangeRequest.focus_range_feedback)
+  return _internal_focus_range_feedback();
+}
+inline void RespondFocusRangeRequest::set_focus_range_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  _internal_set_focus_range_feedback(value);
+  // @@protoc_insertion_point(field_set:mavsdk.rpc.camera_server.RespondFocusRangeRequest.focus_range_feedback)
+}
+inline ::mavsdk::rpc::camera_server::CameraFeedback RespondFocusRangeRequest::_internal_focus_range_feedback() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::mavsdk::rpc::camera_server::CameraFeedback>(_impl_.focus_range_feedback_);
+}
+inline void RespondFocusRangeRequest::_internal_set_focus_range_feedback(::mavsdk::rpc::camera_server::CameraFeedback value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.focus_range_feedback_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// RespondFocusRangeResponse
+
+// .mavsdk.rpc.camera_server.CameraServerResult camera_server_result = 1;
+inline bool RespondFocusRangeResponse::has_camera_server_result() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.camera_server_result_ != nullptr);
+  return value;
+}
+inline void RespondFocusRangeResponse::clear_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ != nullptr) _impl_.camera_server_result_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusRangeResponse::_internal_camera_server_result() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::mavsdk::rpc::camera_server::CameraServerResult* p = _impl_.camera_server_result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::mavsdk::rpc::camera_server::CameraServerResult&>(::mavsdk::rpc::camera_server::_CameraServerResult_default_instance_);
+}
+inline const ::mavsdk::rpc::camera_server::CameraServerResult& RespondFocusRangeResponse::camera_server_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
+  return _internal_camera_server_result();
+}
+inline void RespondFocusRangeResponse::unsafe_arena_set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.camera_server_result_);
+  }
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusRangeResponse::release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* released = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusRangeResponse::unsafe_arena_release_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* temp = _impl_.camera_server_result_;
+  _impl_.camera_server_result_ = nullptr;
+  return temp;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusRangeResponse::_internal_mutable_camera_server_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.camera_server_result_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::mavsdk::rpc::camera_server::CameraServerResult>(GetArena());
+    _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(p);
+  }
+  return _impl_.camera_server_result_;
+}
+inline ::mavsdk::rpc::camera_server::CameraServerResult* RespondFocusRangeResponse::mutable_camera_server_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::mavsdk::rpc::camera_server::CameraServerResult* _msg = _internal_mutable_camera_server_result();
+  // @@protoc_insertion_point(field_mutable:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
+  return _msg;
+}
+inline void RespondFocusRangeResponse::set_allocated_camera_server_result(::mavsdk::rpc::camera_server::CameraServerResult* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.camera_server_result_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.camera_server_result_ = reinterpret_cast<::mavsdk::rpc::camera_server::CameraServerResult*>(value);
+  // @@protoc_insertion_point(field_set_allocated:mavsdk.rpc.camera_server.RespondFocusRangeResponse.camera_server_result)
 }
 
 // -------------------------------------------------------------------

--- a/cpp/src/mavsdk_server/src/plugins/camera/camera_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera/camera_service_impl.hpp
@@ -2441,6 +2441,72 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status FocusInStep(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusInStepRequest* request,
+        rpc::camera::FocusInStepResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusInStep sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_in_step(request->component_id());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status FocusOutStep(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusOutStepRequest* request,
+        rpc::camera::FocusOutStepResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusOutStep sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_out_step(request->component_id());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
     grpc::Status FocusInStart(
         grpc::ServerContext* /* context */,
         const rpc::camera::FocusInStartRequest* request,

--- a/cpp/src/mavsdk_server/src/plugins/camera/camera_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera/camera_service_impl.hpp
@@ -2641,6 +2641,140 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status FocusMeters(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusMetersRequest* request,
+        rpc::camera::FocusMetersResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusMeters sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_meters(request->component_id(), request->distance_m());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status FocusAuto(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusAutoRequest* request,
+        rpc::camera::FocusAutoResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusAuto sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_auto(request->component_id());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status FocusAutoSingle(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusAutoSingleRequest* request,
+        rpc::camera::FocusAutoSingleResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusAutoSingle sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_auto_single(request->component_id());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status FocusAutoContinuous(
+        grpc::ServerContext* /* context */,
+        const rpc::camera::FocusAutoContinuousRequest* request,
+        rpc::camera::FocusAutoContinuousResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                auto result = mavsdk::Camera::Result::NoSystem;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("FocusAutoContinuous sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->focus_auto_continuous(request->component_id());
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
 
     void stop() {
         _stopped.store(true);

--- a/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
@@ -2095,6 +2095,468 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SubscribeFocusInStep(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusInStepRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusInStepResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusInStepHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_in_step(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_in_step) {
+
+            rpc::camera_server::FocusInStepResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_in_step);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_in_step(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusInStep(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusInStepRequest* request,
+        rpc::camera_server::RespondFocusInStepResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusInStep sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_in_step(translateFromRpcCameraFeedback(request->focus_in_step_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusOutStep(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusOutStepRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusOutStepResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusOutStepHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_out_step(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_out_step) {
+
+            rpc::camera_server::FocusOutStepResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_out_step);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_out_step(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusOutStep(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusOutStepRequest* request,
+        rpc::camera_server::RespondFocusOutStepResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusOutStep sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_out_step(translateFromRpcCameraFeedback(request->focus_out_step_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusInStart(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusInStartRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusInStartResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusInStartHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_in_start(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_in_start) {
+
+            rpc::camera_server::FocusInStartResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_in_start);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_in_start(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusInStart(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusInStartRequest* request,
+        rpc::camera_server::RespondFocusInStartResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusInStart sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_in_start(translateFromRpcCameraFeedback(request->focus_in_start_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusOutStart(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusOutStartRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusOutStartResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusOutStartHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_out_start(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_out_start) {
+
+            rpc::camera_server::FocusOutStartResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_out_start);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_out_start(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusOutStart(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusOutStartRequest* request,
+        rpc::camera_server::RespondFocusOutStartResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusOutStart sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_out_start(translateFromRpcCameraFeedback(request->focus_out_start_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusStop(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusStopRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusStopResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusStopHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_stop(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_stop) {
+
+            rpc::camera_server::FocusStopResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_stop);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_stop(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusStop(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusStopRequest* request,
+        rpc::camera_server::RespondFocusStopResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusStop sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_stop(translateFromRpcCameraFeedback(request->focus_stop_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusRange(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusRangeRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusRangeResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusRangeHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_range(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const float focus_range) {
+
+            rpc::camera_server::FocusRangeResponse rpc_response;
+        
+            rpc_response.set_focus_distance_m(focus_range);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_range(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusRange(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusRangeRequest* request,
+        rpc::camera_server::RespondFocusRangeResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusRange sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_range(translateFromRpcCameraFeedback(request->focus_range_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
     grpc::Status SetTrackingRectangleStatus(
         grpc::ServerContext* /* context */,
         const rpc::camera_server::SetTrackingRectangleStatusRequest* request,

--- a/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
+++ b/cpp/src/mavsdk_server/src/plugins/camera_server/camera_server_service_impl.hpp
@@ -2557,6 +2557,314 @@ public:
         return grpc::Status::OK;
     }
 
+    grpc::Status SubscribeFocusMeters(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusMetersRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusMetersResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusMetersHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_meters(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const float focus_meters) {
+
+            rpc::camera_server::FocusMetersResponse rpc_response;
+        
+            rpc_response.set_focus_distance_m(focus_meters);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_meters(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusMeters(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusMetersRequest* request,
+        rpc::camera_server::RespondFocusMetersResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusMeters sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_meters(translateFromRpcCameraFeedback(request->focus_meters_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusAuto(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusAutoRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusAutoResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusAutoHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_auto(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_auto) {
+
+            rpc::camera_server::FocusAutoResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_auto);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_auto(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusAuto(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusAutoRequest* request,
+        rpc::camera_server::RespondFocusAutoResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusAuto sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_auto(translateFromRpcCameraFeedback(request->focus_auto_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusAutoSingle(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusAutoSingleRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusAutoSingleResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusAutoSingleHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_auto_single(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_auto_single) {
+
+            rpc::camera_server::FocusAutoSingleResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_auto_single);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_auto_single(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusAutoSingle(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusAutoSingleRequest* request,
+        rpc::camera_server::RespondFocusAutoSingleResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusAutoSingle sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_auto_single(translateFromRpcCameraFeedback(request->focus_auto_single_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status SubscribeFocusAutoContinuous(grpc::ServerContext* /* context */, const mavsdk::rpc::camera_server::SubscribeFocusAutoContinuousRequest* /* request */, grpc::ServerWriter<rpc::camera_server::FocusAutoContinuousResponse>* writer) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            return grpc::Status::OK;
+        }
+
+        auto stream_closed_promise = std::make_shared<std::promise<void>>();
+        auto stream_closed_future = stream_closed_promise->get_future();
+        register_stream_stop_promise(stream_closed_promise);
+
+        auto is_finished = std::make_shared<bool>(false);
+        auto subscribe_mutex = std::make_shared<std::mutex>();
+
+        const mavsdk::CameraServer::FocusAutoContinuousHandle handle = _lazy_plugin.maybe_plugin()->subscribe_focus_auto_continuous(
+            [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex, &handle](const int32_t focus_auto_continuous) {
+
+            rpc::camera_server::FocusAutoContinuousResponse rpc_response;
+        
+            rpc_response.set_reserved(focus_auto_continuous);
+        
+
+        
+
+            std::unique_lock<std::mutex> lock(*subscribe_mutex);
+            if (!*is_finished && !writer->Write(rpc_response)) {
+                
+                _lazy_plugin.maybe_plugin()->unsubscribe_focus_auto_continuous(handle);
+                
+                *is_finished = true;
+                unregister_stream_stop_promise(stream_closed_promise);
+                stream_closed_promise->set_value();
+            }
+        });
+
+        stream_closed_future.wait();
+        std::unique_lock<std::mutex> lock(*subscribe_mutex);
+        *is_finished = true;
+
+        return grpc::Status::OK;
+    }
+
+    grpc::Status RespondFocusAutoContinuous(
+        grpc::ServerContext* /* context */,
+        const rpc::camera_server::RespondFocusAutoContinuousRequest* request,
+        rpc::camera_server::RespondFocusAutoContinuousResponse* response) override
+    {
+        if (_lazy_plugin.maybe_plugin() == nullptr) {
+            
+            if (response != nullptr) {
+                
+                // For server plugins, this should never happen, they should always be constructible.
+                auto result = mavsdk::CameraServer::Result::Unknown;
+                fillResponseWithResult(response, result);
+            }
+            
+            return grpc::Status::OK;
+        }
+
+        if (request == nullptr) {
+            LogWarn("RespondFocusAutoContinuous sent with a null request! Ignoring...");
+            return grpc::Status::OK;
+        }
+            
+        
+        auto result = _lazy_plugin.maybe_plugin()->respond_focus_auto_continuous(translateFromRpcCameraFeedback(request->focus_auto_continuous_feedback()));
+        
+
+        
+        if (response != nullptr) {
+            fillResponseWithResult(response, result);
+        }
+        
+
+        return grpc::Status::OK;
+    }
+
     grpc::Status SetTrackingRectangleStatus(
         grpc::ServerContext* /* context */,
         const rpc::camera_server::SetTrackingRectangleStatusRequest* request,

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(system_tests_runner
     camera_storage.cpp
     camera_list_cameras.cpp
     camera_video_stream.cpp
+    camera_zoom_focus.cpp
     component_metadata.cpp
     action_arm_disarm.cpp
     param_set_and_get.cpp

--- a/cpp/src/system_tests/camera_zoom_focus.cpp
+++ b/cpp/src/system_tests/camera_zoom_focus.cpp
@@ -173,6 +173,34 @@ TEST(Camera, Focus)
             camera_server.respond_focus_range(CameraServer::CameraFeedback::Ok);
         });
 
+    float last_focus_distance_m = 0;
+    auto focus_meters_handle = camera_server.subscribe_focus_meters(
+        [&camera_server, &last_focus_distance_m](float focus_distance_m) {
+            LogInfo("Focus meters requested: {}", focus_distance_m);
+            last_focus_distance_m = focus_distance_m;
+            camera_server.respond_focus_meters(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_auto_handle = camera_server.subscribe_focus_auto([&camera_server](int32_t index) {
+        LogInfo("Focus auto {}", index);
+
+        camera_server.respond_focus_auto(CameraServer::CameraFeedback::Ok);
+    });
+
+    auto focus_auto_single_handle =
+        camera_server.subscribe_focus_auto_single([&camera_server](int32_t index) {
+            LogInfo("Focus auto single {}", index);
+
+            camera_server.respond_focus_auto_single(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_auto_continuous_handle =
+        camera_server.subscribe_focus_auto_continuous([&camera_server](int32_t index) {
+            LogInfo("Focus auto continuous {}", index);
+
+            camera_server.respond_focus_auto_continuous(CameraServer::CameraFeedback::Ok);
+        });
+
     auto prom = std::promise<std::shared_ptr<System>>();
     auto fut = prom.get_future();
     std::once_flag flag;
@@ -236,6 +264,30 @@ TEST(Camera, Focus)
 
     EXPECT_EQ(last_focus_level, 0.0f);
 
+    EXPECT_EQ(
+        camera.focus_meters(camera.camera_list().cameras[0].component_id, 4.2f),
+        Camera::Result::Success);
+
+    EXPECT_EQ(last_focus_distance_m, 4.2f);
+
+    // A negative distance makes no sense and is rejected.
+    EXPECT_EQ(
+        camera.focus_meters(camera.camera_list().cameras[0].component_id, -1.0f),
+        Camera::Result::Denied);
+
+    EXPECT_EQ(last_focus_distance_m, 4.2f);
+
+    EXPECT_EQ(
+        camera.focus_auto(camera.camera_list().cameras[0].component_id), Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_auto_single(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_auto_continuous(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
     camera_server.unsubscribe_focus_in_step(focus_in_step_handle);
     EXPECT_EQ(
         camera.focus_in_step(camera.camera_list().cameras[0].component_id),
@@ -259,5 +311,21 @@ TEST(Camera, Focus)
     camera_server.unsubscribe_focus_range(focus_range_handle);
     EXPECT_EQ(
         camera.focus_range(camera.camera_list().cameras[0].component_id, 50.0f),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_meters(focus_meters_handle);
+    EXPECT_EQ(
+        camera.focus_meters(camera.camera_list().cameras[0].component_id, 4.2f),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_auto(focus_auto_handle);
+    EXPECT_EQ(
+        camera.focus_auto(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_auto_single(focus_auto_single_handle);
+    EXPECT_EQ(
+        camera.focus_auto_single(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_auto_continuous(focus_auto_continuous_handle);
+    EXPECT_EQ(
+        camera.focus_auto_continuous(camera.camera_list().cameras[0].component_id),
         Camera::Result::ActionUnsupported);
 }

--- a/cpp/src/system_tests/camera_zoom_focus.cpp
+++ b/cpp/src/system_tests/camera_zoom_focus.cpp
@@ -1,0 +1,263 @@
+#include "mavsdk.hpp"
+#include "plugins/camera/camera.hpp"
+#include "plugins/camera_server/camera_server.hpp"
+#include "log.hpp"
+#include <future>
+#include <mutex>
+#include <thread>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+TEST(Camera, Zoom)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+
+    Mavsdk mavsdk_camera{Mavsdk::Configuration{ComponentType::Camera}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_camera.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+
+    auto camera_server = CameraServer{mavsdk_camera.server_component()};
+
+    CameraServer::Information information{};
+    information.vendor_name = "ZoomCameras";
+    information.model_name = "Zoom Cam";
+    information.firmware_version = "1.2.3";
+    information.definition_file_version = 0;
+    information.definition_file_uri = "";
+    camera_server.set_information(information);
+
+    auto zoom_in_start_handle =
+        camera_server.subscribe_zoom_in_start([&camera_server](int32_t index) {
+            LogInfo("Zoom in start {}", index);
+
+            camera_server.respond_zoom_in_start(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto zoom_out_start_handle =
+        camera_server.subscribe_zoom_out_start([&camera_server](int32_t index) {
+            LogInfo("Zoom out start {}", index);
+
+            camera_server.respond_zoom_out_start(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto zoom_stop_handle = camera_server.subscribe_zoom_stop([&camera_server](int32_t index) {
+        LogInfo("Zoom stop {}", index);
+
+        camera_server.respond_zoom_stop(CameraServer::CameraFeedback::Ok);
+    });
+
+    auto zoom_range_handle = camera_server.subscribe_zoom_range([&camera_server](float zoom_level) {
+        LogInfo("Zoom range requested: {}", zoom_level);
+
+        camera_server.respond_zoom_range(CameraServer::CameraFeedback::Ok);
+    });
+
+    auto prom = std::promise<std::shared_ptr<System>>();
+    auto fut = prom.get_future();
+    std::once_flag flag;
+
+    auto handle = mavsdk_groundstation.subscribe_on_new_system([&]() {
+        const auto system = mavsdk_groundstation.systems().back();
+        if (system->is_connected() && system->has_camera()) {
+            std::call_once(flag, [&]() { prom.set_value(system); });
+        }
+    });
+
+    ASSERT_EQ(fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    mavsdk_groundstation.unsubscribe_on_new_system(handle);
+    auto system = fut.get();
+
+    auto camera = Camera{system};
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    EXPECT_EQ(
+        camera.zoom_in_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.zoom_out_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.zoom_stop(camera.camera_list().cameras[0].component_id), Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.zoom_range(camera.camera_list().cameras[0].component_id, 50.0f),
+        Camera::Result::Success);
+
+    camera_server.unsubscribe_zoom_in_start(zoom_in_start_handle);
+    EXPECT_EQ(
+        camera.zoom_in_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_zoom_out_start(zoom_out_start_handle);
+    EXPECT_EQ(
+        camera.zoom_out_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_zoom_stop(zoom_stop_handle);
+    EXPECT_EQ(
+        camera.zoom_stop(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_zoom_range(zoom_range_handle);
+    EXPECT_EQ(
+        camera.zoom_range(camera.camera_list().cameras[0].component_id, 50.0f),
+        Camera::Result::ActionUnsupported);
+}
+
+TEST(Camera, Focus)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+
+    Mavsdk mavsdk_camera{Mavsdk::Configuration{ComponentType::Camera}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17000"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_camera.add_any_connection("udpout://127.0.0.1:17000"), ConnectionResult::Success);
+
+    auto camera_server = CameraServer{mavsdk_camera.server_component()};
+
+    CameraServer::Information information{};
+    information.vendor_name = "FocusCameras";
+    information.model_name = "Focus Cam";
+    information.firmware_version = "3.2.1";
+    information.definition_file_version = 0;
+    information.definition_file_uri = "";
+    camera_server.set_information(information);
+
+    auto focus_in_step_handle =
+        camera_server.subscribe_focus_in_step([&camera_server](int32_t index) {
+            LogInfo("Focus in step {}", index);
+
+            camera_server.respond_focus_in_step(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_out_step_handle =
+        camera_server.subscribe_focus_out_step([&camera_server](int32_t index) {
+            LogInfo("Focus out step {}", index);
+
+            camera_server.respond_focus_out_step(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_in_start_handle =
+        camera_server.subscribe_focus_in_start([&camera_server](int32_t index) {
+            LogInfo("Focus in start {}", index);
+
+            camera_server.respond_focus_in_start(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_out_start_handle =
+        camera_server.subscribe_focus_out_start([&camera_server](int32_t index) {
+            LogInfo("Focus out start {}", index);
+
+            camera_server.respond_focus_out_start(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto focus_stop_handle = camera_server.subscribe_focus_stop([&camera_server](int32_t index) {
+        LogInfo("Focus stop {}", index);
+
+        camera_server.respond_focus_stop(CameraServer::CameraFeedback::Ok);
+    });
+
+    float last_focus_level = 0;
+    auto focus_range_handle =
+        camera_server.subscribe_focus_range([&camera_server, &last_focus_level](float focus_level) {
+            LogInfo("Focus range requested: {}", focus_level);
+            last_focus_level = focus_level;
+            camera_server.respond_focus_range(CameraServer::CameraFeedback::Ok);
+        });
+
+    auto prom = std::promise<std::shared_ptr<System>>();
+    auto fut = prom.get_future();
+    std::once_flag flag;
+
+    auto handle = mavsdk_groundstation.subscribe_on_new_system([&]() {
+        const auto system = mavsdk_groundstation.systems().back();
+        if (system->is_connected() && system->has_camera()) {
+            std::call_once(flag, [&]() { prom.set_value(system); });
+        }
+    });
+
+    ASSERT_EQ(fut.wait_for(std::chrono::seconds(10)), std::future_status::ready);
+    mavsdk_groundstation.unsubscribe_on_new_system(handle);
+    auto system = fut.get();
+
+    auto camera = Camera{system};
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    EXPECT_EQ(
+        camera.focus_in_step(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_out_step(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_in_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_out_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_stop(camera.camera_list().cameras[0].component_id), Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, 50.0f),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, 0.0f),
+        Camera::Result::Success);
+
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, 100.0f),
+        Camera::Result::Success);
+
+    // Camera clamps values out of range.
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, 101.0f),
+        Camera::Result::Success);
+
+    EXPECT_EQ(last_focus_level, 100.0f);
+
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, -1.0f),
+        Camera::Result::Success);
+
+    EXPECT_EQ(last_focus_level, 0.0f);
+
+    camera_server.unsubscribe_focus_in_step(focus_in_step_handle);
+    EXPECT_EQ(
+        camera.focus_in_step(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_out_step(focus_out_step_handle);
+    EXPECT_EQ(
+        camera.focus_out_step(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_in_start(focus_in_start_handle);
+    EXPECT_EQ(
+        camera.focus_in_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_out_start(focus_out_start_handle);
+    EXPECT_EQ(
+        camera.focus_out_start(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_stop(focus_stop_handle);
+    EXPECT_EQ(
+        camera.focus_stop(camera.camera_list().cameras[0].component_id),
+        Camera::Result::ActionUnsupported);
+    camera_server.unsubscribe_focus_range(focus_range_handle);
+    EXPECT_EQ(
+        camera.focus_range(camera.camera_list().cameras[0].component_id, 50.0f),
+        Camera::Result::ActionUnsupported);
+}

--- a/cpp/src/system_tests/camera_zoom_focus.cpp
+++ b/cpp/src/system_tests/camera_zoom_focus.cpp
@@ -2,6 +2,7 @@
 #include "plugins/camera/camera.hpp"
 #include "plugins/camera_server/camera_server.hpp"
 #include "log.hpp"
+#include <atomic>
 #include <future>
 #include <mutex>
 #include <thread>
@@ -165,7 +166,7 @@ TEST(Camera, Focus)
         camera_server.respond_focus_stop(CameraServer::CameraFeedback::Ok);
     });
 
-    float last_focus_level = 0;
+    std::atomic<float> last_focus_level = 0;
     auto focus_range_handle =
         camera_server.subscribe_focus_range([&camera_server, &last_focus_level](float focus_level) {
             LogInfo("Focus range requested: {}", focus_level);
@@ -173,7 +174,7 @@ TEST(Camera, Focus)
             camera_server.respond_focus_range(CameraServer::CameraFeedback::Ok);
         });
 
-    float last_focus_distance_m = 0;
+    std::atomic<float> last_focus_distance_m = 0;
     auto focus_meters_handle = camera_server.subscribe_focus_meters(
         [&camera_server, &last_focus_distance_m](float focus_distance_m) {
             LogInfo("Focus meters requested: {}", focus_distance_m);

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_camera.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_camera.md
@@ -152,6 +152,14 @@ void | [focus_stop_async](#classmavsdk_1_1_camera_1a562ad9fa8f29b359785069a9dc5b
 [Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_stop](#classmavsdk_1_1_camera_1aed5b395a57b14da2d15395dfa2e56600) (int32_t component_id)const | Stop focus.
 void | [focus_range_async](#classmavsdk_1_1_camera_1a44cebbb36a9bc9c203dc0233f8b52f7b) (int32_t component_id, float range, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Focus with range value of full range (value between 0.0 and 100.0).
 [Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_range](#classmavsdk_1_1_camera_1aec7d7a0ed5fa2ba84124f9f363e8d94a) (int32_t component_id, float range)const | Focus with range value of full range (value between 0.0 and 100.0).
+void | [focus_meters_async](#classmavsdk_1_1_camera_1a43c2fa5293b95fa4e1ac69e99d377aff) (int32_t component_id, float distance_m, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Focus at a distance in meters.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_meters](#classmavsdk_1_1_camera_1aa591201c732a3e4ff515234ae1e79878) (int32_t component_id, float distance_m)const | Focus at a distance in meters.
+void | [focus_auto_async](#classmavsdk_1_1_camera_1afae9a492d20045cc61eb84359eade249) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Focus automatically.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_auto](#classmavsdk_1_1_camera_1ac75ec51be83e72a123fc2aa984b71355) (int32_t component_id)const | Focus automatically.
+void | [focus_auto_single_async](#classmavsdk_1_1_camera_1adca0eeafede69b11930700b45d9c9345) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_auto_single](#classmavsdk_1_1_camera_1a53f81bb24eb49cf7a8f497c4aed0075f) (int32_t component_id)const | Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+void | [focus_auto_continuous_async](#classmavsdk_1_1_camera_1a4652d46a9c5ed8251bf9036d07fb3cbc) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_auto_continuous](#classmavsdk_1_1_camera_1ae14bd78f309cfd479b8fb2bff827c8e5) (int32_t component_id)const | Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
 const [Camera](classmavsdk_1_1_camera.md) & | [operator=](#classmavsdk_1_1_camera_1a358026db44ff9a10cf14a166d8f1da78) (const [Camera](classmavsdk_1_1_camera.md) &)=delete | Equality operator (object is not copyable).
 
 
@@ -1639,6 +1647,146 @@ This function is blocking. See 'focus_range_async' for the non-blocking counterp
 
 * int32_t **component_id** - 
 * float **range** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_meters_async() {#classmavsdk_1_1_camera_1a43c2fa5293b95fa4e1ac69e99d377aff}
+```cpp
+void mavsdk::Camera::focus_meters_async(int32_t component_id, float distance_m, const ResultCallback callback)
+```
+
+
+Focus at a distance in meters.
+
+Note that there is no message to get the valid focus range of the camera, so this can only be used for cameras where the range is known.
+
+
+This function is non-blocking. See 'focus_meters' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* float **distance_m** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_meters() {#classmavsdk_1_1_camera_1aa591201c732a3e4ff515234ae1e79878}
+```cpp
+Result mavsdk::Camera::focus_meters(int32_t component_id, float distance_m) const
+```
+
+
+Focus at a distance in meters.
+
+Note that there is no message to get the valid focus range of the camera, so this can only be used for cameras where the range is known.
+
+
+This function is blocking. See 'focus_meters_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* float **distance_m** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_auto_async() {#classmavsdk_1_1_camera_1afae9a492d20045cc61eb84359eade249}
+```cpp
+void mavsdk::Camera::focus_auto_async(int32_t component_id, const ResultCallback callback)
+```
+
+
+Focus automatically.
+
+This function is non-blocking. See 'focus_auto' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_auto() {#classmavsdk_1_1_camera_1ac75ec51be83e72a123fc2aa984b71355}
+```cpp
+Result mavsdk::Camera::focus_auto(int32_t component_id) const
+```
+
+
+Focus automatically.
+
+This function is blocking. See 'focus_auto_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_auto_single_async() {#classmavsdk_1_1_camera_1adca0eeafede69b11930700b45d9c9345}
+```cpp
+void mavsdk::Camera::focus_auto_single_async(int32_t component_id, const ResultCallback callback)
+```
+
+
+Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+
+This function is non-blocking. See 'focus_auto_single' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_auto_single() {#classmavsdk_1_1_camera_1a53f81bb24eb49cf7a8f497c4aed0075f}
+```cpp
+Result mavsdk::Camera::focus_auto_single(int32_t component_id) const
+```
+
+
+Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+
+This function is blocking. See 'focus_auto_single_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_auto_continuous_async() {#classmavsdk_1_1_camera_1a4652d46a9c5ed8251bf9036d07fb3cbc}
+```cpp
+void mavsdk::Camera::focus_auto_continuous_async(int32_t component_id, const ResultCallback callback)
+```
+
+
+Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+
+This function is non-blocking. See 'focus_auto_continuous' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_auto_continuous() {#classmavsdk_1_1_camera_1ae14bd78f309cfd479b8fb2bff827c8e5}
+```cpp
+Result mavsdk::Camera::focus_auto_continuous(int32_t component_id) const
+```
+
+
+Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+
+This function is blocking. See 'focus_auto_continuous_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
 
 **Returns**
 

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_camera.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_camera.md
@@ -140,6 +140,10 @@ void | [track_rectangle_async](#classmavsdk_1_1_camera_1a4fcec80674d2de32934c67a
 [Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [track_rectangle](#classmavsdk_1_1_camera_1a32c338bc723337dcf4229bac94073d03) (int32_t component_id, float top_left_x, float top_left_y, float bottom_right_x, float bottom_right_y)const | Track rectangle.
 void | [track_stop_async](#classmavsdk_1_1_camera_1a7b1c720a0a346516af8c1bc3e49210cc) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Stop tracking.
 [Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [track_stop](#classmavsdk_1_1_camera_1a1f4a0c1c2cfcef55cdab94f3d726766f) (int32_t component_id)const | Stop tracking.
+void | [focus_in_step_async](#classmavsdk_1_1_camera_1aa6e9fb538089b6cfa3cf4544b26331e1) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Step focus in.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_in_step](#classmavsdk_1_1_camera_1a575dd39509f53f55db20a38b278af5bb) (int32_t component_id)const | Step focus in.
+void | [focus_out_step_async](#classmavsdk_1_1_camera_1a14ff25e9f97acf2e63bf052e75e3185e) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Step focus out.
+[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_out_step](#classmavsdk_1_1_camera_1a2293c597722e249614d19a8cb9d3b17b) (int32_t component_id)const | Step focus out.
 void | [focus_in_start_async](#classmavsdk_1_1_camera_1ad40616613df551c00a78099e7790b880) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Start focusing in.
 [Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) | [focus_in_start](#classmavsdk_1_1_camera_1a8be24bc7d5c21b94b388bc1eeed2e8fe) (int32_t component_id)const | Start focusing in.
 void | [focus_out_start_async](#classmavsdk_1_1_camera_1ad7917d952b7d0e43dba631a152575765) (int32_t component_id, const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) callback) | Start focusing out.
@@ -1431,6 +1435,72 @@ Result mavsdk::Camera::track_stop(int32_t component_id) const
 Stop tracking.
 
 This function is blocking. See 'track_stop_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_in_step_async() {#classmavsdk_1_1_camera_1aa6e9fb538089b6cfa3cf4544b26331e1}
+```cpp
+void mavsdk::Camera::focus_in_step_async(int32_t component_id, const ResultCallback callback)
+```
+
+
+Step focus in.
+
+This function is non-blocking. See 'focus_in_step' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_in_step() {#classmavsdk_1_1_camera_1a575dd39509f53f55db20a38b278af5bb}
+```cpp
+Result mavsdk::Camera::focus_in_step(int32_t component_id) const
+```
+
+
+Step focus in.
+
+This function is blocking. See 'focus_in_step_async' for the non-blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a2a84df3938372f4f302576227b308bcf) - Result of request.
+
+### focus_out_step_async() {#classmavsdk_1_1_camera_1a14ff25e9f97acf2e63bf052e75e3185e}
+```cpp
+void mavsdk::Camera::focus_out_step_async(int32_t component_id, const ResultCallback callback)
+```
+
+
+Step focus out.
+
+This function is non-blocking. See 'focus_out_step' for the blocking counterpart.
+
+**Parameters**
+
+* int32_t **component_id** - 
+* const [ResultCallback](classmavsdk_1_1_camera.md#classmavsdk_1_1_camera_1a8d6d59cd8d0a3584ef60b16255b6301f) **callback** - 
+
+### focus_out_step() {#classmavsdk_1_1_camera_1a2293c597722e249614d19a8cb9d3b17b}
+```cpp
+Result mavsdk::Camera::focus_out_step(int32_t component_id) const
+```
+
+
+Step focus out.
+
+This function is blocking. See 'focus_out_step_async' for the non-blocking counterpart.
 
 **Parameters**
 

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
@@ -77,6 +77,14 @@ std::function< void(int32_t)> [FocusStopCallback](#classmavsdk_1_1_camera_server
 [Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusStopHandle](#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_stop.
 std::function< void(float)> [FocusRangeCallback](#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb) | Callback type for subscribe_focus_range.
 [Handle](classmavsdk_1_1_handle.md)< float > [FocusRangeHandle](#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_range.
+std::function< void(float)> [FocusMetersCallback](#classmavsdk_1_1_camera_server_1a51a65ddbb6561ed0d67ed887fd12daad) | Callback type for subscribe_focus_meters.
+[Handle](classmavsdk_1_1_handle.md)< float > [FocusMetersHandle](#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_meters.
+std::function< void(int32_t)> [FocusAutoCallback](#classmavsdk_1_1_camera_server_1ada341a56d8b2a06aa6e6c104c2e82162) | Callback type for subscribe_focus_auto.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusAutoHandle](#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto.
+std::function< void(int32_t)> [FocusAutoSingleCallback](#classmavsdk_1_1_camera_server_1adf4ff37df9583d911329dbd29a41aa9a) | Callback type for subscribe_focus_auto_single.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusAutoSingleHandle](#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto_single.
+std::function< void(int32_t)> [FocusAutoContinuousCallback](#classmavsdk_1_1_camera_server_1a3a93f6e83e7041b3c2590dd09e297143) | Callback type for subscribe_focus_auto_continuous.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusAutoContinuousHandle](#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto_continuous.
 std::function< void([TrackPoint](structmavsdk_1_1_camera_server_1_1_track_point.md))> [TrackingPointCommandCallback](#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4) | Callback type for subscribe_tracking_point_command.
 [Handle](classmavsdk_1_1_handle.md)< [TrackPoint](structmavsdk_1_1_camera_server_1_1_track_point.md) > [TrackingPointCommandHandle](#classmavsdk_1_1_camera_server_1a38c4148c1c717351865787b1529e9617) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_tracking_point_command.
 std::function< void([TrackRectangle](structmavsdk_1_1_camera_server_1_1_track_rectangle.md))> [TrackingRectangleCommandCallback](#classmavsdk_1_1_camera_server_1aa7541523c37bb4b24246e40deb0e35a6) | Callback type for subscribe_tracking_rectangle_command.
@@ -155,6 +163,18 @@ void | [unsubscribe_focus_stop](#classmavsdk_1_1_camera_server_1a2837fce0fc74e63
 [FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) | [subscribe_focus_range](#classmavsdk_1_1_camera_server_1a954fde18d0958a943017e710c01250ef) (const [FocusRangeCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb) & callback) | Subscribe to focus range command.
 void | [unsubscribe_focus_range](#classmavsdk_1_1_camera_server_1ac1410546d1554c0ff9c8aceea5aee47c) ([FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) handle) | Unsubscribe from subscribe_focus_range.
 [Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_range](#classmavsdk_1_1_camera_server_1a006ccea3e7a10304b35d8281da47d84c) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_range_feedback)const | Respond to focus range.
+[FocusMetersHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340) | [subscribe_focus_meters](#classmavsdk_1_1_camera_server_1a6906c921dc5319be97c731471428831e) (const [FocusMetersCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a51a65ddbb6561ed0d67ed887fd12daad) & callback) | Subscribe to focus meters command.
+void | [unsubscribe_focus_meters](#classmavsdk_1_1_camera_server_1aac4a0a8594d037bb6e918f624a260b5a) ([FocusMetersHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340) handle) | Unsubscribe from subscribe_focus_meters.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_meters](#classmavsdk_1_1_camera_server_1a15dc77d217b9795b98f87dc94ca7a1b7) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_meters_feedback)const | Respond to focus meters.
+[FocusAutoHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800) | [subscribe_focus_auto](#classmavsdk_1_1_camera_server_1aa2d43b71296879cb6ceeceb640e9a0f6) (const [FocusAutoCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1ada341a56d8b2a06aa6e6c104c2e82162) & callback) | Subscribe to focus auto command.
+void | [unsubscribe_focus_auto](#classmavsdk_1_1_camera_server_1ad86cdc9bbcf0cb0432891b7478f62616) ([FocusAutoHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800) handle) | Unsubscribe from subscribe_focus_auto.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_auto](#classmavsdk_1_1_camera_server_1a6e979dc4d11946b2bdd664dffd5d57c0) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_auto_feedback)const | Respond to focus auto.
+[FocusAutoSingleHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660) | [subscribe_focus_auto_single](#classmavsdk_1_1_camera_server_1ac6f0cd149419c35469ad159d74819f86) (const [FocusAutoSingleCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1adf4ff37df9583d911329dbd29a41aa9a) & callback) | Subscribe to focus auto single command.
+void | [unsubscribe_focus_auto_single](#classmavsdk_1_1_camera_server_1a9496ce8c32aeeb0f8489b7461dd531b2) ([FocusAutoSingleHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660) handle) | Unsubscribe from subscribe_focus_auto_single.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_auto_single](#classmavsdk_1_1_camera_server_1a6f50eb26a73efe0f04799277c96e3cce) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_auto_single_feedback)const | Respond to focus auto single.
+[FocusAutoContinuousHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2) | [subscribe_focus_auto_continuous](#classmavsdk_1_1_camera_server_1ac65d749b2c2d4b88244c664048b80e07) (const [FocusAutoContinuousCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a3a93f6e83e7041b3c2590dd09e297143) & callback) | Subscribe to focus auto continuous command.
+void | [unsubscribe_focus_auto_continuous](#classmavsdk_1_1_camera_server_1ad366f0e273483a55ff31931c38565512) ([FocusAutoContinuousHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2) handle) | Unsubscribe from subscribe_focus_auto_continuous.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_auto_continuous](#classmavsdk_1_1_camera_server_1a117bfdaead31a6a205bcbb173ecf3ff5) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_auto_continuous_feedback)const | Respond to focus auto continuous.
 void | [set_tracking_rectangle_status](#classmavsdk_1_1_camera_server_1a262b7ec85fee9aa1b83eebd3ffb9abaa) ([TrackRectangle](structmavsdk_1_1_camera_server_1_1_track_rectangle.md) tracked_rectangle)const | Set/update the current rectangle tracking status.
 void | [set_tracking_off_status](#classmavsdk_1_1_camera_server_1a22ba37443a3bc69c826261964949a8d4) () const | Set the current tracking status to off.
 [TrackingPointCommandHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a38c4148c1c717351865787b1529e9617) | [subscribe_tracking_point_command](#classmavsdk_1_1_camera_server_1a474c49eff4fe7a1b707df2c610197b3d) (const [TrackingPointCommandCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4) & callback) | Subscribe to incoming tracking point command.
@@ -627,6 +647,86 @@ using mavsdk::CameraServer::FocusRangeHandle =  Handle<float>
 
 
 [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_range.
+
+
+### typedef FocusMetersCallback {#classmavsdk_1_1_camera_server_1a51a65ddbb6561ed0d67ed887fd12daad}
+
+```cpp
+using mavsdk::CameraServer::FocusMetersCallback =  std::function<void(float)>
+```
+
+
+Callback type for subscribe_focus_meters.
+
+
+### typedef FocusMetersHandle {#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340}
+
+```cpp
+using mavsdk::CameraServer::FocusMetersHandle =  Handle<float>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_meters.
+
+
+### typedef FocusAutoCallback {#classmavsdk_1_1_camera_server_1ada341a56d8b2a06aa6e6c104c2e82162}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_auto.
+
+
+### typedef FocusAutoHandle {#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto.
+
+
+### typedef FocusAutoSingleCallback {#classmavsdk_1_1_camera_server_1adf4ff37df9583d911329dbd29a41aa9a}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoSingleCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_auto_single.
+
+
+### typedef FocusAutoSingleHandle {#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoSingleHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto_single.
+
+
+### typedef FocusAutoContinuousCallback {#classmavsdk_1_1_camera_server_1a3a93f6e83e7041b3c2590dd09e297143}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoContinuousCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_auto_continuous.
+
+
+### typedef FocusAutoContinuousHandle {#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2}
+
+```cpp
+using mavsdk::CameraServer::FocusAutoContinuousHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_auto_continuous.
 
 
 ### typedef TrackingPointCommandCallback {#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4}
@@ -1750,6 +1850,198 @@ This function is blocking.
 **Parameters**
 
 * [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_range_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_meters() {#classmavsdk_1_1_camera_server_1a6906c921dc5319be97c731471428831e}
+```cpp
+FocusMetersHandle mavsdk::CameraServer::subscribe_focus_meters(const FocusMetersCallback &callback)
+```
+
+
+Subscribe to focus meters command.
+
+
+**Parameters**
+
+* const [FocusMetersCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a51a65ddbb6561ed0d67ed887fd12daad)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusMetersHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340) - 
+
+### unsubscribe_focus_meters() {#classmavsdk_1_1_camera_server_1aac4a0a8594d037bb6e918f624a260b5a}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_meters(FocusMetersHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_meters.
+
+
+**Parameters**
+
+* [FocusMetersHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8217145143dbc85de0b930bcd2fe9340) **handle** - 
+
+### respond_focus_meters() {#classmavsdk_1_1_camera_server_1a15dc77d217b9795b98f87dc94ca7a1b7}
+```cpp
+Result mavsdk::CameraServer::respond_focus_meters(CameraFeedback focus_meters_feedback) const
+```
+
+
+Respond to focus meters.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_meters_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_auto() {#classmavsdk_1_1_camera_server_1aa2d43b71296879cb6ceeceb640e9a0f6}
+```cpp
+FocusAutoHandle mavsdk::CameraServer::subscribe_focus_auto(const FocusAutoCallback &callback)
+```
+
+
+Subscribe to focus auto command.
+
+
+**Parameters**
+
+* const [FocusAutoCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1ada341a56d8b2a06aa6e6c104c2e82162)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusAutoHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800) - 
+
+### unsubscribe_focus_auto() {#classmavsdk_1_1_camera_server_1ad86cdc9bbcf0cb0432891b7478f62616}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_auto(FocusAutoHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_auto.
+
+
+**Parameters**
+
+* [FocusAutoHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8c46846f1c66f830fa741bee4d820800) **handle** - 
+
+### respond_focus_auto() {#classmavsdk_1_1_camera_server_1a6e979dc4d11946b2bdd664dffd5d57c0}
+```cpp
+Result mavsdk::CameraServer::respond_focus_auto(CameraFeedback focus_auto_feedback) const
+```
+
+
+Respond to focus auto.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_auto_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_auto_single() {#classmavsdk_1_1_camera_server_1ac6f0cd149419c35469ad159d74819f86}
+```cpp
+FocusAutoSingleHandle mavsdk::CameraServer::subscribe_focus_auto_single(const FocusAutoSingleCallback &callback)
+```
+
+
+Subscribe to focus auto single command.
+
+
+**Parameters**
+
+* const [FocusAutoSingleCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1adf4ff37df9583d911329dbd29a41aa9a)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusAutoSingleHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660) - 
+
+### unsubscribe_focus_auto_single() {#classmavsdk_1_1_camera_server_1a9496ce8c32aeeb0f8489b7461dd531b2}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_auto_single(FocusAutoSingleHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_auto_single.
+
+
+**Parameters**
+
+* [FocusAutoSingleHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a2a2feb660ba5ffdd97dac15602651660) **handle** - 
+
+### respond_focus_auto_single() {#classmavsdk_1_1_camera_server_1a6f50eb26a73efe0f04799277c96e3cce}
+```cpp
+Result mavsdk::CameraServer::respond_focus_auto_single(CameraFeedback focus_auto_single_feedback) const
+```
+
+
+Respond to focus auto single.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_auto_single_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_auto_continuous() {#classmavsdk_1_1_camera_server_1ac65d749b2c2d4b88244c664048b80e07}
+```cpp
+FocusAutoContinuousHandle mavsdk::CameraServer::subscribe_focus_auto_continuous(const FocusAutoContinuousCallback &callback)
+```
+
+
+Subscribe to focus auto continuous command.
+
+
+**Parameters**
+
+* const [FocusAutoContinuousCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a3a93f6e83e7041b3c2590dd09e297143)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusAutoContinuousHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2) - 
+
+### unsubscribe_focus_auto_continuous() {#classmavsdk_1_1_camera_server_1ad366f0e273483a55ff31931c38565512}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_auto_continuous(FocusAutoContinuousHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_auto_continuous.
+
+
+**Parameters**
+
+* [FocusAutoContinuousHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1acdb550989715c0966b9fc4c2ee2b7ae2) **handle** - 
+
+### respond_focus_auto_continuous() {#classmavsdk_1_1_camera_server_1a117bfdaead31a6a205bcbb173ecf3ff5}
+```cpp
+Result mavsdk::CameraServer::respond_focus_auto_continuous(CameraFeedback focus_auto_continuous_feedback) const
+```
+
+
+Respond to focus auto continuous.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_auto_continuous_feedback** - 
 
 **Returns**
 

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_camera_server.md
@@ -65,6 +65,18 @@ std::function< void(int32_t)> [ZoomStopCallback](#classmavsdk_1_1_camera_server_
 [Handle](classmavsdk_1_1_handle.md)< int32_t > [ZoomStopHandle](#classmavsdk_1_1_camera_server_1a8bb9a99dfb5089332be6241230d54d34) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_zoom_stop.
 std::function< void(float)> [ZoomRangeCallback](#classmavsdk_1_1_camera_server_1aa23f7ca9c7bf5eee8a12846743bed3a2) | Callback type for subscribe_zoom_range.
 [Handle](classmavsdk_1_1_handle.md)< float > [ZoomRangeHandle](#classmavsdk_1_1_camera_server_1a37067e1804927f01921079dfa1e133c2) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_zoom_range.
+std::function< void(int32_t)> [FocusInStepCallback](#classmavsdk_1_1_camera_server_1a8f25d1eb4d11c29957033f4faf5b6c35) | Callback type for subscribe_focus_in_step.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusInStepHandle](#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_in_step.
+std::function< void(int32_t)> [FocusOutStepCallback](#classmavsdk_1_1_camera_server_1ac74618e43c6759ad0c8492e56051ed03) | Callback type for subscribe_focus_out_step.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusOutStepHandle](#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_out_step.
+std::function< void(int32_t)> [FocusInStartCallback](#classmavsdk_1_1_camera_server_1a7defa232336b6dd9aedfab9be70b3c57) | Callback type for subscribe_focus_in_start.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusInStartHandle](#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_in_start.
+std::function< void(int32_t)> [FocusOutStartCallback](#classmavsdk_1_1_camera_server_1aef4c0f7c2c304c2684e3933cee3a6b68) | Callback type for subscribe_focus_out_start.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusOutStartHandle](#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_out_start.
+std::function< void(int32_t)> [FocusStopCallback](#classmavsdk_1_1_camera_server_1a1ee6b49a2cb9c9c6668500edc8e308ae) | Callback type for subscribe_focus_stop.
+[Handle](classmavsdk_1_1_handle.md)< int32_t > [FocusStopHandle](#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_stop.
+std::function< void(float)> [FocusRangeCallback](#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb) | Callback type for subscribe_focus_range.
+[Handle](classmavsdk_1_1_handle.md)< float > [FocusRangeHandle](#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_range.
 std::function< void([TrackPoint](structmavsdk_1_1_camera_server_1_1_track_point.md))> [TrackingPointCommandCallback](#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4) | Callback type for subscribe_tracking_point_command.
 [Handle](classmavsdk_1_1_handle.md)< [TrackPoint](structmavsdk_1_1_camera_server_1_1_track_point.md) > [TrackingPointCommandHandle](#classmavsdk_1_1_camera_server_1a38c4148c1c717351865787b1529e9617) | [Handle](classmavsdk_1_1_handle.md) type for subscribe_tracking_point_command.
 std::function< void([TrackRectangle](structmavsdk_1_1_camera_server_1_1_track_rectangle.md))> [TrackingRectangleCommandCallback](#classmavsdk_1_1_camera_server_1aa7541523c37bb4b24246e40deb0e35a6) | Callback type for subscribe_tracking_rectangle_command.
@@ -125,6 +137,24 @@ void | [unsubscribe_zoom_stop](#classmavsdk_1_1_camera_server_1aab7d43df6c39266c
 [ZoomRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a37067e1804927f01921079dfa1e133c2) | [subscribe_zoom_range](#classmavsdk_1_1_camera_server_1a6dc95f635c88749b4e2bbfa07bd5b0fd) (const [ZoomRangeCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa23f7ca9c7bf5eee8a12846743bed3a2) & callback) | Subscribe to zoom range command.
 void | [unsubscribe_zoom_range](#classmavsdk_1_1_camera_server_1a9fc5f5daed094bea620011bce222bb88) ([ZoomRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a37067e1804927f01921079dfa1e133c2) handle) | Unsubscribe from subscribe_zoom_range.
 [Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_zoom_range](#classmavsdk_1_1_camera_server_1a5ea9dd6521f43d91671b0fa1eef6d0f6) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) zoom_range_feedback)const | Respond to zoom range.
+[FocusInStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d) | [subscribe_focus_in_step](#classmavsdk_1_1_camera_server_1ab71c5ac27c494a23daef45e5806d17f5) (const [FocusInStepCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8f25d1eb4d11c29957033f4faf5b6c35) & callback) | Subscribe to focus in step command.
+void | [unsubscribe_focus_in_step](#classmavsdk_1_1_camera_server_1a75a28c7d2ed7548fd2b77fba0e28f26e) ([FocusInStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d) handle) | Unsubscribe from subscribe_focus_in_step.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_in_step](#classmavsdk_1_1_camera_server_1a9fdac017089a2e990956da91ea0111e1) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_in_step_feedback)const | Respond to focus in step.
+[FocusOutStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0) | [subscribe_focus_out_step](#classmavsdk_1_1_camera_server_1a84d79fbcd94cc9c9336c7f02484efae7) (const [FocusOutStepCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1ac74618e43c6759ad0c8492e56051ed03) & callback) | Subscribe to focus out step command.
+void | [unsubscribe_focus_out_step](#classmavsdk_1_1_camera_server_1a50d671c9d2cfc97bc8ead0ab9bccaf22) ([FocusOutStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0) handle) | Unsubscribe from subscribe_focus_out_step.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_out_step](#classmavsdk_1_1_camera_server_1a71fd8f066fefc4ea3ba66723789fc714) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_out_step_feedback)const | Respond to focus out step.
+[FocusInStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803) | [subscribe_focus_in_start](#classmavsdk_1_1_camera_server_1aa9f9fe38cbcd2ec2971339a7dfcce096) (const [FocusInStartCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a7defa232336b6dd9aedfab9be70b3c57) & callback) | Subscribe to focus in start command.
+void | [unsubscribe_focus_in_start](#classmavsdk_1_1_camera_server_1a50a4a83f0404d84067791cbe9cfb6669) ([FocusInStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803) handle) | Unsubscribe from subscribe_focus_in_start.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_in_start](#classmavsdk_1_1_camera_server_1a9301135a5127fd6170b2c5d069ec150a) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_in_start_feedback)const | Respond to focus in start.
+[FocusOutStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782) | [subscribe_focus_out_start](#classmavsdk_1_1_camera_server_1a302db58054397888c39ed6e65af3844f) (const [FocusOutStartCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aef4c0f7c2c304c2684e3933cee3a6b68) & callback) | Subscribe to focus out start command.
+void | [unsubscribe_focus_out_start](#classmavsdk_1_1_camera_server_1afaa7672b671d9f43c7594dcae9774817) ([FocusOutStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782) handle) | Unsubscribe from subscribe_focus_out_start.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_out_start](#classmavsdk_1_1_camera_server_1ad1e61dc4e61e4537b760653f972216b1) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_out_start_feedback)const | Respond to focus out start.
+[FocusStopHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) | [subscribe_focus_stop](#classmavsdk_1_1_camera_server_1a29d34a3e62e161577f902c87287168eb) (const [FocusStopCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1ee6b49a2cb9c9c6668500edc8e308ae) & callback) | Subscribe to focus stop command.
+void | [unsubscribe_focus_stop](#classmavsdk_1_1_camera_server_1a2837fce0fc74e63d8fcb71af13512e63) ([FocusStopHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) handle) | Unsubscribe from subscribe_focus_stop.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_stop](#classmavsdk_1_1_camera_server_1ace6539aef1ff67d390d596339df68876) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_stop_feedback)const | Respond to focus stop.
+[FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) | [subscribe_focus_range](#classmavsdk_1_1_camera_server_1a954fde18d0958a943017e710c01250ef) (const [FocusRangeCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb) & callback) | Subscribe to focus range command.
+void | [unsubscribe_focus_range](#classmavsdk_1_1_camera_server_1ac1410546d1554c0ff9c8aceea5aee47c) ([FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) handle) | Unsubscribe from subscribe_focus_range.
+[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) | [respond_focus_range](#classmavsdk_1_1_camera_server_1a006ccea3e7a10304b35d8281da47d84c) ([CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) focus_range_feedback)const | Respond to focus range.
 void | [set_tracking_rectangle_status](#classmavsdk_1_1_camera_server_1a262b7ec85fee9aa1b83eebd3ffb9abaa) ([TrackRectangle](structmavsdk_1_1_camera_server_1_1_track_rectangle.md) tracked_rectangle)const | Set/update the current rectangle tracking status.
 void | [set_tracking_off_status](#classmavsdk_1_1_camera_server_1a22ba37443a3bc69c826261964949a8d4) () const | Set the current tracking status to off.
 [TrackingPointCommandHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a38c4148c1c717351865787b1529e9617) | [subscribe_tracking_point_command](#classmavsdk_1_1_camera_server_1a474c49eff4fe7a1b707df2c610197b3d) (const [TrackingPointCommandCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4) & callback) | Subscribe to incoming tracking point command.
@@ -477,6 +507,126 @@ using mavsdk::CameraServer::ZoomRangeHandle =  Handle<float>
 
 
 [Handle](classmavsdk_1_1_handle.md) type for subscribe_zoom_range.
+
+
+### typedef FocusInStepCallback {#classmavsdk_1_1_camera_server_1a8f25d1eb4d11c29957033f4faf5b6c35}
+
+```cpp
+using mavsdk::CameraServer::FocusInStepCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_in_step.
+
+
+### typedef FocusInStepHandle {#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d}
+
+```cpp
+using mavsdk::CameraServer::FocusInStepHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_in_step.
+
+
+### typedef FocusOutStepCallback {#classmavsdk_1_1_camera_server_1ac74618e43c6759ad0c8492e56051ed03}
+
+```cpp
+using mavsdk::CameraServer::FocusOutStepCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_out_step.
+
+
+### typedef FocusOutStepHandle {#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0}
+
+```cpp
+using mavsdk::CameraServer::FocusOutStepHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_out_step.
+
+
+### typedef FocusInStartCallback {#classmavsdk_1_1_camera_server_1a7defa232336b6dd9aedfab9be70b3c57}
+
+```cpp
+using mavsdk::CameraServer::FocusInStartCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_in_start.
+
+
+### typedef FocusInStartHandle {#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803}
+
+```cpp
+using mavsdk::CameraServer::FocusInStartHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_in_start.
+
+
+### typedef FocusOutStartCallback {#classmavsdk_1_1_camera_server_1aef4c0f7c2c304c2684e3933cee3a6b68}
+
+```cpp
+using mavsdk::CameraServer::FocusOutStartCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_out_start.
+
+
+### typedef FocusOutStartHandle {#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782}
+
+```cpp
+using mavsdk::CameraServer::FocusOutStartHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_out_start.
+
+
+### typedef FocusStopCallback {#classmavsdk_1_1_camera_server_1a1ee6b49a2cb9c9c6668500edc8e308ae}
+
+```cpp
+using mavsdk::CameraServer::FocusStopCallback =  std::function<void(int32_t)>
+```
+
+
+Callback type for subscribe_focus_stop.
+
+
+### typedef FocusStopHandle {#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597}
+
+```cpp
+using mavsdk::CameraServer::FocusStopHandle =  Handle<int32_t>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_stop.
+
+
+### typedef FocusRangeCallback {#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb}
+
+```cpp
+using mavsdk::CameraServer::FocusRangeCallback =  std::function<void(float)>
+```
+
+
+Callback type for subscribe_focus_range.
+
+
+### typedef FocusRangeHandle {#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d}
+
+```cpp
+using mavsdk::CameraServer::FocusRangeHandle =  Handle<float>
+```
+
+
+[Handle](classmavsdk_1_1_handle.md) type for subscribe_focus_range.
 
 
 ### typedef TrackingPointCommandCallback {#classmavsdk_1_1_camera_server_1afcb7cf46d38b362562653e9648191ef4}
@@ -1312,6 +1462,294 @@ This function is blocking.
 **Parameters**
 
 * [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **zoom_range_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_in_step() {#classmavsdk_1_1_camera_server_1ab71c5ac27c494a23daef45e5806d17f5}
+```cpp
+FocusInStepHandle mavsdk::CameraServer::subscribe_focus_in_step(const FocusInStepCallback &callback)
+```
+
+
+Subscribe to focus in step command.
+
+
+**Parameters**
+
+* const [FocusInStepCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a8f25d1eb4d11c29957033f4faf5b6c35)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusInStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d) - 
+
+### unsubscribe_focus_in_step() {#classmavsdk_1_1_camera_server_1a75a28c7d2ed7548fd2b77fba0e28f26e}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_in_step(FocusInStepHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_in_step.
+
+
+**Parameters**
+
+* [FocusInStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a24886394f39293a65facdcb118bb620d) **handle** - 
+
+### respond_focus_in_step() {#classmavsdk_1_1_camera_server_1a9fdac017089a2e990956da91ea0111e1}
+```cpp
+Result mavsdk::CameraServer::respond_focus_in_step(CameraFeedback focus_in_step_feedback) const
+```
+
+
+Respond to focus in step.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_in_step_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_out_step() {#classmavsdk_1_1_camera_server_1a84d79fbcd94cc9c9336c7f02484efae7}
+```cpp
+FocusOutStepHandle mavsdk::CameraServer::subscribe_focus_out_step(const FocusOutStepCallback &callback)
+```
+
+
+Subscribe to focus out step command.
+
+
+**Parameters**
+
+* const [FocusOutStepCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1ac74618e43c6759ad0c8492e56051ed03)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusOutStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0) - 
+
+### unsubscribe_focus_out_step() {#classmavsdk_1_1_camera_server_1a50d671c9d2cfc97bc8ead0ab9bccaf22}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_out_step(FocusOutStepHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_out_step.
+
+
+**Parameters**
+
+* [FocusOutStepHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a32c13ec9701bbb79f5174740447fadf0) **handle** - 
+
+### respond_focus_out_step() {#classmavsdk_1_1_camera_server_1a71fd8f066fefc4ea3ba66723789fc714}
+```cpp
+Result mavsdk::CameraServer::respond_focus_out_step(CameraFeedback focus_out_step_feedback) const
+```
+
+
+Respond to focus out step.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_out_step_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_in_start() {#classmavsdk_1_1_camera_server_1aa9f9fe38cbcd2ec2971339a7dfcce096}
+```cpp
+FocusInStartHandle mavsdk::CameraServer::subscribe_focus_in_start(const FocusInStartCallback &callback)
+```
+
+
+Subscribe to focus in start command.
+
+
+**Parameters**
+
+* const [FocusInStartCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a7defa232336b6dd9aedfab9be70b3c57)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusInStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803) - 
+
+### unsubscribe_focus_in_start() {#classmavsdk_1_1_camera_server_1a50a4a83f0404d84067791cbe9cfb6669}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_in_start(FocusInStartHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_in_start.
+
+
+**Parameters**
+
+* [FocusInStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a00723c0fbd851504f988bfb965441803) **handle** - 
+
+### respond_focus_in_start() {#classmavsdk_1_1_camera_server_1a9301135a5127fd6170b2c5d069ec150a}
+```cpp
+Result mavsdk::CameraServer::respond_focus_in_start(CameraFeedback focus_in_start_feedback) const
+```
+
+
+Respond to focus in start.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_in_start_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_out_start() {#classmavsdk_1_1_camera_server_1a302db58054397888c39ed6e65af3844f}
+```cpp
+FocusOutStartHandle mavsdk::CameraServer::subscribe_focus_out_start(const FocusOutStartCallback &callback)
+```
+
+
+Subscribe to focus out start command.
+
+
+**Parameters**
+
+* const [FocusOutStartCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aef4c0f7c2c304c2684e3933cee3a6b68)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusOutStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782) - 
+
+### unsubscribe_focus_out_start() {#classmavsdk_1_1_camera_server_1afaa7672b671d9f43c7594dcae9774817}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_out_start(FocusOutStartHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_out_start.
+
+
+**Parameters**
+
+* [FocusOutStartHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a0caf928df97b7f60b62875be222e7782) **handle** - 
+
+### respond_focus_out_start() {#classmavsdk_1_1_camera_server_1ad1e61dc4e61e4537b760653f972216b1}
+```cpp
+Result mavsdk::CameraServer::respond_focus_out_start(CameraFeedback focus_out_start_feedback) const
+```
+
+
+Respond to focus out start.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_out_start_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_stop() {#classmavsdk_1_1_camera_server_1a29d34a3e62e161577f902c87287168eb}
+```cpp
+FocusStopHandle mavsdk::CameraServer::subscribe_focus_stop(const FocusStopCallback &callback)
+```
+
+
+Subscribe to focus stop command.
+
+
+**Parameters**
+
+* const [FocusStopCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1ee6b49a2cb9c9c6668500edc8e308ae)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusStopHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) - 
+
+### unsubscribe_focus_stop() {#classmavsdk_1_1_camera_server_1a2837fce0fc74e63d8fcb71af13512e63}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_stop(FocusStopHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_stop.
+
+
+**Parameters**
+
+* [FocusStopHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1afe0020f3ecf00b001192d663ed5b4597) **handle** - 
+
+### respond_focus_stop() {#classmavsdk_1_1_camera_server_1ace6539aef1ff67d390d596339df68876}
+```cpp
+Result mavsdk::CameraServer::respond_focus_stop(CameraFeedback focus_stop_feedback) const
+```
+
+
+Respond to focus stop.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_stop_feedback** - 
+
+**Returns**
+
+&emsp;[Result](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa625af622ca91165c737cffebfe57f8d) - Result of request.
+
+### subscribe_focus_range() {#classmavsdk_1_1_camera_server_1a954fde18d0958a943017e710c01250ef}
+```cpp
+FocusRangeHandle mavsdk::CameraServer::subscribe_focus_range(const FocusRangeCallback &callback)
+```
+
+
+Subscribe to focus range command.
+
+
+**Parameters**
+
+* const [FocusRangeCallback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1aa71fb42ea5134a898608162aab9085fb)& **callback** - 
+
+**Returns**
+
+&emsp;[FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) - 
+
+### unsubscribe_focus_range() {#classmavsdk_1_1_camera_server_1ac1410546d1554c0ff9c8aceea5aee47c}
+```cpp
+void mavsdk::CameraServer::unsubscribe_focus_range(FocusRangeHandle handle)
+```
+
+
+Unsubscribe from subscribe_focus_range.
+
+
+**Parameters**
+
+* [FocusRangeHandle](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a1f3403018959b69085becff44d8b4f3d) **handle** - 
+
+### respond_focus_range() {#classmavsdk_1_1_camera_server_1a006ccea3e7a10304b35d8281da47d84c}
+```cpp
+Result mavsdk::CameraServer::respond_focus_range(CameraFeedback focus_range_feedback) const
+```
+
+
+Respond to focus range.
+
+This function is blocking.
+
+**Parameters**
+
+* [CameraFeedback](classmavsdk_1_1_camera_server.md#classmavsdk_1_1_camera_server_1a088cdcd9da37b84f075d20d5b7458a72) **focus_range_feedback** - 
 
 **Returns**
 

--- a/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera/NativeCamera.java
+++ b/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera/NativeCamera.java
@@ -501,6 +501,26 @@ public final class NativeCamera {
         void invoke(int result);
     }
 
+    @FunctionalInterface
+    public interface FocusMetersCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoSingleCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoContinuousCallback {
+        void invoke(int result);
+    }
+
     public static native long create(long systemHandle);
 
     public static native void destroy(long pluginHandle);
@@ -644,5 +664,21 @@ public final class NativeCamera {
     public static native int focusRange(long pluginHandle, int componentId, float range);
 
     public static native void focusRangeAsync(long pluginHandle, int componentId, float range, FocusRangeCallback callback);
+
+    public static native int focusMeters(long pluginHandle, int componentId, float distanceM);
+
+    public static native void focusMetersAsync(long pluginHandle, int componentId, float distanceM, FocusMetersCallback callback);
+
+    public static native int focusAuto(long pluginHandle, int componentId);
+
+    public static native void focusAutoAsync(long pluginHandle, int componentId, FocusAutoCallback callback);
+
+    public static native int focusAutoSingle(long pluginHandle, int componentId);
+
+    public static native void focusAutoSingleAsync(long pluginHandle, int componentId, FocusAutoSingleCallback callback);
+
+    public static native int focusAutoContinuous(long pluginHandle, int componentId);
+
+    public static native void focusAutoContinuousAsync(long pluginHandle, int componentId, FocusAutoContinuousCallback callback);
 
 }

--- a/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera/NativeCamera.java
+++ b/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera/NativeCamera.java
@@ -472,6 +472,16 @@ public final class NativeCamera {
     }
 
     @FunctionalInterface
+    public interface FocusInStepCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
+    public interface FocusOutStepCallback {
+        void invoke(int result);
+    }
+
+    @FunctionalInterface
     public interface FocusInStartCallback {
         void invoke(int result);
     }
@@ -610,6 +620,14 @@ public final class NativeCamera {
     public static native int trackStop(long pluginHandle, int componentId);
 
     public static native void trackStopAsync(long pluginHandle, int componentId, TrackStopCallback callback);
+
+    public static native int focusInStep(long pluginHandle, int componentId);
+
+    public static native void focusInStepAsync(long pluginHandle, int componentId, FocusInStepCallback callback);
+
+    public static native int focusOutStep(long pluginHandle, int componentId);
+
+    public static native void focusOutStepAsync(long pluginHandle, int componentId, FocusOutStepCallback callback);
 
     public static native int focusInStart(long pluginHandle, int componentId);
 

--- a/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera_server/NativeCameraServer.java
+++ b/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera_server/NativeCameraServer.java
@@ -298,6 +298,36 @@ public final class NativeCameraServer {
     }
 
     @FunctionalInterface
+    public interface FocusInStepCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusOutStepCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusInStartCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusOutStartCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusStopCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusRangeCallback {
+        void invoke(float value);
+    }
+
+    @FunctionalInterface
     public interface TrackingPointCommandCallback {
         void invoke(TrackPoint value);
     }
@@ -405,6 +435,42 @@ public final class NativeCameraServer {
     public static native void unsubscribeZoomRange(long pluginHandle, long subscriptionHandle);
 
     public static native int respondZoomRange(long pluginHandle, int zoomRangeFeedback);
+
+    public static native long subscribeFocusInStep(long pluginHandle, FocusInStepCallback callback);
+
+    public static native void unsubscribeFocusInStep(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusInStep(long pluginHandle, int focusInStepFeedback);
+
+    public static native long subscribeFocusOutStep(long pluginHandle, FocusOutStepCallback callback);
+
+    public static native void unsubscribeFocusOutStep(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusOutStep(long pluginHandle, int focusOutStepFeedback);
+
+    public static native long subscribeFocusInStart(long pluginHandle, FocusInStartCallback callback);
+
+    public static native void unsubscribeFocusInStart(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusInStart(long pluginHandle, int focusInStartFeedback);
+
+    public static native long subscribeFocusOutStart(long pluginHandle, FocusOutStartCallback callback);
+
+    public static native void unsubscribeFocusOutStart(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusOutStart(long pluginHandle, int focusOutStartFeedback);
+
+    public static native long subscribeFocusStop(long pluginHandle, FocusStopCallback callback);
+
+    public static native void unsubscribeFocusStop(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusStop(long pluginHandle, int focusStopFeedback);
+
+    public static native long subscribeFocusRange(long pluginHandle, FocusRangeCallback callback);
+
+    public static native void unsubscribeFocusRange(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusRange(long pluginHandle, int focusRangeFeedback);
 
     public static native void setTrackingRectangleStatus(long pluginHandle, TrackRectangle trackedRectangle);
 

--- a/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera_server/NativeCameraServer.java
+++ b/jni/jvm/src/main/java/io/mavsdk/jni/plugins/camera_server/NativeCameraServer.java
@@ -328,6 +328,26 @@ public final class NativeCameraServer {
     }
 
     @FunctionalInterface
+    public interface FocusMetersCallback {
+        void invoke(float value);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoSingleCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
+    public interface FocusAutoContinuousCallback {
+        void invoke(int value);
+    }
+
+    @FunctionalInterface
     public interface TrackingPointCommandCallback {
         void invoke(TrackPoint value);
     }
@@ -471,6 +491,30 @@ public final class NativeCameraServer {
     public static native void unsubscribeFocusRange(long pluginHandle, long subscriptionHandle);
 
     public static native int respondFocusRange(long pluginHandle, int focusRangeFeedback);
+
+    public static native long subscribeFocusMeters(long pluginHandle, FocusMetersCallback callback);
+
+    public static native void unsubscribeFocusMeters(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusMeters(long pluginHandle, int focusMetersFeedback);
+
+    public static native long subscribeFocusAuto(long pluginHandle, FocusAutoCallback callback);
+
+    public static native void unsubscribeFocusAuto(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusAuto(long pluginHandle, int focusAutoFeedback);
+
+    public static native long subscribeFocusAutoSingle(long pluginHandle, FocusAutoSingleCallback callback);
+
+    public static native void unsubscribeFocusAutoSingle(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusAutoSingle(long pluginHandle, int focusAutoSingleFeedback);
+
+    public static native long subscribeFocusAutoContinuous(long pluginHandle, FocusAutoContinuousCallback callback);
+
+    public static native void unsubscribeFocusAutoContinuous(long pluginHandle, long subscriptionHandle);
+
+    public static native int respondFocusAutoContinuous(long pluginHandle, int focusAutoContinuousFeedback);
 
     public static native void setTrackingRectangleStatus(long pluginHandle, TrackRectangle trackedRectangle);
 

--- a/jni/plugins/camera/camera_jni.cpp
+++ b/jni/plugins/camera/camera_jni.cpp
@@ -2753,6 +2753,72 @@ struct TrackStopCallbackWrapper {
         }
     }
 };
+struct FocusInStepCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusInStepCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusOutStepCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusOutStepCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
 struct FocusInStartCallbackWrapper {
     GlobalRefHolder callback;
     jmethodID invokeMethod;
@@ -4328,6 +4394,94 @@ Java_io_mavsdk_jni_plugins_camera_NativeCamera_trackStopAsync(
         [](const mavsdk_camera_result_t result, void* userData) {
             auto* callbackWrapper =
                 static_cast<TrackStopCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusInStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_in_step(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusInStepAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusInStepCallbackWrapper(env, callback);
+    mavsdk_camera_focus_in_step_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusInStepCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusOutStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_out_step(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusOutStepAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusOutStepCallbackWrapper(env, callback);
+    mavsdk_camera_focus_out_step_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusOutStepCallbackWrapper*>(userData);
             (*callbackWrapper)(result);
             if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
                 delete callbackWrapper;

--- a/jni/plugins/camera/camera_jni.cpp
+++ b/jni/plugins/camera/camera_jni.cpp
@@ -2951,6 +2951,138 @@ struct FocusRangeCallbackWrapper {
         }
     }
 };
+struct FocusMetersCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusMetersCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoSingleCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoSingleCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoContinuousCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoContinuousCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const mavsdk_camera_result_t result    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(result)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
 
 } // namespace
 
@@ -4662,6 +4794,186 @@ Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusRangeAsync(
         [](const mavsdk_camera_result_t result, void* userData) {
             auto* callbackWrapper =
                 static_cast<FocusRangeCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusMeters(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jfloat distance_m) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_meters(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id),
+            static_cast<float>(distance_m));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusMetersAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jfloat distance_m,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusMetersCallbackWrapper(env, callback);
+    mavsdk_camera_focus_meters_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        static_cast<float>(distance_m),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusMetersCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAuto(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_auto(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAutoAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusAutoCallbackWrapper(env, callback);
+    mavsdk_camera_focus_auto_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusAutoCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAutoSingle(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_auto_single(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAutoSingleAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusAutoSingleCallbackWrapper(env, callback);
+    mavsdk_camera_focus_auto_single_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusAutoSingleCallbackWrapper*>(userData);
+            (*callbackWrapper)(result);
+            if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
+                delete callbackWrapper;
+            }
+        },
+        wrapper);
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAutoContinuous(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id) {
+    if (!requireHandle(env, handle, "Camera plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_result_t result =
+        mavsdk_camera_focus_auto_continuous(
+            reinterpret_cast<mavsdk_camera_t>(handle),
+            static_cast<int32_t>(component_id));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_NativeCamera_focusAutoContinuousAsync(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint component_id,
+    jobject callback) {
+    if (!requireHandle(env, handle, "Camera plugin") || !callback) {
+        return;
+    }
+
+    auto* wrapper = new FocusAutoContinuousCallbackWrapper(env, callback);
+    mavsdk_camera_focus_auto_continuous_async(
+        reinterpret_cast<mavsdk_camera_t>(handle),
+        static_cast<int32_t>(component_id),
+        [](const mavsdk_camera_result_t result, void* userData) {
+            auto* callbackWrapper =
+                static_cast<FocusAutoContinuousCallbackWrapper*>(userData);
             (*callbackWrapper)(result);
             if (result != MAVSDK_CAMERA_RESULT_IN_PROGRESS) {
                 delete callbackWrapper;

--- a/jni/plugins/camera_server/camera_server_jni.cpp
+++ b/jni/plugins/camera_server/camera_server_jni.cpp
@@ -1477,6 +1477,210 @@ struct ZoomRangeCallbackWrapper {
         }
     }
 };
+struct FocusInStepCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusInStepCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusOutStepCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusOutStepCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusInStartCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusInStartCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusOutStartCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusOutStartCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusStopCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusStopCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusRangeCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusRangeCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(F)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const float value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jfloat>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
 struct TrackingPointCommandCallbackWrapper {
     GlobalRefHolder callback;
     jmethodID invokeMethod;
@@ -2613,6 +2817,402 @@ JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondZoom
         mavsdk_camera_server_respond_zoom_range(
             reinterpret_cast<mavsdk_camera_server_t>(handle),
             static_cast<mavsdk_camera_server_camera_feedback_t>(zoom_range_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusInStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusInStepCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_in_step(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusInStepCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_in_step_handle_t,
+        FocusInStepCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusInStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_in_step_handle_t,
+        FocusInStepCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_in_step(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusInStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_in_step_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_in_step(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_in_step_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusOutStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusOutStepCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_out_step(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusOutStepCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_out_step_handle_t,
+        FocusOutStepCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusOutStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_out_step_handle_t,
+        FocusOutStepCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_out_step(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusOutStep(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_out_step_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_out_step(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_out_step_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusInStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusInStartCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_in_start(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusInStartCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_in_start_handle_t,
+        FocusInStartCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusInStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_in_start_handle_t,
+        FocusInStartCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_in_start(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusInStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_in_start_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_in_start(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_in_start_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusOutStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusOutStartCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_out_start(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusOutStartCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_out_start_handle_t,
+        FocusOutStartCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusOutStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_out_start_handle_t,
+        FocusOutStartCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_out_start(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusOutStart(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_out_start_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_out_start(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_out_start_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusStop(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusStopCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_stop(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusStopCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_stop_handle_t,
+        FocusStopCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusStop(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_stop_handle_t,
+        FocusStopCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_stop(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusStop(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_stop_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_stop(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_stop_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusRange(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusRangeCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_range(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const float value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusRangeCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_range_handle_t,
+        FocusRangeCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusRange(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_range_handle_t,
+        FocusRangeCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_range(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusRange(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_range_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_range(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_range_feedback));
     return static_cast<jint>(result);
 }
 

--- a/jni/plugins/camera_server/camera_server_jni.cpp
+++ b/jni/plugins/camera_server/camera_server_jni.cpp
@@ -1681,6 +1681,142 @@ struct FocusRangeCallbackWrapper {
         }
     }
 };
+struct FocusMetersCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusMetersCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(F)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const float value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jfloat>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoSingleCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoSingleCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
+struct FocusAutoContinuousCallbackWrapper {
+    GlobalRefHolder callback;
+    jmethodID invokeMethod;
+
+    FocusAutoContinuousCallbackWrapper(JNIEnv* env, jobject callbackObject)
+        : callback(env, callbackObject), invokeMethod(nullptr) {
+        if (callback.isValid()) {
+            jclass callbackClass = env->GetObjectClass(callbackObject);
+            invokeMethod = env->GetMethodID(callbackClass, "invoke", "(I)V");
+            env->DeleteLocalRef(callbackClass);
+        }
+    }
+
+    void operator()(
+        const int32_t value
+    ) const {
+
+        if (!callback.isValid() || !invokeMethod || !g_jvm) {
+            return;
+        }
+        JavaVMAttacher attacher(g_jvm);
+        JNIEnv* env = attacher.getEnv();
+        if (!env) {
+            return;
+        }
+        env->CallVoidMethod(callback.get(), invokeMethod
+            , static_cast<jint>(value)
+        );
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+        }
+    }
+};
 struct TrackingPointCommandCallbackWrapper {
     GlobalRefHolder callback;
     jmethodID invokeMethod;
@@ -3213,6 +3349,270 @@ JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocu
         mavsdk_camera_server_respond_focus_range(
             reinterpret_cast<mavsdk_camera_server_t>(handle),
             static_cast<mavsdk_camera_server_camera_feedback_t>(focus_range_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusMeters(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusMetersCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_meters(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const float value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusMetersCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_meters_handle_t,
+        FocusMetersCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusMeters(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_meters_handle_t,
+        FocusMetersCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_meters(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusMeters(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_meters_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_meters(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_meters_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusAuto(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusAutoCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_auto(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusAutoCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_auto_handle_t,
+        FocusAutoCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusAuto(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_auto_handle_t,
+        FocusAutoCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_auto(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusAuto(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_auto_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_auto(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_auto_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusAutoSingle(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusAutoSingleCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_auto_single(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusAutoSingleCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_auto_single_handle_t,
+        FocusAutoSingleCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusAutoSingle(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_auto_single_handle_t,
+        FocusAutoSingleCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_auto_single(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusAutoSingle(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_auto_single_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_auto_single(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_auto_single_feedback));
+    return static_cast<jint>(result);
+}
+
+JNIEXPORT jlong JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_subscribeFocusAutoContinuous(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jobject callback) {
+    if (!requireHandle(env, handle, "CameraServer plugin") || !callback) {
+        return 0;
+    }
+
+    auto* wrapper = new FocusAutoContinuousCallbackWrapper(env, callback);
+    auto subscriptionHandle =
+        mavsdk_camera_server_subscribe_focus_auto_continuous(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            [](
+               const int32_t value,
+               void* userData) {
+                auto* callbackWrapper =
+                    static_cast<FocusAutoContinuousCallbackWrapper*>(userData);
+                (*callbackWrapper)(value);
+            },
+            wrapper);
+    auto* handlePair = new std::pair<
+        mavsdk_camera_server_focus_auto_continuous_handle_t,
+        FocusAutoContinuousCallbackWrapper*>(subscriptionHandle, wrapper);
+    return reinterpret_cast<jlong>(handlePair);
+}
+
+JNIEXPORT void JNICALL
+Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_unsubscribeFocusAutoContinuous(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jlong subscriptionHandle) {
+    if (!requireHandle(env, handle, "CameraServer plugin") ||
+        !subscriptionHandle) {
+        return;
+    }
+    auto* handlePair = reinterpret_cast<std::pair<
+        mavsdk_camera_server_focus_auto_continuous_handle_t,
+        FocusAutoContinuousCallbackWrapper*>*>(subscriptionHandle);
+    mavsdk_camera_server_unsubscribe_focus_auto_continuous(
+        reinterpret_cast<mavsdk_camera_server_t>(handle),
+        handlePair->first);
+    delete handlePair->second;
+    delete handlePair;
+}
+
+JNIEXPORT
+jint
+JNICALL Java_io_mavsdk_jni_plugins_camera_1server_NativeCameraServer_respondFocusAutoContinuous(
+    JNIEnv* env,
+    jclass,
+    jlong handle,
+    jint focus_auto_continuous_feedback) {
+    if (!requireHandle(env, handle, "CameraServer plugin")) {
+        return {};
+    }
+
+    mavsdk_camera_server_result_t result =
+        mavsdk_camera_server_respond_focus_auto_continuous(
+            reinterpret_cast<mavsdk_camera_server_t>(handle),
+            static_cast<mavsdk_camera_server_camera_feedback_t>(focus_auto_continuous_feedback));
     return static_cast<jint>(result);
 }
 

--- a/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera/Camera.kt
+++ b/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera/Camera.kt
@@ -1091,6 +1091,93 @@ class Camera internal constructor(private val native: CameraNative) {
             }
         }
 
+    /**
+     * Focus at a distance in meters.
+     *
+     * Note that there is no message to get the valid focus range of the camera, so this can only be
+     * used for cameras where the range is known.
+     *
+     * @param componentId Component ID
+     * @param distanceM Focus distance in meters
+     * @return The result of the request.
+     */
+    suspend fun focusMeters(componentId: Int, distanceM: Float): Result =
+        suspendCancellableCoroutine { continuation ->
+            val callbackGuard = CameraCallbackGuard()
+            native.focusMetersAsync(componentId, distanceM) { result ->
+                val parsedResult = Result.fromValue(result)
+                if (
+                    continuation.isActive &&
+                        parsedResult != Result.IN_PROGRESS &&
+                        callbackGuard.tryClaim()
+                ) {
+                    continuation.resume(parsedResult)
+                }
+            }
+        }
+
+    /**
+     * Focus automatically.
+     *
+     * @param componentId Component ID
+     * @return The result of the request.
+     */
+    suspend fun focusAuto(componentId: Int): Result = suspendCancellableCoroutine { continuation ->
+        val callbackGuard = CameraCallbackGuard()
+        native.focusAutoAsync(componentId) { result ->
+            val parsedResult = Result.fromValue(result)
+            if (
+                continuation.isActive &&
+                    parsedResult != Result.IN_PROGRESS &&
+                    callbackGuard.tryClaim()
+            ) {
+                continuation.resume(parsedResult)
+            }
+        }
+    }
+
+    /**
+     * Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+     *
+     * @param componentId Component ID
+     * @return The result of the request.
+     */
+    suspend fun focusAutoSingle(componentId: Int): Result =
+        suspendCancellableCoroutine { continuation ->
+            val callbackGuard = CameraCallbackGuard()
+            native.focusAutoSingleAsync(componentId) { result ->
+                val parsedResult = Result.fromValue(result)
+                if (
+                    continuation.isActive &&
+                        parsedResult != Result.IN_PROGRESS &&
+                        callbackGuard.tryClaim()
+                ) {
+                    continuation.resume(parsedResult)
+                }
+            }
+        }
+
+    /**
+     * Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+     *
+     * @param componentId Component ID
+     * @return The result of the request.
+     */
+    suspend fun focusAutoContinuous(componentId: Int): Result =
+        suspendCancellableCoroutine { continuation ->
+            val callbackGuard = CameraCallbackGuard()
+            native.focusAutoContinuousAsync(componentId) { result ->
+                val parsedResult = Result.fromValue(result)
+                if (
+                    continuation.isActive &&
+                        parsedResult != Result.IN_PROGRESS &&
+                        callbackGuard.tryClaim()
+                ) {
+                    continuation.resume(parsedResult)
+                }
+            }
+        }
+
     internal fun destroy() {
         if (closed) return
         closed = true
@@ -1215,6 +1302,14 @@ internal interface CameraNative {
     fun focusStopAsync(componentId: Int, callback: (Int) -> Unit)
 
     fun focusRangeAsync(componentId: Int, range: Float, callback: (Int) -> Unit)
+
+    fun focusMetersAsync(componentId: Int, distanceM: Float, callback: (Int) -> Unit)
+
+    fun focusAutoAsync(componentId: Int, callback: (Int) -> Unit)
+
+    fun focusAutoSingleAsync(componentId: Int, callback: (Int) -> Unit)
+
+    fun focusAutoContinuousAsync(componentId: Int, callback: (Int) -> Unit)
 
     fun destroy()
 }

--- a/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera/Camera.kt
+++ b/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera/Camera.kt
@@ -966,6 +966,48 @@ class Camera internal constructor(private val native: CameraNative) {
     }
 
     /**
+     * Step focus in.
+     *
+     * @param componentId Component ID
+     * @return The result of the request.
+     */
+    suspend fun focusInStep(componentId: Int): Result =
+        suspendCancellableCoroutine { continuation ->
+            val callbackGuard = CameraCallbackGuard()
+            native.focusInStepAsync(componentId) { result ->
+                val parsedResult = Result.fromValue(result)
+                if (
+                    continuation.isActive &&
+                        parsedResult != Result.IN_PROGRESS &&
+                        callbackGuard.tryClaim()
+                ) {
+                    continuation.resume(parsedResult)
+                }
+            }
+        }
+
+    /**
+     * Step focus out.
+     *
+     * @param componentId Component ID
+     * @return The result of the request.
+     */
+    suspend fun focusOutStep(componentId: Int): Result =
+        suspendCancellableCoroutine { continuation ->
+            val callbackGuard = CameraCallbackGuard()
+            native.focusOutStepAsync(componentId) { result ->
+                val parsedResult = Result.fromValue(result)
+                if (
+                    continuation.isActive &&
+                        parsedResult != Result.IN_PROGRESS &&
+                        callbackGuard.tryClaim()
+                ) {
+                    continuation.resume(parsedResult)
+                }
+            }
+        }
+
+    /**
      * Start focusing in.
      *
      * @param componentId Component ID
@@ -1161,6 +1203,10 @@ internal interface CameraNative {
     )
 
     fun trackStopAsync(componentId: Int, callback: (Int) -> Unit)
+
+    fun focusInStepAsync(componentId: Int, callback: (Int) -> Unit)
+
+    fun focusOutStepAsync(componentId: Int, callback: (Int) -> Unit)
 
     fun focusInStartAsync(componentId: Int, callback: (Int) -> Unit)
 

--- a/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServer.kt
+++ b/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServer.kt
@@ -615,6 +615,120 @@ class CameraServer internal constructor(private val native: CameraServerNative) 
         Result.fromValue(native.respondZoomRange(zoomRangeFeedback))
 
     /**
+     * Subscribe to focus in step command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusInStep(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusInStep() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusInStep(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus in step.
+     *
+     * @param focusInStepFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusInStep(focusInStepFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusInStep(focusInStepFeedback))
+
+    /**
+     * Subscribe to focus out step command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusOutStep(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusOutStep() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusOutStep(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus out step.
+     *
+     * @param focusOutStepFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusOutStep(focusOutStepFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusOutStep(focusOutStepFeedback))
+
+    /**
+     * Subscribe to focus in start command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusInStart(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusInStart() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusInStart(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus in start.
+     *
+     * @param focusInStartFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusInStart(focusInStartFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusInStart(focusInStartFeedback))
+
+    /**
+     * Subscribe to focus out start command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusOutStart(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusOutStart() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusOutStart(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus out start.
+     *
+     * @param focusOutStartFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusOutStart(focusOutStartFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusOutStart(focusOutStartFeedback))
+
+    /**
+     * Subscribe to focus stop command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusStop(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusStop() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusStop(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus stop.
+     *
+     * @param focusStopFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusStop(focusStopFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusStop(focusStopFeedback))
+
+    /**
+     * Subscribe to focus range command.
+     *
+     * @return The focus distance in meters.
+     */
+    fun subscribeFocusRange(): Flow<Float> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusRange() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusRange(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus range.
+     *
+     * @param focusRangeFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusRange(focusRangeFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusRange(focusRangeFeedback))
+
+    /**
      * Set/update the current rectangle tracking status.
      *
      * @param trackedRectangle The tracked rectangle
@@ -830,6 +944,42 @@ internal interface CameraServerNative {
     fun unsubscribeZoomRange(subscriptionHandle: Long)
 
     fun respondZoomRange(zoomRangeFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusInStep(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusInStep(subscriptionHandle: Long)
+
+    fun respondFocusInStep(focusInStepFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusOutStep(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusOutStep(subscriptionHandle: Long)
+
+    fun respondFocusOutStep(focusOutStepFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusInStart(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusInStart(subscriptionHandle: Long)
+
+    fun respondFocusInStart(focusInStartFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusOutStart(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusOutStart(subscriptionHandle: Long)
+
+    fun respondFocusOutStart(focusOutStartFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusStop(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusStop(subscriptionHandle: Long)
+
+    fun respondFocusStop(focusStopFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusRange(callback: (Float) -> Unit): Long
+
+    fun unsubscribeFocusRange(subscriptionHandle: Long)
+
+    fun respondFocusRange(focusRangeFeedback: CameraServer.CameraFeedback): Int
 
     fun setTrackingRectangleStatus(trackedRectangle: CameraServer.TrackRectangle)
 

--- a/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServer.kt
+++ b/kt/mavsdk-kotlin/src/commonMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServer.kt
@@ -729,6 +729,82 @@ class CameraServer internal constructor(private val native: CameraServerNative) 
         Result.fromValue(native.respondFocusRange(focusRangeFeedback))
 
     /**
+     * Subscribe to focus meters command.
+     *
+     * @return The focus distance in meters.
+     */
+    fun subscribeFocusMeters(): Flow<Float> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusMeters() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusMeters(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus meters.
+     *
+     * @param focusMetersFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusMeters(focusMetersFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusMeters(focusMetersFeedback))
+
+    /**
+     * Subscribe to focus auto command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusAuto(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusAuto() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusAuto(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus auto.
+     *
+     * @param focusAutoFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusAuto(focusAutoFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusAuto(focusAutoFeedback))
+
+    /**
+     * Subscribe to focus auto single command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusAutoSingle(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusAutoSingle() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusAutoSingle(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus auto single.
+     *
+     * @param focusAutoSingleFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusAutoSingle(focusAutoSingleFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusAutoSingle(focusAutoSingleFeedback))
+
+    /**
+     * Subscribe to focus auto continuous command.
+     *
+     * @return reserved, just make protoc-gen-mavsdk working
+     */
+    fun subscribeFocusAutoContinuous(): Flow<Int> = callbackFlow {
+        val subscriptionHandle = native.subscribeFocusAutoContinuous() { value -> trySend(value) }
+        awaitClose { native.unsubscribeFocusAutoContinuous(subscriptionHandle) }
+    }
+
+    /**
+     * Respond to focus auto continuous.
+     *
+     * @param focusAutoContinuousFeedback the feedback
+     * @return The result of the request.
+     */
+    fun respondFocusAutoContinuous(focusAutoContinuousFeedback: CameraFeedback): Result =
+        Result.fromValue(native.respondFocusAutoContinuous(focusAutoContinuousFeedback))
+
+    /**
      * Set/update the current rectangle tracking status.
      *
      * @param trackedRectangle The tracked rectangle
@@ -980,6 +1056,30 @@ internal interface CameraServerNative {
     fun unsubscribeFocusRange(subscriptionHandle: Long)
 
     fun respondFocusRange(focusRangeFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusMeters(callback: (Float) -> Unit): Long
+
+    fun unsubscribeFocusMeters(subscriptionHandle: Long)
+
+    fun respondFocusMeters(focusMetersFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusAuto(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusAuto(subscriptionHandle: Long)
+
+    fun respondFocusAuto(focusAutoFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusAutoSingle(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusAutoSingle(subscriptionHandle: Long)
+
+    fun respondFocusAutoSingle(focusAutoSingleFeedback: CameraServer.CameraFeedback): Int
+
+    fun subscribeFocusAutoContinuous(callback: (Int) -> Unit): Long
+
+    fun unsubscribeFocusAutoContinuous(subscriptionHandle: Long)
+
+    fun respondFocusAutoContinuous(focusAutoContinuousFeedback: CameraServer.CameraFeedback): Int
 
     fun setTrackingRectangleStatus(trackedRectangle: CameraServer.TrackRectangle)
 

--- a/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera/CameraNative.kt
+++ b/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera/CameraNative.kt
@@ -698,6 +698,47 @@ private class CameraNativeImpl(private val handle: Long) : CameraNative {
         }
     }
 
+    override fun focusMetersAsync(componentId: Int, distanceM: Float, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusMetersAsync(
+                handle,
+                componentId,
+                distanceM,
+                NativeCamera.FocusMetersCallback { result -> callback(result) },
+            )
+        }
+    }
+
+    override fun focusAutoAsync(componentId: Int, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusAutoAsync(
+                handle,
+                componentId,
+                NativeCamera.FocusAutoCallback { result -> callback(result) },
+            )
+        }
+    }
+
+    override fun focusAutoSingleAsync(componentId: Int, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusAutoSingleAsync(
+                handle,
+                componentId,
+                NativeCamera.FocusAutoSingleCallback { result -> callback(result) },
+            )
+        }
+    }
+
+    override fun focusAutoContinuousAsync(componentId: Int, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusAutoContinuousAsync(
+                handle,
+                componentId,
+                NativeCamera.FocusAutoContinuousCallback { result -> callback(result) },
+            )
+        }
+    }
+
     override fun destroy() {
         lifecycle.write {
             if (destroyed) return

--- a/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera/CameraNative.kt
+++ b/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera/CameraNative.kt
@@ -637,6 +637,26 @@ private class CameraNativeImpl(private val handle: Long) : CameraNative {
         }
     }
 
+    override fun focusInStepAsync(componentId: Int, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusInStepAsync(
+                handle,
+                componentId,
+                NativeCamera.FocusInStepCallback { result -> callback(result) },
+            )
+        }
+    }
+
+    override fun focusOutStepAsync(componentId: Int, callback: (Int) -> Unit) {
+        withOpen {
+            NativeCamera.focusOutStepAsync(
+                handle,
+                componentId,
+                NativeCamera.FocusOutStepCallback { result -> callback(result) },
+            )
+        }
+    }
+
     override fun focusInStartAsync(componentId: Int, callback: (Int) -> Unit) {
         withOpen {
             NativeCamera.focusInStartAsync(

--- a/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServerNative.kt
+++ b/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServerNative.kt
@@ -538,6 +538,155 @@ private class CameraServerNativeImpl(private val handle: Long) : CameraServerNat
         NativeCameraServer.respondZoomRange(handle, zoomRangeFeedback.value)
     }
 
+    override fun subscribeFocusInStep(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusInStep(
+                handle,
+                NativeCameraServer.FocusInStepCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusInStep(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusInStep(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusInStep(focusInStepFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusInStep(handle, focusInStepFeedback.value)
+        }
+
+    override fun subscribeFocusOutStep(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusOutStep(
+                handle,
+                NativeCameraServer.FocusOutStepCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusOutStep(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusOutStep(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusOutStep(focusOutStepFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusOutStep(handle, focusOutStepFeedback.value)
+        }
+
+    override fun subscribeFocusInStart(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusInStart(
+                handle,
+                NativeCameraServer.FocusInStartCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusInStart(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusInStart(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusInStart(focusInStartFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusInStart(handle, focusInStartFeedback.value)
+        }
+
+    override fun subscribeFocusOutStart(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusOutStart(
+                handle,
+                NativeCameraServer.FocusOutStartCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusOutStart(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusOutStart(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusOutStart(focusOutStartFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusOutStart(handle, focusOutStartFeedback.value)
+        }
+
+    override fun subscribeFocusStop(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusStop(
+                handle,
+                NativeCameraServer.FocusStopCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusStop(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusStop(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusStop(focusStopFeedback: CameraServer.CameraFeedback): Int = withOpen {
+        NativeCameraServer.respondFocusStop(handle, focusStopFeedback.value)
+    }
+
+    override fun subscribeFocusRange(callback: (Float) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusRange(
+                handle,
+                NativeCameraServer.FocusRangeCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusRange(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusRange(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusRange(focusRangeFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusRange(handle, focusRangeFeedback.value)
+        }
+
     override fun setTrackingRectangleStatus(trackedRectangle: CameraServer.TrackRectangle) {
         withOpen {
             NativeCameraServer.setTrackingRectangleStatus(handle, trackedRectangle.toNative())

--- a/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServerNative.kt
+++ b/kt/mavsdk-kotlin/src/jvmAndroidMain/kotlin/io/mavsdk/kotlin/plugins/camera_server/CameraServerNative.kt
@@ -687,6 +687,106 @@ private class CameraServerNativeImpl(private val handle: Long) : CameraServerNat
             NativeCameraServer.respondFocusRange(handle, focusRangeFeedback.value)
         }
 
+    override fun subscribeFocusMeters(callback: (Float) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusMeters(
+                handle,
+                NativeCameraServer.FocusMetersCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusMeters(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusMeters(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusMeters(focusMetersFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusMeters(handle, focusMetersFeedback.value)
+        }
+
+    override fun subscribeFocusAuto(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusAuto(
+                handle,
+                NativeCameraServer.FocusAutoCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusAuto(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusAuto(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusAuto(focusAutoFeedback: CameraServer.CameraFeedback): Int = withOpen {
+        NativeCameraServer.respondFocusAuto(handle, focusAutoFeedback.value)
+    }
+
+    override fun subscribeFocusAutoSingle(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusAutoSingle(
+                handle,
+                NativeCameraServer.FocusAutoSingleCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusAutoSingle(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusAutoSingle(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusAutoSingle(focusAutoSingleFeedback: CameraServer.CameraFeedback): Int =
+        withOpen {
+            NativeCameraServer.respondFocusAutoSingle(handle, focusAutoSingleFeedback.value)
+        }
+
+    override fun subscribeFocusAutoContinuous(callback: (Int) -> Unit): Long = withOpen {
+        val subscriptionHandle =
+            NativeCameraServer.subscribeFocusAutoContinuous(
+                handle,
+                NativeCameraServer.FocusAutoContinuousCallback { value -> callback(value) },
+            )
+        if (subscriptionHandle != 0L) {
+            activeSubscriptions[subscriptionHandle] = {
+                NativeCameraServer.unsubscribeFocusAutoContinuous(handle, subscriptionHandle)
+            }
+        }
+        subscriptionHandle
+    }
+
+    override fun unsubscribeFocusAutoContinuous(subscriptionHandle: Long) {
+        // No destroyed check: flow cancellation races teardown, and destroy() already
+        // drained the map, so this is a no-op rather than an error after close.
+        lifecycle.read { activeSubscriptions.remove(subscriptionHandle)?.invoke() }
+    }
+
+    override fun respondFocusAutoContinuous(
+        focusAutoContinuousFeedback: CameraServer.CameraFeedback
+    ): Int = withOpen {
+        NativeCameraServer.respondFocusAutoContinuous(handle, focusAutoContinuousFeedback.value)
+    }
+
     override fun setTrackingRectangleStatus(trackedRectangle: CameraServer.TrackRectangle) {
         withOpen {
             NativeCameraServer.setTrackingRectangleStatus(handle, trackedRectangle.toNative())

--- a/py/aiomavsdk/aiomavsdk/plugins/camera/camera.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/camera/camera.py
@@ -751,6 +751,40 @@ class CameraAsync:
             None, lambda: self._plugin.track_stop(component_id)
         )
 
+    async def focus_in_step(self, component_id):
+        """
+        Step focus in.
+
+        Parameters
+        ----------
+        component_id : int
+        Raises
+        ------
+        CameraError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_in_step(component_id)
+        )
+
+    async def focus_out_step(self, component_id):
+        """
+        Step focus out.
+
+        Parameters
+        ----------
+        component_id : int
+        Raises
+        ------
+        CameraError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_out_step(component_id)
+        )
+
     async def focus_in_start(self, component_id):
         """
         Start focusing in.

--- a/py/aiomavsdk/aiomavsdk/plugins/camera/camera.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/camera/camera.py
@@ -854,6 +854,78 @@ class CameraAsync:
             None, lambda: self._plugin.focus_range(component_id, range)
         )
 
+    async def focus_meters(self, component_id, distance_m):
+        """
+               Focus at a distance in meters.
+
+        Note that there is no message to get the valid focus range of the camera,
+        so this can only be used for cameras where the range is known.
+
+               Parameters
+               ----------
+               component_id : int
+               distance_m : float
+               Raises
+               ------
+               CameraError
+                   If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_meters(component_id, distance_m)
+        )
+
+    async def focus_auto(self, component_id):
+        """
+        Focus automatically.
+
+        Parameters
+        ----------
+        component_id : int
+        Raises
+        ------
+        CameraError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_auto(component_id)
+        )
+
+    async def focus_auto_single(self, component_id):
+        """
+        Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S.
+
+        Parameters
+        ----------
+        component_id : int
+        Raises
+        ------
+        CameraError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_auto_single(component_id)
+        )
+
+    async def focus_auto_continuous(self, component_id):
+        """
+        Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C.
+
+        Parameters
+        ----------
+        component_id : int
+        Raises
+        ------
+        CameraError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.focus_auto_continuous(component_id)
+        )
+
     def destroy(self):
         self._subscription_handles.clear()
         self._plugin.destroy()

--- a/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
@@ -706,6 +706,258 @@ class CameraServerAsync:
             None, lambda: self._plugin.respond_zoom_range(zoom_range_feedback)
         )
 
+    async def subscribe_focus_in_step(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus in step command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_in_step(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_in_step(handle)
+
+    async def respond_focus_in_step(self, focus_in_step_feedback):
+        """
+        Respond to focus in step.
+
+        Parameters
+        ----------
+        focus_in_step_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_in_step(focus_in_step_feedback)
+        )
+
+    async def subscribe_focus_out_step(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus out step command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_out_step(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_out_step(handle)
+
+    async def respond_focus_out_step(self, focus_out_step_feedback):
+        """
+        Respond to focus out step.
+
+        Parameters
+        ----------
+        focus_out_step_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_out_step(focus_out_step_feedback)
+        )
+
+    async def subscribe_focus_in_start(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus in start command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_in_start(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_in_start(handle)
+
+    async def respond_focus_in_start(self, focus_in_start_feedback):
+        """
+        Respond to focus in start.
+
+        Parameters
+        ----------
+        focus_in_start_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_in_start(focus_in_start_feedback)
+        )
+
+    async def subscribe_focus_out_start(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus out start command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_out_start(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_out_start(handle)
+
+    async def respond_focus_out_start(self, focus_out_start_feedback):
+        """
+        Respond to focus out start.
+
+        Parameters
+        ----------
+        focus_out_start_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_out_start(focus_out_start_feedback)
+        )
+
+    async def subscribe_focus_stop(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus stop command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_stop(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_stop(handle)
+
+    async def respond_focus_stop(self, focus_stop_feedback):
+        """
+        Respond to focus stop.
+
+        Parameters
+        ----------
+        focus_stop_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_stop(focus_stop_feedback)
+        )
+
+    async def subscribe_focus_range(self) -> AsyncGenerator[float, None]:
+        """
+        Subscribe to focus range command.
+
+        Yields
+        ------
+         : float
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_range(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_range(handle)
+
+    async def respond_focus_range(self, focus_range_feedback):
+        """
+        Respond to focus range.
+
+        Parameters
+        ----------
+        focus_range_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_range(focus_range_feedback)
+        )
+
     async def set_tracking_rectangle_status(self, tracked_rectangle):
         """
         Set/update the current rectangle tracking status.

--- a/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
+++ b/py/aiomavsdk/aiomavsdk/plugins/camera_server/camera_server.py
@@ -958,6 +958,178 @@ class CameraServerAsync:
             None, lambda: self._plugin.respond_focus_range(focus_range_feedback)
         )
 
+    async def subscribe_focus_meters(self) -> AsyncGenerator[float, None]:
+        """
+        Subscribe to focus meters command.
+
+        Yields
+        ------
+         : float
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_meters(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_meters(handle)
+
+    async def respond_focus_meters(self, focus_meters_feedback):
+        """
+        Respond to focus meters.
+
+        Parameters
+        ----------
+        focus_meters_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_meters(focus_meters_feedback)
+        )
+
+    async def subscribe_focus_auto(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus auto command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_auto(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_auto(handle)
+
+    async def respond_focus_auto(self, focus_auto_feedback):
+        """
+        Respond to focus auto.
+
+        Parameters
+        ----------
+        focus_auto_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, lambda: self._plugin.respond_focus_auto(focus_auto_feedback)
+        )
+
+    async def subscribe_focus_auto_single(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus auto single command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_auto_single(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_auto_single(handle)
+
+    async def respond_focus_auto_single(self, focus_auto_single_feedback):
+        """
+        Respond to focus auto single.
+
+        Parameters
+        ----------
+        focus_auto_single_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: self._plugin.respond_focus_auto_single(focus_auto_single_feedback),
+        )
+
+    async def subscribe_focus_auto_continuous(self) -> AsyncGenerator[int, None]:
+        """
+        Subscribe to focus auto continuous command.
+
+        Yields
+        ------
+         : int
+             The next update
+        """
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def callback(data, _user_data):
+            loop.call_soon_threadsafe(queue.put_nowait, data)
+
+        handle = self._plugin.subscribe_focus_auto_continuous(callback)
+        self._subscription_handles[id(queue)] = handle
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            if id(queue) in self._subscription_handles:
+                self._subscription_handles.pop(id(queue))
+                self._plugin.unsubscribe_focus_auto_continuous(handle)
+
+    async def respond_focus_auto_continuous(self, focus_auto_continuous_feedback):
+        """
+        Respond to focus auto continuous.
+
+        Parameters
+        ----------
+        focus_auto_continuous_feedback : CameraFeedback
+        Raises
+        ------
+        CameraServerError
+            If the request fails. The error contains the reason for the failure.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: self._plugin.respond_focus_auto_continuous(
+                focus_auto_continuous_feedback
+            ),
+        )
+
     async def set_tracking_rectangle_status(self, tracked_rectangle):
         """
         Set/update the current rectangle tracking status.

--- a/py/mavsdk/mavsdk/plugins/camera/camera.py
+++ b/py/mavsdk/mavsdk/plugins/camera/camera.py
@@ -2134,6 +2134,74 @@ class Camera:
 
         return result
 
+    def focus_in_step_async(
+        self, component_id, callback: Callable, user_data: Any = None
+    ):
+        """Step focus in."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_in_step callback: {e}")
+
+        cb = FocusInStepCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_in_step_async(
+            self._handle, component_id, cb, None
+        )
+
+    def focus_in_step(self, component_id):
+        """Get focus_in_step (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_in_step(
+            self._handle,
+            component_id,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_in_step failed: {result}")
+
+        return result
+
+    def focus_out_step_async(
+        self, component_id, callback: Callable, user_data: Any = None
+    ):
+        """Step focus out."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_out_step callback: {e}")
+
+        cb = FocusOutStepCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_out_step_async(
+            self._handle, component_id, cb, None
+        )
+
+    def focus_out_step(self, component_id):
+        """Get focus_out_step (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_out_step(
+            self._handle,
+            component_id,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_out_step failed: {result}")
+
+        return result
+
     def focus_in_start_async(
         self, component_id, callback: Callable, user_data: Any = None
     ):
@@ -2317,6 +2385,8 @@ ZoomRangeCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 TrackPointCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 TrackRectangleCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 TrackStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusInStepCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusOutStepCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusInStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusOutStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
@@ -2982,6 +3052,36 @@ _cmavsdk_lib.mavsdk_camera_track_stop.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_camera_track_stop.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_in_step_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    FocusInStepCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_in_step_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_in_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_in_step.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_out_step_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    FocusOutStepCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_out_step_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_out_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_out_step.restype = ctypes.c_int
 _cmavsdk_lib.mavsdk_camera_focus_in_start_async.argtypes = [
     ctypes.c_void_p,
     ctypes.c_int32,

--- a/py/mavsdk/mavsdk/plugins/camera/camera.py
+++ b/py/mavsdk/mavsdk/plugins/camera/camera.py
@@ -2335,6 +2335,142 @@ class Camera:
 
         return result
 
+    def focus_meters_async(
+        self, component_id, distance_m, callback: Callable, user_data: Any = None
+    ):
+        """Focus at a distance in meters.
+
+        Note that there is no message to get the valid focus range of the camera,
+        so this can only be used for cameras where the range is known."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_meters callback: {e}")
+
+        cb = FocusMetersCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_meters_async(
+            self._handle, component_id, distance_m, cb, None
+        )
+
+    def focus_meters(self, component_id, distance_m):
+        """Get focus_meters (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_meters(
+            self._handle,
+            component_id,
+            distance_m,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_meters failed: {result}")
+
+        return result
+
+    def focus_auto_async(self, component_id, callback: Callable, user_data: Any = None):
+        """Focus automatically."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto callback: {e}")
+
+        cb = FocusAutoCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_auto_async(self._handle, component_id, cb, None)
+
+    def focus_auto(self, component_id):
+        """Get focus_auto (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_auto(
+            self._handle,
+            component_id,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_auto failed: {result}")
+
+        return result
+
+    def focus_auto_single_async(
+        self, component_id, callback: Callable, user_data: Any = None
+    ):
+        """Single auto focus. Mainly used for still pictures. Usually abbreviated as AF-S."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto_single callback: {e}")
+
+        cb = FocusAutoSingleCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_auto_single_async(
+            self._handle, component_id, cb, None
+        )
+
+    def focus_auto_single(self, component_id):
+        """Get focus_auto_single (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_auto_single(
+            self._handle,
+            component_id,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_auto_single failed: {result}")
+
+        return result
+
+    def focus_auto_continuous_async(
+        self, component_id, callback: Callable, user_data: Any = None
+    ):
+        """Continuous auto focus. Mainly used for dynamic scenes. Abbreviated as AF-C."""
+
+        def c_callback(result, ud):
+            try:
+                py_result = CameraResult(result)
+
+                callback(py_result, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto_continuous callback: {e}")
+
+        cb = FocusAutoContinuousCallback(c_callback)
+        self._callbacks.append(cb)
+
+        self._lib.mavsdk_camera_focus_auto_continuous_async(
+            self._handle, component_id, cb, None
+        )
+
+    def focus_auto_continuous(self, component_id):
+        """Get focus_auto_continuous (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_focus_auto_continuous(
+            self._handle,
+            component_id,
+        )
+        result = CameraResult(result_code)
+        if result != CameraResult.SUCCESS:
+            raise Exception(f"focus_auto_continuous failed: {result}")
+
+        return result
+
     def destroy(self):
         """Destroy the plugin instance"""
         if self._handle:
@@ -2391,6 +2527,10 @@ FocusInStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusOutStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 FocusRangeCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusMetersCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusAutoCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusAutoSingleCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
+FocusAutoContinuousCallback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_void_p)
 
 # ===== Setup Functions =====
 _cmavsdk_lib.mavsdk_camera_create.argtypes = [ctypes.c_void_p]
@@ -3144,3 +3284,65 @@ _cmavsdk_lib.mavsdk_camera_focus_range.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_camera_focus_range.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_meters_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    ctypes.c_float,
+    FocusMetersCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_meters_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_meters.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    ctypes.c_float,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_meters.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_auto_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    FocusAutoCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_auto.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_auto_single_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    FocusAutoSingleCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_single_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_single.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_single.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_focus_auto_continuous_async.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+    FocusAutoContinuousCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_continuous_async.restype = None
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_continuous.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int32,
+]
+
+_cmavsdk_lib.mavsdk_camera_focus_auto_continuous.restype = ctypes.c_int

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -1494,6 +1494,156 @@ class CameraServer:
 
         return result
 
+    def subscribe_focus_meters(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus meters command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_meters callback: {e}")
+
+        cb = FocusMetersCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_meters(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_meters(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_meters"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_meters(self._handle, handle)
+
+    def respond_focus_meters(self, focus_meters_feedback):
+        """Get respond_focus_meters (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_meters(
+            self._handle,
+            focus_meters_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_meters failed: {result}")
+
+        return result
+
+    def subscribe_focus_auto(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus auto command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto callback: {e}")
+
+        cb = FocusAutoCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_auto(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_auto(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_auto"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_auto(self._handle, handle)
+
+    def respond_focus_auto(self, focus_auto_feedback):
+        """Get respond_focus_auto (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_auto(
+            self._handle,
+            focus_auto_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_auto failed: {result}")
+
+        return result
+
+    def subscribe_focus_auto_single(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus auto single command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto_single callback: {e}")
+
+        cb = FocusAutoSingleCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_auto_single(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_auto_single(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_auto_single"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_auto_single(
+            self._handle, handle
+        )
+
+    def respond_focus_auto_single(self, focus_auto_single_feedback):
+        """Get respond_focus_auto_single (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_auto_single(
+            self._handle,
+            focus_auto_single_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_auto_single failed: {result}")
+
+        return result
+
+    def subscribe_focus_auto_continuous(
+        self, callback: Callable, user_data: Any = None
+    ):
+        """Subscribe to focus auto continuous command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_auto_continuous callback: {e}")
+
+        cb = FocusAutoContinuousCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_auto_continuous(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_auto_continuous(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_auto_continuous"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_auto_continuous(
+            self._handle, handle
+        )
+
+    def respond_focus_auto_continuous(self, focus_auto_continuous_feedback):
+        """Get respond_focus_auto_continuous (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_auto_continuous(
+            self._handle,
+            focus_auto_continuous_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_auto_continuous failed: {result}")
+
+        return result
+
     def set_tracking_rectangle_status(self, tracked_rectangle):
         """Get set_tracking_rectangle_status (blocking)"""
 
@@ -1717,6 +1867,10 @@ FocusInStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 FocusOutStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 FocusStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 FocusRangeCallback = ctypes.CFUNCTYPE(None, ctypes.c_float, ctypes.c_void_p)
+FocusMetersCallback = ctypes.CFUNCTYPE(None, ctypes.c_float, ctypes.c_void_p)
+FocusAutoCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusAutoSingleCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusAutoContinuousCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 TrackingPointCommandCallback = ctypes.CFUNCTYPE(
     None, TrackPointCStruct, ctypes.c_void_p
 )
@@ -2307,6 +2461,96 @@ _cmavsdk_lib.mavsdk_camera_server_respond_focus_range.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_camera_server_respond_focus_range.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_meters.argtypes = [
+    ctypes.c_void_p,
+    FocusMetersCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_meters.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_meters.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_meters.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_meters.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_meters.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto.argtypes = [
+    ctypes.c_void_p,
+    FocusAutoCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto_single.argtypes = [
+    ctypes.c_void_p,
+    FocusAutoSingleCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto_single.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto_single.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto_single.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto_single.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto_single.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto_continuous.argtypes = [
+    ctypes.c_void_p,
+    FocusAutoContinuousCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_auto_continuous.restype = (
+    ctypes.c_void_p
+)
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto_continuous.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_auto_continuous.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto_continuous.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_auto_continuous.restype = ctypes.c_int
 
 _cmavsdk_lib.mavsdk_camera_server_set_tracking_rectangle_status.argtypes = [
     ctypes.c_void_p,

--- a/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
+++ b/py/mavsdk/mavsdk/plugins/camera_server/camera_server.py
@@ -1278,6 +1278,222 @@ class CameraServer:
 
         return result
 
+    def subscribe_focus_in_step(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus in step command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_in_step callback: {e}")
+
+        cb = FocusInStepCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_in_step(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_in_step(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_in_step"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_in_step(self._handle, handle)
+
+    def respond_focus_in_step(self, focus_in_step_feedback):
+        """Get respond_focus_in_step (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_in_step(
+            self._handle,
+            focus_in_step_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_in_step failed: {result}")
+
+        return result
+
+    def subscribe_focus_out_step(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus out step command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_out_step callback: {e}")
+
+        cb = FocusOutStepCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_out_step(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_out_step(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_out_step"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_out_step(self._handle, handle)
+
+    def respond_focus_out_step(self, focus_out_step_feedback):
+        """Get respond_focus_out_step (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_out_step(
+            self._handle,
+            focus_out_step_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_out_step failed: {result}")
+
+        return result
+
+    def subscribe_focus_in_start(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus in start command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_in_start callback: {e}")
+
+        cb = FocusInStartCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_in_start(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_in_start(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_in_start"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_in_start(self._handle, handle)
+
+    def respond_focus_in_start(self, focus_in_start_feedback):
+        """Get respond_focus_in_start (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_in_start(
+            self._handle,
+            focus_in_start_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_in_start failed: {result}")
+
+        return result
+
+    def subscribe_focus_out_start(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus out start command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_out_start callback: {e}")
+
+        cb = FocusOutStartCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_out_start(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_out_start(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_out_start"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_out_start(self._handle, handle)
+
+    def respond_focus_out_start(self, focus_out_start_feedback):
+        """Get respond_focus_out_start (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_out_start(
+            self._handle,
+            focus_out_start_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_out_start failed: {result}")
+
+        return result
+
+    def subscribe_focus_stop(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus stop command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_stop callback: {e}")
+
+        cb = FocusStopCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_stop(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_stop(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_stop"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_stop(self._handle, handle)
+
+    def respond_focus_stop(self, focus_stop_feedback):
+        """Get respond_focus_stop (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_stop(
+            self._handle,
+            focus_stop_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_stop failed: {result}")
+
+        return result
+
+    def subscribe_focus_range(self, callback: Callable, user_data: Any = None):
+        """Subscribe to focus range command."""
+
+        def c_callback(c_data, ud):
+            try:
+                py_data = c_data
+
+                callback(py_data, user_data)
+
+            except Exception as e:
+                print(f"Error in focus_range callback: {e}")
+
+        cb = FocusRangeCallback(c_callback)
+        self._callbacks.append(cb)
+
+        return self._lib.mavsdk_camera_server_subscribe_focus_range(
+            self._handle, cb, None
+        )
+
+    def unsubscribe_focus_range(self, handle: ctypes.c_void_p):
+        """Unsubscribe from focus_range"""
+        self._lib.mavsdk_camera_server_unsubscribe_focus_range(self._handle, handle)
+
+    def respond_focus_range(self, focus_range_feedback):
+        """Get respond_focus_range (blocking)"""
+
+        result_code = self._lib.mavsdk_camera_server_respond_focus_range(
+            self._handle,
+            focus_range_feedback,
+        )
+        result = CameraServerResult(result_code)
+        if result != CameraServerResult.SUCCESS:
+            raise Exception(f"respond_focus_range failed: {result}")
+
+        return result
+
     def set_tracking_rectangle_status(self, tracked_rectangle):
         """Get set_tracking_rectangle_status (blocking)"""
 
@@ -1495,6 +1711,12 @@ ZoomInStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 ZoomOutStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 ZoomStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
 ZoomRangeCallback = ctypes.CFUNCTYPE(None, ctypes.c_float, ctypes.c_void_p)
+FocusInStepCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusOutStepCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusInStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusOutStartCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusStopCallback = ctypes.CFUNCTYPE(None, ctypes.c_int32, ctypes.c_void_p)
+FocusRangeCallback = ctypes.CFUNCTYPE(None, ctypes.c_float, ctypes.c_void_p)
 TrackingPointCommandCallback = ctypes.CFUNCTYPE(
     None, TrackPointCStruct, ctypes.c_void_p
 )
@@ -1953,6 +2175,138 @@ _cmavsdk_lib.mavsdk_camera_server_respond_zoom_range.argtypes = [
 ]
 
 _cmavsdk_lib.mavsdk_camera_server_respond_zoom_range.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_in_step.argtypes = [
+    ctypes.c_void_p,
+    FocusInStepCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_in_step.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_in_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_in_step.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_in_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_in_step.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_out_step.argtypes = [
+    ctypes.c_void_p,
+    FocusOutStepCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_out_step.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_out_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_out_step.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_out_step.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_out_step.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_in_start.argtypes = [
+    ctypes.c_void_p,
+    FocusInStartCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_in_start.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_in_start.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_in_start.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_in_start.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_in_start.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_out_start.argtypes = [
+    ctypes.c_void_p,
+    FocusOutStartCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_out_start.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_out_start.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_out_start.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_out_start.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_out_start.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_stop.argtypes = [
+    ctypes.c_void_p,
+    FocusStopCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_stop.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_stop.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_stop.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_stop.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_stop.restype = ctypes.c_int
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_range.argtypes = [
+    ctypes.c_void_p,
+    FocusRangeCallback,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_subscribe_focus_range.restype = ctypes.c_void_p
+# Unsubscribe
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_range.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_unsubscribe_focus_range.restype = None
+
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_range.argtypes = [
+    ctypes.c_void_p,
+    ctypes.c_int,
+]
+
+_cmavsdk_lib.mavsdk_camera_server_respond_focus_range.restype = ctypes.c_int
 
 _cmavsdk_lib.mavsdk_camera_server_set_tracking_rectangle_status.argtypes = [
     ctypes.c_void_p,


### PR DESCRIPTION
Added support for the SET_CAMERA_FOCUS command on camera_server.

- `subscribe_focus_in_step`, `subscribe_focus_out_step`: Step focus subscriptions ([FOCUS_TYPE_STEP](https://mavlink.io/en/messages/common.html#FOCUS_TYPE_STEP))
- `subscribe_focus_in_start`, `subscribe_focus_out_start`, `subscribe_focus_stop`: Continuous normalized focus ([FOCUS_TYPE_CONTINUOUS](https://mavlink.io/en/messages/common.html#FOCUS_TYPE_CONTINUOUS))
- `subscribe_focus_range`: Focus range (between 0.0 and 100.0) ([FOCUS_TYPE_RANGE](https://mavlink.io/en/messages/common.html#FOCUS_TYPE_RANGE))
- `subscribe_focus_meters`: Focus value in meters.
- `subscribe_focus_auto`: Focus automatically.
- `subscribe_focus_auto_single`: Single auto focus.
- `subscribe_focus_auto_continuous`: Continuous auto focus.

~~Currently unsupported (can be added later):
`FOCUS_TYPE_METERS`, `FOCUS_TYPE_AUTO`, `FOCUS_TYPE_AUTO_SINGLE`, `FOCUS_TYPE_AUTO_CONTINUOUS`~~.

Also added associated functions in camera plugin.

MAVLink Command: https://mavlink.io/en/messages/common.html#MAV_CMD_SET_CAMERA_FOCUS

