### PR TITLE
Fix Android build with recent symbol visibility changes

### DIFF
--- a/cpp/src/mavsdk/core/fs_utils.cpp
+++ b/cpp/src/mavsdk/core/fs_utils.cpp
@@ -3,6 +3,7 @@
 #include "log.hpp"
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <fstream>
 #include <random>
 #include <sstream>
@@ -20,13 +21,6 @@
 #endif
 
 namespace mavsdk {
-
-#ifdef ANDROID
-extern "C" {
-// Default Android temp path that can be overridden by JNI if needed
-char* mavsdk_temp_path = const_cast<char*>("/data/local/tmp");
-}
-#endif
 
 #ifdef WINDOWS
 static std::optional<std::filesystem::path> get_known_windows_path(REFKNOWNFOLDERID folderId)
@@ -102,12 +96,14 @@ std::optional<std::filesystem::path> create_tmp_directory(const std::string& pre
 {
     // Inspired by https://stackoverflow.com/a/58454949/8548472
 #ifdef ANDROID
-    // Android points TMPDIR at the app's own cache directory, which is the only
-    // temp location an app process may write to; mavsdk_temp_path is only a
-    // fallback for the unusual case of it being unset.
-    const char* env_tmp_dir = getenv("TMPDIR");
-    const auto tmp_dir =
-        std::filesystem::path(env_tmp_dir != nullptr ? env_tmp_dir : mavsdk_temp_path);
+    // Android points TMPDIR at the app's cache directory, which is the only
+    // temporary location an app process may write to.
+    const char* env_tmp_dir = std::getenv("TMPDIR");
+    if (env_tmp_dir == nullptr || env_tmp_dir[0] == '\0') {
+        LogErr("TMPDIR is not set; cannot create a temporary directory.");
+        return std::nullopt;
+    }
+    const auto tmp_dir = std::filesystem::path(env_tmp_dir);
 #else
     const auto tmp_dir = std::filesystem::temp_directory_path();
 #endif

--- a/cpp/src/mavsdk/core/fs_utils.hpp
+++ b/cpp/src/mavsdk/core/fs_utils.hpp
@@ -21,10 +21,4 @@ create_tmp_directory(const std::string& prefix);
 
 MAVSDK_TEST_EXPORT std::string replace_non_ascii_and_whitespace(const std::string& input);
 
-#ifdef ANDROID
-extern "C" {
-extern char* mavsdk_temp_path;
-}
-#endif
-
 } // namespace mavsdk


### PR DESCRIPTION
The symbol visibility change introduced another bug, see https://github.com/mavlink/MAVSDK-Java/actions/runs/32870520336/job/97876116507.

Better remove that `mavsdk_temp_path` entirely, I think.