### PR TITLE
core: make timer removal actually stop the callback

### DIFF
--- a/cpp/src/mavsdk/core/call_every_handler.cpp
+++ b/cpp/src/mavsdk/core/call_every_handler.cpp
@@ -2,7 +2,6 @@
 
 #include <utility>
 #include <algorithm>
-#include <vector>
 
 namespace mavsdk {
 
@@ -18,7 +17,7 @@ CallEveryHandler::Cookie CallEveryHandler::add(std::function<void()> callback, d
     _time.shift_steady_time_by(before, -interval_s - 0.001);
     new_entry.last_time = before;
     new_entry.interval_s = interval_s;
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     new_entry.cookie = _next_cookie++;
     _entries.push_back(new_entry);
 
@@ -27,7 +26,7 @@ CallEveryHandler::Cookie CallEveryHandler::add(std::function<void()> callback, d
 
 void CallEveryHandler::change(double interval_s, Cookie cookie)
 {
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
         return entry.cookie == cookie;
     });
@@ -38,7 +37,7 @@ void CallEveryHandler::change(double interval_s, Cookie cookie)
 
 void CallEveryHandler::reset(Cookie cookie)
 {
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
         return entry.cookie == cookie;
     });
@@ -49,40 +48,86 @@ void CallEveryHandler::reset(Cookie cookie)
 
 void CallEveryHandler::remove(Cookie cookie)
 {
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
-    auto it = std::find_if(
-        _entries.begin(), _entries.end(), [&](auto& timeout) { return timeout.cookie == cookie; });
+    remove_impl(cookie, false);
+}
 
-    if (it != _entries.end()) {
-        _entries.erase(it);
+void CallEveryHandler::remove_blocking(Cookie cookie)
+{
+    remove_impl(cookie, true);
+}
+
+void CallEveryHandler::remove_impl(Cookie cookie, bool blocking)
+{
+    // Cookie 0 is never handed out by add(), so it means "nothing registered" --
+    // callers keep a default-initialised cookie around for a timer they may never
+    // have started. Bail out before the wait below, which uses 0 for "not executing"
+    // and would otherwise never be satisfied.
+    if (cookie == 0) {
+        return;
     }
+
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    _entries.remove_if([&](const Entry& entry) { return entry.cookie == cookie; });
+    // Also drop it if run_once() has already found it due but has not gotten around to
+    // invoking it yet -- otherwise removing an entry would not actually stop it from firing.
+    _due.remove(cookie);
+
+    if (!blocking) {
+        return;
+    }
+
+    // The callback is running right now: wait for it to return so that the caller can
+    // destroy whatever it captured. Unless we are being called from that very callback, in
+    // which case waiting would deadlock on ourselves.
+    _callback_done.wait(lock, [&]() {
+        return _executing_cookie != cookie || _executing_thread == std::this_thread::get_id();
+    });
 }
 
 void CallEveryHandler::run_once()
 {
-    // First, identify all entries that need to be executed and update timestamps
-    // while holding the lock
-    std::vector<std::function<void()>> callbacks_to_execute;
+    std::unique_lock<std::mutex> lock(_mutex);
 
-    {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+    for (auto& entry : _entries) {
+        if (_time.elapsed_since_s(entry.last_time) > double(entry.interval_s)) {
+            // Update the timestamp before potentially executing
+            _time.shift_steady_time_by(entry.last_time, double(entry.interval_s));
 
-        for (auto& entry : _entries) {
-            if (_time.elapsed_since_s(entry.last_time) > double(entry.interval_s)) {
-                // Update the timestamp before potentially executing
-                _time.shift_steady_time_by(entry.last_time, double(entry.interval_s));
-
-                // Store the callback for later execution
-                if (entry.callback) {
-                    callbacks_to_execute.push_back(entry.callback);
-                }
+            if (entry.callback) {
+                _due.push_back(entry.cookie);
             }
         }
     }
 
-    // Now execute all callbacks outside the lock to prevent lock-order inversions
-    for (const auto& callback : callbacks_to_execute) {
+    // Note that the entries are looked up again by cookie right before they are invoked, so
+    // that a callback removing another due entry actually prevents it from running.
+    while (!_due.empty()) {
+        const auto cookie = _due.front();
+        _due.pop_front();
+
+        auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
+            return entry.cookie == cookie;
+        });
+        if (it == _entries.end() || !it->callback) {
+            continue;
+        }
+
+        auto callback = it->callback;
+
+        _executing_cookie = cookie;
+        _executing_thread = std::this_thread::get_id();
+
+        lock.unlock();
         callback();
+        // Drop whatever the callback captured while we are not holding the lock, in case
+        // its destructor calls back into us.
+        callback = nullptr;
+        lock.lock();
+
+        _executing_cookie = 0;
+        _executing_thread = {};
+        _callback_done.notify_all();
     }
 }
 

--- a/cpp/src/mavsdk/core/call_every_handler.hpp
+++ b/cpp/src/mavsdk/core/call_every_handler.hpp
@@ -1,15 +1,25 @@
 #pragma once
 
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
-#include <memory>
 #include <functional>
 #include <list>
+#include <thread>
 #include "mavsdk_time.hpp"
 #include "mavsdk_export.h"
 
 namespace mavsdk {
 
+// Recurring callbacks, driven by run_once() from the io_context thread.
+//
+// Threading: add/change/reset/remove are callable from any thread. Callbacks are invoked by
+// run_once() outside the lock, so a callback may call back into the handler.
+//
+// Cancellation: remove() cancels an entry even if run_once() has already found it due but
+// has not invoked it yet. It does not wait for a callback that is running right now -- use
+// remove_blocking() for that, which is what an owner about to be destroyed needs. See the
+// comments on those two functions.
 class MAVSDK_TEST_EXPORT CallEveryHandler {
 public:
     explicit CallEveryHandler(Time& time);
@@ -26,11 +36,26 @@ public:
     Cookie add(std::function<void()> callback, double interval_s);
     void change(double interval_s, Cookie cookie);
     void reset(Cookie cookie);
+
+    // Stop a recurring callback. After this returns it will not be started anymore, but if
+    // it is running right now it keeps running. Safe to call from within a callback and
+    // safe to call while holding a lock that the callback also takes.
     void remove(Cookie cookie);
+
+    // Stop a recurring callback and wait for it if it happens to be running right now. Once
+    // this returns, the callback is neither running nor going to run, so an owner that
+    // captured 'this' can be destroyed safely.
+    //
+    // Must not be called while holding a lock that the callback itself takes -- that would
+    // deadlock. Calling it from within the very callback being removed is fine (it does not
+    // wait on itself), as is calling it for a different cookie from within a callback.
+    void remove_blocking(Cookie cookie);
 
     void run_once();
 
 private:
+    void remove_impl(Cookie cookie, bool blocking);
+
     struct Entry {
         std::function<void()> callback{nullptr};
         SteadyTimePoint last_time{};
@@ -38,8 +63,20 @@ private:
         Cookie cookie{};
     };
 
-    std::recursive_mutex _mutex{};
+    std::mutex _mutex{};
     std::list<Entry> _entries{};
+    // Cookies that run_once() has found due but has not invoked yet, in order. Kept so that
+    // remove() can still cancel them before they fire.
+    std::list<Cookie> _due{};
+
+    // Signalled whenever a callback returns, so remove_blocking() can wait for one.
+    std::condition_variable _callback_done{};
+
+    // The entry whose callback run_once() is invoking right now (0 if none), and the thread
+    // invoking it so that removing an entry from its own callback does not wait on itself.
+    // Guarded by _mutex.
+    Cookie _executing_cookie{0};
+    std::thread::id _executing_thread{};
 
     Time& _time;
 

--- a/cpp/src/mavsdk/core/call_every_handler_test.cpp
+++ b/cpp/src/mavsdk/core/call_every_handler_test.cpp
@@ -1,5 +1,9 @@
 #include "call_every_handler.hpp"
 #include "unused.hpp"
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
 #include <gtest/gtest.h>
 
 #ifdef FAKE_TIME
@@ -187,4 +191,101 @@ TEST(CallEveryHandler, AllHandlersRemovedDuringCallback)
 
     time.sleep_for(std::chrono::milliseconds(200));
     ceh.run_once();
+}
+
+TEST(CallEveryHandler, RemovingDueHandlerDuringCallbackPreventsIt)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    bool second_called = false;
+    CallEveryHandler::Cookie cookie2{};
+
+    // Both entries are due in the same run_once(). The first one removes the second,
+    // which has to actually stop it from being called.
+    CallEveryHandler::Cookie cookie1 = ceh.add([&ceh, &cookie2]() { ceh.remove(cookie2); }, 0.1);
+    cookie2 = ceh.add([&second_called]() { second_called = true; }, 0.1);
+
+    time.sleep_for(std::chrono::milliseconds(200));
+    ceh.run_once();
+
+    EXPECT_FALSE(second_called);
+
+    UNUSED(cookie1);
+}
+
+TEST(CallEveryHandler, RemoveBlockingWaitsForRunningCallback)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    std::promise<void> callback_entered;
+    std::atomic<bool> release{false};
+    std::atomic<bool> callback_returned{false};
+
+    auto cookie = ceh.add(
+        [&]() {
+            callback_entered.set_value();
+            while (!release) {
+                std::this_thread::yield();
+            }
+            callback_returned = true;
+        },
+        0.1);
+
+    time.sleep_for(std::chrono::milliseconds(200));
+
+    std::thread runner([&ceh]() { ceh.run_once(); });
+
+    // Only call remove_blocking() once we know the callback is actually running.
+    callback_entered.get_future().wait();
+
+    std::thread releaser([&release]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        release = true;
+    });
+
+    ceh.remove_blocking(cookie);
+
+    // The whole point: remove_blocking() does not return while the callback is running.
+    EXPECT_TRUE(callback_returned);
+
+    releaser.join();
+    runner.join();
+}
+
+TEST(CallEveryHandler, RemoveBlockingFromOwnCallbackDoesNotDeadlock)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    int num_called = 0;
+    CallEveryHandler::Cookie cookie{};
+
+    cookie = ceh.add(
+        [&ceh, &cookie, &num_called]() {
+            ++num_called;
+            // Waiting for ourselves here would hang forever.
+            ceh.remove_blocking(cookie);
+        },
+        0.1);
+
+    time.sleep_for(std::chrono::milliseconds(200));
+    ceh.run_once();
+    time.sleep_for(std::chrono::milliseconds(200));
+    ceh.run_once();
+
+    EXPECT_EQ(num_called, 1);
+}
+
+TEST(CallEveryHandler, RemoveBlockingUnsetCookieReturns)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    // A default-initialised cookie means "never registered". Nothing is executing, so this
+    // has to return rather than wait for a callback that does not exist.
+    CallEveryHandler::Cookie never_registered{};
+    ceh.remove_blocking(never_registered);
+    ceh.remove_blocking(static_cast<CallEveryHandler::Cookie>(999999));
 }

--- a/cpp/src/mavsdk/core/mavlink_command_receiver.cpp
+++ b/cpp/src/mavsdk/core/mavlink_command_receiver.cpp
@@ -32,7 +32,8 @@ MavlinkCommandReceiver::MavlinkCommandReceiver(ServerComponentImpl& server_compo
 MavlinkCommandReceiver::~MavlinkCommandReceiver()
 {
     _server_component_impl.unregister_all_mavlink_command_handlers(this);
-    _server_component_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    _server_component_impl.unregister_all_mavlink_message_handlers_blocking(this);
 }
 
 void MavlinkCommandReceiver::receive_command_int(const mavlink_message_t& message)

--- a/cpp/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/cpp/src/mavsdk/core/mavlink_command_sender.cpp
@@ -30,10 +30,11 @@ MavlinkCommandSender::~MavlinkCommandSender()
     if (_command_debugging) {
         LogDebug("CommandSender destroyed");
     }
-    _system_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking, so that nothing can be dispatched into us while we are being destroyed.
+    _system_impl.unregister_all_mavlink_message_handlers_blocking(this);
 
     for (const auto& work : _work_queue) {
-        _system_impl.unregister_timeout_handler(work->timeout_cookie);
+        _system_impl.unregister_timeout_handler_blocking(work->timeout_cookie);
     }
 }
 

--- a/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_client.cpp
@@ -35,8 +35,10 @@ MavlinkFtpClient::MavlinkFtpClient(SystemImpl& system_impl) :
 
 MavlinkFtpClient::~MavlinkFtpClient()
 {
-    stop_timer();
-    _system_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking variants, so that neither a timeout nor a message can be dispatched into us
+    // while we are being destroyed.
+    _system_impl.unregister_timeout_handler_blocking(_timeout_cookie);
+    _system_impl.unregister_all_mavlink_message_handlers_blocking(this);
 }
 
 void MavlinkFtpClient::do_work()

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -207,7 +207,8 @@ void MavlinkFtpServer::process_mavlink_ftp_message(const mavlink_message_t& msg)
 
 MavlinkFtpServer::~MavlinkFtpServer()
 {
-    _server_component_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    _server_component_impl.unregister_all_mavlink_message_handlers_blocking(this);
 
     std::lock_guard<std::mutex> lock(_mutex);
     _reset();

--- a/cpp/src/mavsdk/core/mavlink_request_message.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace mavsdk {
 
@@ -35,9 +36,19 @@ MavlinkRequestMessage::~MavlinkRequestMessage()
     // In-flight requests schedule timeouts that also capture 'this'. Cancel any that
     // are still pending, otherwise TimeoutHandler could fire handle_timeout on us
     // after destruction (use-after-free).
-    std::lock_guard<std::mutex> lock(_mutex);
-    for (const auto& item : _work_items) {
-        _timeout_handler.remove(item.timeout_cookie);
+    std::vector<TimeoutHandler::Cookie> cookies;
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        cookies.reserve(_work_items.size());
+        for (const auto& item : _work_items) {
+            cookies.push_back(item.timeout_cookie);
+        }
+    }
+
+    // Outside _mutex: the blocking removal waits for a handle_timeout() that is running
+    // right now, and that takes _mutex itself.
+    for (const auto cookie : cookies) {
+        _timeout_handler.remove_blocking(cookie);
     }
 }
 

--- a/cpp/src/mavsdk/core/mavlink_request_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_request_message_handler.cpp
@@ -25,7 +25,8 @@ MavlinkRequestMessageHandler::MavlinkRequestMessageHandler(
 
 MavlinkRequestMessageHandler::~MavlinkRequestMessageHandler()
 {
-    _mavsdk_impl.mavlink_message_handler.unregister_all(this);
+    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    _mavsdk_impl.mavlink_message_handler.unregister_all_blocking(this);
 }
 
 bool MavlinkRequestMessageHandler::register_handler(

--- a/cpp/src/mavsdk/core/ping.cpp
+++ b/cpp/src/mavsdk/core/ping.cpp
@@ -15,7 +15,8 @@ Ping::Ping(SystemImpl& system_impl) : _system_impl(system_impl)
 
 Ping::~Ping()
 {
-    _system_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    _system_impl.unregister_all_mavlink_message_handlers_blocking(this);
 }
 
 void Ping::run_once()

--- a/cpp/src/mavsdk/core/server_component_impl.cpp
+++ b/cpp/src/mavsdk/core/server_component_impl.cpp
@@ -251,6 +251,11 @@ void ServerComponentImpl::remove_call_every(CallEveryHandler::Cookie cookie)
     _mavsdk_impl.call_every_handler.remove(cookie);
 }
 
+void ServerComponentImpl::remove_call_every_blocking(CallEveryHandler::Cookie cookie)
+{
+    _mavsdk_impl.call_every_handler.remove_blocking(cookie);
+}
+
 mavlink_command_ack_t ServerComponentImpl::make_command_ack_message(
     const MavlinkCommandReceiver::CommandLong& command, MAV_RESULT result)
 {
@@ -349,6 +354,11 @@ void ServerComponentImpl::refresh_timeout_handler(TimeoutHandler::Cookie cookie)
 void ServerComponentImpl::unregister_timeout_handler(TimeoutHandler::Cookie cookie)
 {
     _mavsdk_impl.timeout_handler.remove(cookie);
+}
+
+void ServerComponentImpl::unregister_timeout_handler_blocking(TimeoutHandler::Cookie cookie)
+{
+    _mavsdk_impl.timeout_handler.remove_blocking(cookie);
 }
 
 void ServerComponentImpl::add_capabilities(uint64_t add_capabilities)

--- a/cpp/src/mavsdk/core/server_component_impl.hpp
+++ b/cpp/src/mavsdk/core/server_component_impl.hpp
@@ -118,6 +118,10 @@ public:
     register_timeout_handler(const std::function<void()>& callback, double duration_s);
     void refresh_timeout_handler(TimeoutHandler::Cookie cookie);
     void unregister_timeout_handler(TimeoutHandler::Cookie cookie);
+    // Blocking variant for owners about to be destroyed: once it returns, the timeout
+    // callback is neither running nor going to run. Must not be called while holding a lock
+    // that the callback itself takes.
+    void unregister_timeout_handler_blocking(TimeoutHandler::Cookie cookie);
 
     [[nodiscard]] uint8_t get_own_system_id() const;
 
@@ -143,6 +147,10 @@ public:
     void change_call_every(float interval_s, CallEveryHandler::Cookie cookie);
     void reset_call_every(CallEveryHandler::Cookie cookie);
     void remove_call_every(CallEveryHandler::Cookie cookie);
+    // Blocking variant for owners about to be destroyed: once it returns, the callback is
+    // neither running nor going to run. Must not be called while holding a lock that the
+    // callback itself takes.
+    void remove_call_every_blocking(CallEveryHandler::Cookie cookie);
 
     mavlink_command_ack_t
     make_command_ack_message(const MavlinkCommandReceiver::CommandLong& command, MAV_RESULT result);

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -61,7 +61,8 @@ SystemImpl::~SystemImpl()
     // Clear all libmav message callbacks
     _libmav_message_callbacks.clear();
 
-    unregister_timeout_handler(_heartbeat_timeout_cookie);
+    // Blocking, so a heartbeat timeout that is running right now cannot outlive us.
+    unregister_timeout_handler_blocking(_heartbeat_timeout_cookie);
 }
 
 void SystemImpl::init(uint8_t system_id, uint8_t comp_id)
@@ -254,6 +255,11 @@ void SystemImpl::unregister_timeout_handler(TimeoutHandler::Cookie cookie)
     _mavsdk_impl.timeout_handler.remove(cookie);
 }
 
+void SystemImpl::unregister_timeout_handler_blocking(TimeoutHandler::Cookie cookie)
+{
+    _mavsdk_impl.timeout_handler.remove_blocking(cookie);
+}
+
 double SystemImpl::timeout_s() const
 {
     return _mavsdk_impl.timeout_s();
@@ -300,6 +306,11 @@ void SystemImpl::reset_call_every(CallEveryHandler::Cookie cookie)
 void SystemImpl::remove_call_every(CallEveryHandler::Cookie cookie)
 {
     _mavsdk_impl.call_every_handler.remove(cookie);
+}
+
+void SystemImpl::remove_call_every_blocking(CallEveryHandler::Cookie cookie)
+{
+    _mavsdk_impl.call_every_handler.remove_blocking(cookie);
 }
 
 void SystemImpl::register_statustext_handler(

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -100,11 +100,19 @@ public:
     register_timeout_handler(const std::function<void()>& callback, double duration_s);
     void refresh_timeout_handler(TimeoutHandler::Cookie cookie);
     void unregister_timeout_handler(TimeoutHandler::Cookie cookie);
+    // Blocking variant for owners about to be destroyed: once it returns, the timeout
+    // callback is neither running nor going to run. Must not be called while holding a lock
+    // that the callback itself takes.
+    void unregister_timeout_handler_blocking(TimeoutHandler::Cookie cookie);
 
     CallEveryHandler::Cookie add_call_every(std::function<void()> callback, float interval_s);
     void change_call_every(float interval_s, CallEveryHandler::Cookie cookie);
     void reset_call_every(CallEveryHandler::Cookie cookie);
     void remove_call_every(CallEveryHandler::Cookie cookie);
+    // Blocking variant for owners about to be destroyed: once it returns, the callback is
+    // neither running nor going to run. Must not be called while holding a lock that the
+    // callback itself takes.
+    void remove_call_every_blocking(CallEveryHandler::Cookie cookie);
 
     void register_statustext_handler(
         std::function<void(const MavlinkStatustextHandler::Statustext&)>, void* cookie);

--- a/cpp/src/mavsdk/core/timeout_handler.cpp
+++ b/cpp/src/mavsdk/core/timeout_handler.cpp
@@ -1,6 +1,5 @@
 #include "timeout_handler.hpp"
 #include <algorithm>
-#include <vector>
 
 namespace mavsdk {
 
@@ -8,7 +7,7 @@ TimeoutHandler::TimeoutHandler(Time& time) : _time(time) {}
 
 TimeoutHandler::Cookie TimeoutHandler::add(std::function<void()> callback, double duration_s)
 {
-    std::lock_guard<std::recursive_mutex> lock(_timeouts_mutex);
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
     auto new_timeout = Timeout{};
     new_timeout.callback = std::move(callback);
     new_timeout.time = _time.steady_time_in_future(duration_s);
@@ -21,7 +20,7 @@ TimeoutHandler::Cookie TimeoutHandler::add(std::function<void()> callback, doubl
 
 void TimeoutHandler::refresh(Cookie cookie)
 {
-    std::lock_guard<std::recursive_mutex> lock(_timeouts_mutex);
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
 
     auto it = std::find_if(_timeouts.begin(), _timeouts.end(), [&](const Timeout& timeout) {
         return timeout.cookie == cookie;
@@ -34,54 +33,85 @@ void TimeoutHandler::refresh(Cookie cookie)
 
 void TimeoutHandler::remove(Cookie cookie)
 {
-    std::lock_guard<std::recursive_mutex> lock(_timeouts_mutex);
+    remove_impl(cookie, false);
+}
 
-    auto it = std::find_if(_timeouts.begin(), _timeouts.end(), [&](auto& timeout) {
-        return timeout.cookie == cookie;
-    });
+void TimeoutHandler::remove_blocking(Cookie cookie)
+{
+    remove_impl(cookie, true);
+}
 
-    if (it != _timeouts.end()) {
-        _timeouts.erase(it);
+void TimeoutHandler::remove_impl(Cookie cookie, bool blocking)
+{
+    // Cookie 0 is never handed out by add(), so it means "nothing registered" --
+    // callers keep a default-initialised cookie around for a timer they may never
+    // have started. Bail out before the wait below, which uses 0 for "not executing"
+    // and would otherwise never be satisfied.
+    if (cookie == 0) {
+        return;
     }
+
+    std::unique_lock<std::mutex> lock(_timeouts_mutex);
+
+    const auto matches = [&](const Timeout& timeout) { return timeout.cookie == cookie; };
+
+    _timeouts.remove_if(matches);
+    // Also drop it if run_once() has already taken it out of _timeouts as due but has not
+    // gotten around to invoking it yet -- otherwise removing a timeout would not actually
+    // stop it from firing.
+    _due.remove_if(matches);
+
+    if (!blocking) {
+        return;
+    }
+
+    // The callback is running right now: wait for it to return so that the caller can
+    // destroy whatever it captured. Unless we are being called from that very callback, in
+    // which case waiting would deadlock on ourselves.
+    _callback_done.wait(lock, [&]() {
+        return _executing_cookie != cookie || _executing_thread == std::this_thread::get_id();
+    });
 }
 
 void TimeoutHandler::run_once()
 {
-    // First, identify all timeouts that need to be executed and remove them
-    // while holding the lock
-    std::vector<std::function<void()>> callbacks_to_execute;
+    std::unique_lock<std::mutex> lock(_timeouts_mutex);
 
-    {
-        std::lock_guard<std::recursive_mutex> lock(_timeouts_mutex);
-        auto now = _time.steady_time();
+    const auto now = _time.steady_time();
 
-        // Identify timeouts that need to be executed
-        std::vector<Cookie> cookies_to_remove;
-
-        for (const auto& timeout : _timeouts) {
-            if (timeout.time < now) {
-                if (timeout.callback) {
-                    callbacks_to_execute.push_back(timeout.callback);
-                }
-                cookies_to_remove.push_back(timeout.cookie);
-            }
-        }
-
-        // Remove all timeouts that need to be executed
-        for (const auto& cookie : cookies_to_remove) {
-            auto it = std::find_if(_timeouts.begin(), _timeouts.end(), [&](auto& timeout) {
-                return timeout.cookie == cookie;
-            });
-
-            if (it != _timeouts.end()) {
-                _timeouts.erase(it);
-            }
+    // Move the due timeouts over to _due in one go. They are one-shot, so they leave
+    // _timeouts here either way, and parking them in _due (instead of a local vector)
+    // keeps them cancellable by remove() until the moment they are invoked.
+    for (auto it = _timeouts.begin(); it != _timeouts.end();) {
+        if (it->time < now) {
+            auto due_it = it++;
+            _due.splice(_due.end(), _timeouts, due_it);
+        } else {
+            ++it;
         }
     }
 
-    // Now execute all callbacks outside the lock to prevent lock-order inversions
-    for (const auto& callback : callbacks_to_execute) {
-        callback();
+    while (!_due.empty()) {
+        auto timeout = std::move(_due.front());
+        _due.pop_front();
+
+        if (!timeout.callback) {
+            continue;
+        }
+
+        _executing_cookie = timeout.cookie;
+        _executing_thread = std::this_thread::get_id();
+
+        lock.unlock();
+        timeout.callback();
+        // Drop whatever the callback captured while we are not holding the lock, in case
+        // its destructor calls back into us.
+        timeout.callback = nullptr;
+        lock.lock();
+
+        _executing_cookie = 0;
+        _executing_thread = {};
+        _callback_done.notify_all();
     }
 }
 

--- a/cpp/src/mavsdk/core/timeout_handler.hpp
+++ b/cpp/src/mavsdk/core/timeout_handler.hpp
@@ -3,14 +3,24 @@
 #include "mavsdk_time.hpp"
 #include "mavsdk_export.h"
 
+#include <condition_variable>
 #include <cstdint>
 #include <mutex>
-#include <memory>
 #include <functional>
 #include <list>
+#include <thread>
 
 namespace mavsdk {
 
+// One-shot timeouts, driven by run_once() from the io_context thread.
+//
+// Threading: add/refresh/remove are callable from any thread. Callbacks are invoked by
+// run_once() outside the lock, so a callback may call back into the handler.
+//
+// Cancellation: remove() cancels a timeout even if run_once() has already picked it up as
+// due but has not invoked it yet. It does not wait for a callback that is running right
+// now -- use remove_blocking() for that, which is what an owner about to be destroyed
+// needs. See the comments on those two functions.
 class MAVSDK_TEST_EXPORT TimeoutHandler {
 public:
     explicit TimeoutHandler(Time& time);
@@ -26,11 +36,26 @@ public:
 
     [[nodiscard]] Cookie add(std::function<void()> callback, double duration_s);
     void refresh(Cookie cookie);
+
+    // Cancel a timeout. After this returns the callback will not be started anymore, but if
+    // it is running right now it keeps running. Safe to call from within a callback and
+    // safe to call while holding a lock that the callback also takes.
     void remove(Cookie cookie);
+
+    // Cancel a timeout and wait for it if it happens to be running right now. Once this
+    // returns, the callback is neither running nor going to run, so an owner that captured
+    // 'this' can be destroyed safely.
+    //
+    // Must not be called while holding a lock that the callback itself takes -- that would
+    // deadlock. Calling it from within the very callback being removed is fine (it does not
+    // wait on itself), as is calling it for a different cookie from within a callback.
+    void remove_blocking(Cookie cookie);
 
     void run_once();
 
 private:
+    void remove_impl(Cookie cookie, bool blocking);
+
     struct Timeout {
         std::function<void()> callback{};
         SteadyTimePoint time{};
@@ -39,7 +64,19 @@ private:
     };
 
     std::list<Timeout> _timeouts{};
-    std::recursive_mutex _timeouts_mutex{};
+    // Timeouts that run_once() has found due and taken out of _timeouts, but has not
+    // invoked yet. They stay reachable here so that remove() can still cancel them.
+    std::list<Timeout> _due{};
+
+    std::mutex _timeouts_mutex{};
+    // Signalled whenever a callback returns, so remove_blocking() can wait for one.
+    std::condition_variable _callback_done{};
+
+    // The timeout whose callback run_once() is invoking right now (0 if none), and the
+    // thread invoking it so that removing a timeout from its own callback does not wait
+    // on itself. Guarded by _timeouts_mutex.
+    Cookie _executing_cookie{0};
+    std::thread::id _executing_thread{};
 
     Time& _time;
 

--- a/cpp/src/mavsdk/core/timeout_handler_test.cpp
+++ b/cpp/src/mavsdk/core/timeout_handler_test.cpp
@@ -1,5 +1,9 @@
 #include "timeout_handler.hpp"
 #include "unused.hpp"
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
 #include <gtest/gtest.h>
 
 #ifdef FAKE_TIME
@@ -199,4 +203,99 @@ TEST(TimeoutHandler, RefreshAfterFireDoesNotResurrect)
     time.sleep_for(std::chrono::milliseconds(400));
     th.run_once();
     EXPECT_EQ(fires, 1);
+}
+
+TEST(TimeoutHandler, RemovingDueTimeoutDuringCallbackPreventsIt)
+{
+    Time time{};
+    TimeoutHandler th(time);
+
+    bool second_happened = false;
+    TimeoutHandler::Cookie cookie2{};
+
+    // Both timeouts are due in the same run_once(). The first one removes the second,
+    // which has to actually stop it from being called.
+    TimeoutHandler::Cookie cookie1 = th.add([&th, &cookie2]() { th.remove(cookie2); }, 0.5);
+    cookie2 = th.add([&second_happened]() { second_happened = true; }, 0.5);
+
+    time.sleep_for(std::chrono::milliseconds(1000));
+    th.run_once();
+
+    EXPECT_FALSE(second_happened);
+
+    UNUSED(cookie1);
+}
+
+TEST(TimeoutHandler, RemoveBlockingWaitsForRunningCallback)
+{
+    Time time{};
+    TimeoutHandler th(time);
+
+    std::promise<void> callback_entered;
+    std::atomic<bool> release{false};
+    std::atomic<bool> callback_returned{false};
+
+    auto cookie = th.add(
+        [&]() {
+            callback_entered.set_value();
+            while (!release) {
+                std::this_thread::yield();
+            }
+            callback_returned = true;
+        },
+        0.5);
+
+    time.sleep_for(std::chrono::milliseconds(1000));
+
+    std::thread runner([&th]() { th.run_once(); });
+
+    // Only call remove_blocking() once we know the callback is actually running.
+    callback_entered.get_future().wait();
+
+    std::thread releaser([&release]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        release = true;
+    });
+
+    th.remove_blocking(cookie);
+
+    // The whole point: remove_blocking() does not return while the callback is running.
+    EXPECT_TRUE(callback_returned);
+
+    releaser.join();
+    runner.join();
+}
+
+TEST(TimeoutHandler, RemoveBlockingFromOwnCallbackDoesNotDeadlock)
+{
+    Time time{};
+    TimeoutHandler th(time);
+
+    bool timeout_happened = false;
+    TimeoutHandler::Cookie cookie{};
+
+    cookie = th.add(
+        [&th, &cookie, &timeout_happened]() {
+            timeout_happened = true;
+            // Waiting for ourselves here would hang forever.
+            th.remove_blocking(cookie);
+        },
+        0.5);
+
+    time.sleep_for(std::chrono::milliseconds(1000));
+    th.run_once();
+
+    EXPECT_TRUE(timeout_happened);
+}
+
+TEST(TimeoutHandler, RemoveBlockingUnsetCookieReturns)
+{
+    Time time{};
+    TimeoutHandler th(time);
+
+    // A default-initialised cookie means "never registered". Nothing is executing, so this
+    // has to return rather than wait for a callback that does not exist.
+    TimeoutHandler::Cookie never_registered{};
+    th.remove_blocking(never_registered);
+    th.remove_blocking(static_cast<TimeoutHandler::Cookie>(999999));
 }

--- a/cpp/src/mavsdk/core/timesync.cpp
+++ b/cpp/src/mavsdk/core/timesync.cpp
@@ -11,7 +11,8 @@ Timesync::Timesync(SystemImpl& parent) : _system_impl(parent) {}
 
 Timesync::~Timesync()
 {
-    _system_impl.unregister_all_mavlink_message_handlers(this);
+    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    _system_impl.unregister_all_mavlink_message_handlers_blocking(this);
 }
 
 void Timesync::enable()

--- a/cpp/src/mavsdk/plugins/action_server/action_server_impl.cpp
+++ b/cpp/src/mavsdk/plugins/action_server/action_server_impl.cpp
@@ -374,7 +374,7 @@ void ActionServerImpl::init()
 void ActionServerImpl::deinit()
 {
     _server_component_impl->unregister_all_mavlink_command_handlers(this);
-    _server_component_impl->remove_call_every(_send_version_cookie);
+    _server_component_impl->remove_call_every_blocking(_send_version_cookie);
     _server_component_impl->unregister_all_mavlink_command_handlers(this);
 }
 

--- a/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
+++ b/cpp/src/mavsdk/plugins/camera/camera_impl.cpp
@@ -20,7 +20,6 @@
 #include <filesystem>
 #include <functional>
 #include <string>
-#include <thread>
 
 #include "mavsdk_export.h"
 
@@ -129,18 +128,16 @@ void CameraImpl::deinit()
 
     _system_impl->cancel_all_param(this);
 
-    _system_impl->remove_call_every(_request_missing_capture_info_cookie);
-    _system_impl->remove_call_every(_request_slower_call_every_cookie);
-    _system_impl->remove_call_every(_request_faster_call_every_cookie);
+    // Blocking, so that a call_every lambda that is mid-flight has returned by the time we
+    // get here. We hold no lock at this point, so waiting for it is safe.
+    _system_impl->remove_call_every_blocking(_request_missing_capture_info_cookie);
+    _system_impl->remove_call_every_blocking(_request_slower_call_every_cookie);
+    _system_impl->remove_call_every_blocking(_request_faster_call_every_cookie);
 
     // Cancel any pending MAVLink FTP operations so their callbacks don't fire
     // after we are gone.  This is synchronous: once it returns no further FTP
     // callbacks will be dispatched from the io_context thread.
     _system_impl->mavlink_ftp_client().cancel_all_operations();
-
-    // Wait briefly for call_every lambdas that may already be mid-flight
-    // (remove_call_every only prevents future invocations).
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
     std::lock_guard lock(_mutex);
     // Signal any user-callback-queued lambdas that slipped through before

--- a/cpp/src/mavsdk/plugins/events/event_handler.cpp
+++ b/cpp/src/mavsdk/plugins/events/event_handler.cpp
@@ -83,7 +83,9 @@ EventHandler::EventHandler(
 EventHandler::~EventHandler()
 {
     if (_timer_cookie != 0) {
-        _system_impl.unregister_timeout_handler(_timer_cookie);
+        // Blocking: the timeout callback captures 'this' and takes _protocol_mutex, which
+        // we do not hold here.
+        _system_impl.unregister_timeout_handler_blocking(_timer_cookie);
     }
     // Use blocking version to ensure any in-flight callbacks complete before destruction.
     for (size_t i = 0; i < _message_handler_cookies.size(); ++i) {

--- a/cpp/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
+++ b/cpp/src/mavsdk/plugins/follow_me/follow_me_impl.cpp
@@ -21,7 +21,7 @@ FollowMeImpl::FollowMeImpl(std::shared_ptr<System> system) : PluginImplBase(std:
 
 FollowMeImpl::~FollowMeImpl()
 {
-    _system_impl->remove_call_every(_target_location_cookie);
+    _system_impl->remove_call_every_blocking(_target_location_cookie);
     _system_impl->unregister_plugin(this);
 }
 

--- a/cpp/src/mavsdk/plugins/info/info_impl.cpp
+++ b/cpp/src/mavsdk/plugins/info/info_impl.cpp
@@ -63,7 +63,7 @@ void InfoImpl::enable()
 
 void InfoImpl::disable()
 {
-    _system_impl->remove_call_every(_call_every_cookie);
+    _system_impl->remove_call_every_blocking(_call_every_cookie);
 
     std::lock_guard<std::mutex> lock(_mutex);
     _identification_received = false;

--- a/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
+++ b/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
@@ -88,15 +88,22 @@ void LogFilesImpl::init()
 
 void LogFilesImpl::deinit()
 {
+    TimeoutHandler::Cookie entries_cookie{};
+    TimeoutHandler::Cookie download_cookie{};
     {
         std::lock_guard<std::mutex> lock(_entries_mutex);
-        _system_impl->unregister_timeout_handler(_entries_timeout_cookie);
+        entries_cookie = _entries_timeout_cookie;
     }
-
     {
         std::lock_guard<std::mutex> lock(_download_data_mutex);
-        _system_impl->unregister_timeout_handler(_download_data.timeout_cookie);
+        download_cookie = _download_data.timeout_cookie;
     }
+
+    // Outside those mutexes: the blocking removals wait for entries_timeout() /
+    // data_timeout() if one is running right now, and those take the mutexes themselves.
+    _system_impl->unregister_timeout_handler_blocking(entries_cookie);
+    _system_impl->unregister_timeout_handler_blocking(download_cookie);
+
     _system_impl->unregister_all_mavlink_message_handlers_blocking(this);
 }
 

--- a/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
+++ b/cpp/src/mavsdk/plugins/log_streaming/log_streaming_impl.cpp
@@ -41,18 +41,20 @@ void LogStreamingImpl::init()
 void LogStreamingImpl::deinit()
 {
     std::unique_ptr<LogStreamingBackend> backend;
+    CallEveryHandler::Cookie check_autopilot_cookie{};
     {
         std::lock_guard<std::mutex> lock(_mutex);
 
-        // Cancel any pending autopilot type polling
-        if (_check_autopilot_cookie) {
-            _system_impl->remove_call_every(_check_autopilot_cookie);
-            _check_autopilot_cookie = {};
-        }
+        // Cancel any pending autopilot type polling. The blocking removal happens below,
+        // outside _mutex, because the callback takes _mutex itself.
+        check_autopilot_cookie = _check_autopilot_cookie;
+        _check_autopilot_cookie = {};
         _start_callback = nullptr;
 
         backend = std::move(_backend);
     }
+
+    _system_impl->remove_call_every_blocking(check_autopilot_cookie);
 
     // Deinit (and destroy) the backend outside of _mutex: its blocking unregister can wait
     // for an in-flight message callback to finish, and that callback may be in

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -203,15 +203,13 @@ void TelemetryImpl::enable()
 
 void TelemetryImpl::disable()
 {
-    _system_impl->remove_call_every(_homepos_cookie);
+    // Blocking, so that request_home_position_again() cannot still be executing once we
+    // return. It takes _health_mutex, so this has to happen before we take it below.
+    _system_impl->remove_call_every_blocking(_homepos_cookie);
     {
         std::lock_guard<std::mutex> lock(_health_mutex);
         _health.is_home_position_ok = false;
     }
-
-    // FIXME: this is a race condition where request_home_position_again
-    //        could still be executing after we have removed it.
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
 }
 
 void TelemetryImpl::request_home_position_again()


### PR DESCRIPTION
Part 3.3 and 3.4 of an Asio/threading review. Stacked on #3047 (async writes) and the async-resolve branch.

`TimeoutHandler::run_once()` and `CallEveryHandler::run_once()` copied the due callbacks out under the lock and then invoked them outside it. Between those two steps `remove()` — callable from any thread — could return, letting the caller tear down the object the callback had captured, and the callback would then run on the io thread anyway. Removing a due entry from within another callback of the same batch did not stop it either, since it had already been copied out.

Both handlers now park the due entries in a member list instead of a local, so `remove()` cancels them right up to the moment they are invoked, and they gain a `remove_blocking()` that additionally waits when the callback is executing right now. Once that returns, the callback is neither running nor going to run.

`remove()` keeps the non-blocking behaviour on purpose: several call sites remove a cookie while holding a lock the callback itself takes (Offboard, FollowMe, LogStreaming), and waiting there would deadlock.

Destructors and `deinit()`/`disable()` paths switch to the blocking variants, and where they held such a lock the removal is moved out of it. That let two sleeps go — the ones that were standing in for the missing guarantee:

- `CameraImpl::deinit()`'s 100 ms *"wait briefly for call_every lambdas that may already be mid-flight"*
- `TelemetryImpl::disable()`'s 200 ms sleep, next to its `FIXME` about exactly this race

The remaining destructors that unregistered message handlers via the posted `unregister_all()` now use `unregister_all_blocking()` too, so "my destructor stops callbacks" means the same thing everywhere.

### Note for reviewers

Cookie `0` is never handed out by `add()`, and callers keep a default-initialised cookie around for a timer they may never have started. `remove_blocking()` also uses `0` for "nothing executing", so it has to bail out on that value before waiting — without the guard the very first system test deadlocks. There is a regression test for both handlers.

### Testing

426/426 unit tests, 102/102 system tests.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW