### PR TITLE
core: resolve TCP client hostnames asynchronously

### DIFF
--- a/cpp/src/mavsdk/core/tcp_client_connection.cpp
+++ b/cpp/src/mavsdk/core/tcp_client_connection.cpp
@@ -31,6 +31,7 @@ TcpClientConnection::TcpClientConnection(
     _remote_ip(std::move(remote_ip)),
     _remote_port_number(remote_port),
     _socket(mavsdk_impl.io_context()),
+    _resolver(mavsdk_impl.io_context()),
     _reconnect_timer(mavsdk_impl.io_context())
 {}
 
@@ -72,16 +73,18 @@ ConnectionResult TcpClientConnection::stop()
     _stopping = true;
     _connected = false;
 
-    _reconnect_timer.cancel();
-
     auto& io_ctx = static_cast<asio::io_context&>(_socket.get_executor().context());
     if (!io_ctx.stopped()) {
-        // Close the socket from the io_context thread to avoid a data race with
-        // a concurrent async_read_some() / async_connect() / async_write() reading
-        // socket state. Because io_ctx is driven by a single thread, posting here
-        // serialises the close with all in-flight socket access.
+        // Cancel and close from the io_context thread to avoid a data race with
+        // a concurrent async_read_some() / async_connect() / async_write() /
+        // async_resolve() touching the same object. Because io_ctx is driven by a
+        // single thread, posting here serialises all of it with the in-flight work.
+        // (The timer cancel used to happen on the caller's thread, which was the same
+        // kind of cross-thread access this avoids.)
         std::promise<void> close_done;
         asio::post(io_ctx, [this, &close_done]() {
+            _reconnect_timer.cancel();
+            _resolver.cancel();
             _tx_queue.clear();
             if (_socket.is_open()) {
                 asio::error_code ec;
@@ -98,6 +101,8 @@ ConnectionResult TcpClientConnection::stop()
         fence.get_future().wait();
     } else {
         // io_context already stopped — no concurrent async operations are running.
+        _reconnect_timer.cancel();
+        _resolver.cancel();
         _tx_queue.clear();
         if (_socket.is_open()) {
             asio::error_code ec;
@@ -187,48 +192,65 @@ void TcpClientConnection::start_write()
 
 void TcpClientConnection::do_connect()
 {
-    // Resolve the remote hostname/IP synchronously. This is called rarely (once at startup,
-    // then on each reconnect) so blocking briefly here is acceptable.
-    asio::error_code ec;
-    asio::ip::tcp::resolver resolver(_socket.get_executor());
-    auto endpoints = resolver.resolve(_remote_ip, std::to_string(_remote_port_number), ec);
-
-    if (ec) {
-        LogErr(
-            "Resolve error for {}:{}: {}, trying to reconnect...",
-            _remote_ip,
-            _remote_port_number,
-            ec.message());
-        start_reconnect();
-        return;
-    }
-
-    // Ensure the socket is in a clean state before connecting.
-    if (_socket.is_open()) {
-        asio::error_code close_ec;
-        _socket.close(close_ec);
-    }
-
-    asio::async_connect(
-        _socket,
-        endpoints,
-        [this](const asio::error_code& connect_ec, const asio::ip::tcp::endpoint&) {
-            if (connect_ec == asio::error::operation_aborted || _stopping) {
-                // stop() was called — do not reconnect.
+    // Resolve asynchronously. A synchronous resolve() would run getaddrinfo() on the io
+    // thread, and this is not a one-off: the reconnect path calls it again every second
+    // for as long as the peer is unreachable. A DNS server that is itself unreachable
+    // then freezes the whole SDK -- message dispatch, timers, every other connection --
+    // for the resolver timeout, over and over. Asio runs the lookup on its own internal
+    // thread and delivers the result back here on the io thread.
+    _resolver.async_resolve(
+        _remote_ip,
+        std::to_string(_remote_port_number),
+        [this](const asio::error_code& ec, const asio::ip::tcp::resolver::results_type& endpoints) {
+            // The operation_aborted check must stay FIRST, and the || must short-circuit
+            // before `_stopping` dereferences `this`. resolver::cancel() cannot interrupt
+            // a getaddrinfo() already running on Asio's internal resolver thread: it only
+            // expires the cancellation token, so this handler is still invoked afterwards
+            // -- possibly after stop() has returned and the connection has been
+            // destroyed. Reading `ec` is safe then; touching a member would not be.
+            if (ec == asio::error::operation_aborted || _stopping) {
+                // stop() cancelled the resolve — do not reconnect.
                 return;
             }
-            if (connect_ec) {
-                LogErr("Connect error: {}", connect_ec.message());
-                if (!_stopping) {
-                    start_reconnect();
-                }
+
+            if (ec) {
+                LogErr(
+                    "Resolve error for {}:{}: {}, trying to reconnect...",
+                    _remote_ip,
+                    _remote_port_number,
+                    ec.message());
+                start_reconnect();
                 return;
             }
-            _connected = true;
-            do_receive();
-            // Anything queued while we were disconnected is stale by now, but a send
-            // that raced the connect completing is not, so drain whatever is waiting.
-            start_write();
+
+            // Ensure the socket is in a clean state before connecting.
+            if (_socket.is_open()) {
+                asio::error_code close_ec;
+                _socket.close(close_ec);
+            }
+
+            asio::async_connect(
+                _socket,
+                endpoints,
+                [this](const asio::error_code& connect_ec, const asio::ip::tcp::endpoint&) {
+                    if (connect_ec == asio::error::operation_aborted || _stopping) {
+                        // stop() was called — do not reconnect.
+                        return;
+                    }
+                    if (connect_ec) {
+                        LogErr("Connect error: {}", connect_ec.message());
+                        if (!_stopping) {
+                            start_reconnect();
+                        }
+                        return;
+                    }
+                    _connected = true;
+                    do_receive();
+                    // Anything queued while we were disconnected is stale by now, but a
+                    // send that raced the connect completing is not, so drain whatever
+                    // is waiting.
+                    start_write();
+                });
         });
 }
 

--- a/cpp/src/mavsdk/core/tcp_client_connection.hpp
+++ b/cpp/src/mavsdk/core/tcp_client_connection.hpp
@@ -53,6 +53,7 @@ private:
     // Asio objects and the send queue — all only touched on MavsdkImpl::_io_context's
     // thread, which is why none of them need a lock.
     asio::ip::tcp::socket _socket;
+    asio::ip::tcp::resolver _resolver;
     asio::steady_timer _reconnect_timer;
     std::array<char, 2048> _recv_buffer{};
     TxQueue<std::vector<char>> _tx_queue{MAX_TX_QUEUE_ITEMS};

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(system_tests_runner
     connections.cpp
     raw_bytes.cpp
     stalled_link.cpp
+    tcp_unresolvable_host.cpp
     system_tests_runner.cpp
 )
 

--- a/cpp/src/system_tests/tcp_unresolvable_host.cpp
+++ b/cpp/src/system_tests/tcp_unresolvable_host.cpp
@@ -1,0 +1,73 @@
+#include "log.hpp"
+#include "mavsdk.hpp"
+#include "plugins/mavlink_direct/mavlink_direct.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+using namespace std::chrono_literals;
+
+// A TCP client pointed at a name that cannot be resolved must keep retrying quietly and
+// must not disturb anything else in the SDK.
+//
+// This covers the async_resolve path end to end: the failing branch has to reschedule the
+// reconnect, and stop() has to cancel an in-flight resolve without leaving a handler
+// behind (the teardown at the end of this test would trip over that).
+//
+// Note on what this does *not* prove: the reason for moving off the synchronous resolve()
+// is a DNS server that hangs rather than one that answers NXDOMAIN, which is what a
+// .invalid name gives us. Making a lookup actually hang needs an unreachable resolver,
+// which is not something a test can arrange portably, so the "does not block the io
+// thread" property is argued in the commit message rather than asserted here.
+TEST(Connections, UnresolvableTcpHostDoesNotDisturbOtherConnections)
+{
+    const int udp_port = 17422;
+
+    Mavsdk autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    // .invalid is reserved by RFC 2606 and is guaranteed never to resolve.
+    ASSERT_EQ(
+        autopilot.add_any_connection("tcpout://this-host-does-not-exist.invalid:17423"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        autopilot.add_any_connection("udpout://127.0.0.1:" + std::to_string(udp_port)),
+        ConnectionResult::Success);
+
+    Mavsdk ground_station{Mavsdk::Configuration{ComponentType::GroundStation}};
+    ASSERT_EQ(
+        ground_station.add_any_connection("udpin://0.0.0.0:" + std::to_string(udp_port)),
+        ConnectionResult::Success);
+
+    auto maybe_system = ground_station.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system) << "Ground station did not discover the autopilot over UDP "
+                                 "while a TCP connection was stuck retrying a bad name";
+
+    std::atomic<int> heartbeats{0};
+    MavlinkDirect gcs_mavlink{maybe_system.value()};
+    auto handle = gcs_mavlink.subscribe_message(
+        "HEARTBEAT", [&heartbeats](MavlinkDirect::MavlinkMessage) { ++heartbeats; });
+
+    // Several reconnect attempts happen in this window (the retry timer is 1 s), so the
+    // resolve failure path is exercised repeatedly rather than just once.
+    const int heartbeats_before = heartbeats;
+    std::this_thread::sleep_for(3s);
+    const int heartbeats_after = heartbeats;
+
+    gcs_mavlink.unsubscribe_message(handle);
+
+    LogInfo(
+        "Heartbeats received while the TCP name kept failing to resolve: {}",
+        heartbeats_after - heartbeats_before);
+
+    EXPECT_GT(heartbeats_after, heartbeats_before)
+        << "The UDP link went quiet while a TCP connection was retrying an unresolvable "
+           "host";
+
+    // Tearing down here is the other half of the test: stop() has to cancel a resolve
+    // that may be in flight right now, and a leaked handler would show up as a hang or a
+    // use-after-free under the sanitizers.
+}


### PR DESCRIPTION
> Stacked on #3047 — please review that one first. Base is `async-writes`, so the diff here is just this change.

Finding 3.2 from the threading review.

## The problem

`TcpClientConnection::do_connect()` called `resolver.resolve()`, which runs `getaddrinfo()` **on the io thread**.

That would be tolerable as a one-off at startup, which is what the comment there claimed:

```cpp
// Resolve the remote hostname/IP synchronously. This is called rarely (once at startup,
// then on each reconnect) so blocking briefly here is acceptable.
```

But the reconnect path calls it again **every second** for as long as the peer is unreachable. A DNS server that is itself unreachable then freezes the whole SDK — message dispatch, every internal timer, every other connection — for the resolver timeout, and again a second later, indefinitely.

## The change

`async_resolve()`, which hands the lookup to Asio's internal resolver thread and delivers the result back on the io thread.

Two details worth a reviewer's attention:

**`resolver::cancel()` does not interrupt an in-flight lookup.** It only expires the cancellation token, so a `getaddrinfo()` already running on Asio's resolver thread runs to completion and the handler is *still* invoked afterwards — possibly after `stop()` has returned and the connection has been destroyed. That is safe here only because the handler checks `ec == asio::error::operation_aborted` first and `||` short-circuits before `_stopping` dereferences `this`. Reading `ec` on a dead object is fine; touching a member would not be. Since that ordering is load-bearing and easy to "tidy up" into a bug, it is spelled out in a comment at the check.

**`_reconnect_timer.cancel()` moved into the posted lambda in `stop()`.** It was being called on the caller's thread — the same kind of cross-thread access to an Asio object that the rest of `stop()` exists to avoid. `_resolver.cancel()` joins it there.

## Testing

`Connections.UnresolvableTcpHostDoesNotDisturbOtherConnections` points a TCP client at a `.invalid` name (RFC 2606, guaranteed never to resolve) alongside a working UDP link, and checks the UDP link keeps delivering heartbeats. The retry timer fires several times in the test window, so the resolve-failure path is exercised repeatedly rather than once, and teardown at the end exercises cancelling a resolve that may be in flight.

**What this does not prove**, stated plainly because it matters: the case that motivates the change is a DNS server that *hangs*, whereas `.invalid` answers NXDOMAIN quickly. Making a lookup actually hang needs an unreachable resolver, which a test cannot arrange portably. So this test guards the new code path and the cancel, not the non-blocking property itself. The test says so in a comment.

- system tests: **102/102**
- unit tests: **418/418**
- clang-format clean

## Next in the stack

3.3 (`TimeoutHandler` / `CallEveryHandler` can fire a callback after `remove()` returned — the one memory-safety bug in the review), then 3.4 (uniform unregister-on-destroy), then 3.6 + 3.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMVJeAkDnTNSvfb3uogDDW
