### PR TITLE
core: keep every receive path on the io thread

### DIFF
--- a/cpp/src/mavsdk/core/connection.cpp
+++ b/cpp/src/mavsdk/core/connection.cpp
@@ -1,5 +1,8 @@
 #include "connection.hpp"
 
+#include <asio/post.hpp>
+#include <cassert>
+#include <future>
 #include <memory>
 #include <utility>
 #include "mavsdk_impl.hpp"
@@ -12,6 +15,27 @@
 namespace mavsdk {
 
 std::atomic<unsigned> Connection::_forwarding_connections_count = 0;
+
+asio::io_context& Connection::io_context()
+{
+    return _mavsdk_impl.io_context();
+}
+
+void Connection::drain_io_context()
+{
+    // Waiting for the io thread from the io thread would wait for ourselves. Nothing does
+    // this today; the assert is here so it stays that way.
+    assert(!_mavsdk_impl.on_io_thread());
+
+    auto& io_ctx = io_context();
+    if (io_ctx.stopped()) {
+        return;
+    }
+
+    std::promise<void> fence;
+    asio::post(io_ctx, [&fence]() { fence.set_value(); });
+    fence.get_future().wait();
+}
 
 Connection::Connection(
     ReceiverCallback receiver_callback,

--- a/cpp/src/mavsdk/core/connection.hpp
+++ b/cpp/src/mavsdk/core/connection.hpp
@@ -3,6 +3,7 @@
 #include "mavsdk.hpp"
 #include "mavlink_receiver.hpp"
 #include "libmav_receiver.hpp"
+#include <asio/io_context.hpp>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -67,6 +68,19 @@ protected:
     bool start_libmav_receiver();
     void stop_libmav_receiver();
     void receive_libmav_message(const Mavsdk::MavlinkMessage& message, Connection* connection);
+
+    // The io_context every connection does its async I/O on, owned by MavsdkImpl.
+    // Preferable to static_cast-ing socket.get_executor().context() back to an
+    // io_context&, which is only correct as long as nothing rebinds the executor.
+    asio::io_context& io_context();
+
+    // Post an empty handler onto the io_context and wait for it, so that every handler
+    // queued before it has run. Used by stop() to make sure no completion handler still
+    // references the connection once it returns. No-op if the io_context is already
+    // stopped, in which case nothing can be running anymore anyway.
+    //
+    // Must not be called from the io_context thread -- it would wait for itself.
+    void drain_io_context();
 
     // Report a send failure that was only discovered asynchronously, i.e. after
     // send_message()/send_raw_bytes() already returned. Reaches the same

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -1,5 +1,6 @@
 #include "mavsdk_impl.hpp"
 
+#include <asio/dispatch.hpp>
 #include <asio/post.hpp>
 
 #include <algorithm>
@@ -112,7 +113,10 @@ MavsdkImpl::MavsdkImpl(const Mavsdk::Configuration& configuration) :
 
     // Start the Asio io_context on its own thread.  All async I/O completions,
     // message dispatch, and timer callbacks are dispatched here.
-    _io_thread = std::make_unique<std::thread>([this]() { _io_context.run(); });
+    _io_thread = std::make_unique<std::thread>([this]() {
+        _io_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+        _io_context.run();
+    });
 }
 
 MavsdkImpl::~MavsdkImpl()
@@ -366,11 +370,10 @@ MavsdkImpl::server_component_by_id_with_lock(uint8_t component_id, uint8_t mav_t
 {
     for (auto& it : _server_components) {
         if (it.first == component_id) {
-            if (it.second != nullptr) {
-                return it.second;
-            } else {
+            if (it.second == nullptr) {
                 it.second = std::make_shared<ServerComponent>(*this, component_id, mav_type);
             }
+            return it.second;
         }
     }
 
@@ -427,10 +430,11 @@ void MavsdkImpl::receive_message(
     MavlinkReceiver::ParseResult result, mavlink_message_t& message, Connection* connection)
 {
     if (result == MavlinkReceiver::ParseResult::MessageParsed) {
-        // Post directly to the io_context — no intermediate queue needed.
-        // The io_context thread already owns all connection callbacks, so this
-        // keeps message processing single-threaded on that same executor.
-        asio::post(_io_context, [this, msg = message, conn = connection]() mutable {
+        // Dispatch, not post: every connection already parses on the io_context thread, so
+        // this runs inline and saves a deferred turn plus a mavlink_message_t copy per
+        // received message. If a caller ever does arrive on another thread, dispatch()
+        // falls back to posting, so message processing stays on the one executor either way.
+        asio::dispatch(_io_context, [this, msg = message, conn = connection]() mutable {
             process_message(msg, conn);
         });
     } else if (result == MavlinkReceiver::ParseResult::BadCrc) {
@@ -442,8 +446,8 @@ void MavsdkImpl::receive_message(
 void MavsdkImpl::receive_libmav_message(
     const Mavsdk::MavlinkMessage& message, Connection* connection)
 {
-    // Post directly to the io_context — no intermediate queue needed.
-    asio::post(_io_context, [this, message, conn = connection]() {
+    // Dispatch, not post: see receive_message() above.
+    asio::dispatch(_io_context, [this, message, conn = connection]() {
         process_libmav_message(message, conn);
     });
 }
@@ -656,6 +660,9 @@ void MavsdkImpl::process_message(mavlink_message_t& message, Connection* connect
 
     mavlink_message_handler.process_message(message);
 
+    // Deliberately outside _mutex: this dispatches into plugin code, which must not run
+    // with the instance lock held. It is safe because _systems is only ever written on the
+    // io_context thread, which is the thread we are on here.
     for (auto& system : _systems) {
         if (system.first == message.sysid) {
             system.second->system_impl()->process_mavlink_message(message);
@@ -769,7 +776,9 @@ void MavsdkImpl::process_libmav_message(
         }
     }
 
-    // Distribute libmav message to systems for libmav-specific handling
+    // Distribute libmav message to systems for libmav-specific handling.
+    // Deliberately outside _mutex, same as in process_message(): this dispatches into
+    // plugin code, and _systems is only ever written on the io_context thread.
     bool found_system = false;
     for (auto& system : _systems) {
         if (system.first == message.system_id) {
@@ -807,9 +816,14 @@ void MavsdkImpl::process_libmav_message(
 
 bool MavsdkImpl::send_message(mavlink_message_t& message)
 {
-    // Post directly to the io_context — no intermediate queue needed.
-    // deliver_message() always runs on the io_context thread, so ordering
-    // is preserved (posts are executed FIFO) and no mutex is required.
+    // Post, not dispatch: deliver_message() always runs on the io_context thread, so
+    // ordering is preserved (posts are executed FIFO) and no mutex is required. Dispatching
+    // would let a send made from the io thread jump ahead of user-thread sends that are
+    // already queued.
+    //
+    // Note that the return value only says the message was queued, never that it went out:
+    // the actual send happens later on the io thread. Failures are reported through
+    // Mavsdk::subscribe_connection_errors() instead.
     asio::post(_io_context, [this, msg = message]() mutable { deliver_message(msg); });
 
     return true;
@@ -1429,14 +1443,21 @@ void MavsdkImpl::schedule_timers_poll()
 
 void MavsdkImpl::set_callback_executor(std::function<void(std::function<void()>)> executor)
 {
-    bool has_executor;
-    {
-        std::lock_guard<std::mutex> lock(_callback_executor_mutex);
-        _callback_executor = std::move(executor);
-        has_executor = !!_callback_executor;
+    // Two concurrent calls would otherwise race on _process_user_callbacks_thread, which
+    // the branches below start, join and reset without any other synchronisation.
+    std::lock_guard<std::mutex> change_lock(_callback_executor_change_mutex);
+
+    std::shared_ptr<const CallbackExecutor> new_executor;
+    if (executor) {
+        new_executor = std::make_shared<const CallbackExecutor>(std::move(executor));
     }
 
-    if (has_executor) {
+    {
+        std::lock_guard<std::mutex> lock(_callback_executor_mutex);
+        _callback_executor = new_executor;
+    }
+
+    if (new_executor) {
         // Stop the internal callback thread since user will handle callbacks
         if (_process_user_callbacks_thread) {
             _user_callback_queue.stop();
@@ -1444,15 +1465,13 @@ void MavsdkImpl::set_callback_executor(std::function<void(std::function<void()>)
             _process_user_callbacks_thread.reset();
         }
 
-        // Drain any remaining callbacks through the executor
+        // Drain any remaining callbacks through the executor. Uses the local copy, so
+        // _callback_executor_mutex is not held while the user's executor runs.
         {
-            std::lock_guard<std::mutex> lock(_callback_executor_mutex);
-            if (_callback_executor) {
-                LockedQueue<UserCallback>::Guard guard(_user_callback_queue);
-                while (auto ptr = guard.get_front()) {
-                    _callback_executor(ptr->func);
-                    guard.pop_front();
-                }
+            LockedQueue<UserCallback>::Guard guard(_user_callback_queue);
+            while (auto ptr = guard.get_front()) {
+                (*new_executor)(ptr->func);
+                guard.pop_front();
             }
         }
     } else {
@@ -1473,12 +1492,17 @@ void MavsdkImpl::call_user_callback_located(
         return;
     }
 
+    // Take a reference to the executor under the lock, but call it outside: this runs on the
+    // io thread, and a slow user executor must not hold up everyone else queuing a callback.
+    std::shared_ptr<const CallbackExecutor> executor;
     {
         std::lock_guard<std::mutex> lock(_callback_executor_mutex);
-        if (_callback_executor) {
-            _callback_executor(func);
-            return;
-        }
+        executor = _callback_executor;
+    }
+
+    if (executor) {
+        (*executor)(func);
+        return;
     }
 
     auto callback_size = _user_callback_queue.size();
@@ -1729,6 +1753,11 @@ void MavsdkImpl::unsubscribe_outgoing_messages_json(Mavsdk::InterceptJsonHandle 
     if (it != _outgoing_json_message_subscriptions.end()) {
         _outgoing_json_message_subscriptions.erase(it);
     }
+}
+
+bool MavsdkImpl::on_io_thread() const
+{
+    return _io_thread_id.load(std::memory_order_relaxed) == std::this_thread::get_id();
 }
 
 RawConnection* MavsdkImpl::find_raw_connection()

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -357,8 +357,15 @@ private:
     // is a leaf, so taking it under _heartbeat_mutex is safe.
     HeartbeatWatchdog _heartbeat_watchdog{time};
 
+    using CallbackExecutor = std::function<void(std::function<void()>)>;
+    // Serialises set_callback_executor() calls against each other: they start and join
+    // _process_user_callbacks_thread, which nothing else guards.
+    std::mutex _callback_executor_change_mutex{};
+    // Held only to read or swap the pointer, never while the executor runs -- a slow user
+    // executor must not block whoever else wants to queue a callback. Held as a shared_ptr
+    // so a caller can keep it alive across the invocation without copying the std::function.
     std::mutex _callback_executor_mutex{};
-    std::function<void(std::function<void()>)> _callback_executor{};
+    std::shared_ptr<const CallbackExecutor> _callback_executor{};
 
     std::atomic<bool> _should_exit{false};
 
@@ -374,6 +381,16 @@ private:
     void schedule_do_work();
 
     std::unique_ptr<std::thread> _io_thread{};
+    // The io thread's own id, recorded by the thread itself when it starts. Asserts use
+    // this instead of asio's running_in_this_thread(), whose thread-local is instantiated
+    // per DSO with header-only asio plus hidden visibility, and so cannot be trusted from
+    // inside libmavsdk when something outside it drives the io_context.
+    std::atomic<std::thread::id> _io_thread_id{};
+
+public:
+    // Whether the caller is the io_context thread. Only meant for asserts and for picking
+    // between an inline and a posted path, not for synchronisation.
+    bool on_io_thread() const;
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/raw_connection.cpp
+++ b/cpp/src/mavsdk/core/raw_connection.cpp
@@ -1,6 +1,8 @@
 #include "raw_connection.hpp"
 #include "mavsdk_impl.hpp"
 #include "log.hpp"
+#include <asio/post.hpp>
+#include <vector>
 
 namespace mavsdk {
 
@@ -29,6 +31,10 @@ ConnectionResult RawConnection::start()
 
 ConnectionResult RawConnection::stop()
 {
+    // Wait for anything receive() posted, so that no handler still references us (or the
+    // receivers below) once this returns.
+    drain_io_context();
+
     stop_mavlink_receiver();
     stop_libmav_receiver();
     return ConnectionResult::Success;
@@ -53,9 +59,24 @@ std::pair<bool, std::string> RawConnection::send_raw_bytes(const char* bytes, si
 
 void RawConnection::receive(const char* bytes, size_t length)
 {
-    // set_new_datagram expects char*, not const char*, so we need to cast
-    // This is safe because the receivers only read from the buffer
-    _mavlink_receiver->set_new_datagram(const_cast<char*>(bytes), static_cast<int>(length));
+    // Callers hand us bytes from whatever thread they like. The receivers below hold parser
+    // state that is not synchronized -- two threads feeding bytes concurrently would corrupt
+    // it -- and every other connection parses on the io_context thread, so hop over there
+    // instead of parsing here. stop() drains the io_context, so the posted handler cannot
+    // outlive us.
+    auto& io_ctx = io_context();
+    if (io_ctx.stopped()) {
+        return;
+    }
+
+    asio::post(io_ctx, [this, buffer = std::vector<char>(bytes, bytes + length)]() mutable {
+        parse(buffer.data(), buffer.size());
+    });
+}
+
+void RawConnection::parse(char* bytes, size_t length)
+{
+    _mavlink_receiver->set_new_datagram(bytes, static_cast<int>(length));
 
     // Parse all mavlink messages in one datagram. Once exhausted, we'll exit loop.
     auto parse_result = _mavlink_receiver->parse_message();
@@ -66,7 +87,7 @@ void RawConnection::receive(const char* bytes, size_t length)
 
     // Also parse with libmav if available
     if (_libmav_receiver) {
-        _libmav_receiver->set_new_datagram(const_cast<char*>(bytes), static_cast<int>(length));
+        _libmav_receiver->set_new_datagram(bytes, static_cast<int>(length));
 
         while (_libmav_receiver->parse_message()) {
             receive_libmav_message(_libmav_receiver->get_last_message(), this);

--- a/cpp/src/mavsdk/core/raw_connection.hpp
+++ b/cpp/src/mavsdk/core/raw_connection.hpp
@@ -28,11 +28,17 @@ public:
     std::pair<bool, std::string> send_message(const mavlink_message_t& message) override;
     std::pair<bool, std::string> send_raw_bytes(const char* bytes, size_t length) override;
 
+    // Hand raw bytes in from an arbitrary user thread. The actual parsing is posted onto
+    // the io_context, so it happens on the same thread as for every other connection.
     void receive(const char* bytes, size_t length);
 
     // Non-copyable
     RawConnection(const RawConnection&) = delete;
     const RawConnection& operator=(const RawConnection&) = delete;
+
+private:
+    // Runs on the io_context thread.
+    void parse(char* bytes, size_t length);
 };
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/serial_connection.cpp
+++ b/cpp/src/mavsdk/core/serial_connection.cpp
@@ -2,6 +2,8 @@
 #include "mavsdk_impl.hpp"
 #include "log.hpp"
 
+#include <cassert>
+
 #if defined(APPLE) || defined(LINUX)
 #include <termios.h>
 #include <unistd.h>
@@ -227,10 +229,13 @@ ConnectionResult SerialConnection::setup_port()
 
 ConnectionResult SerialConnection::stop()
 {
+    // This posts onto the io_context and waits, so it must not run on the io thread.
+    assert(!_mavsdk_impl.on_io_thread());
+
     _stopping = true;
     _port_open = false;
 
-    auto& io_ctx = static_cast<asio::io_context&>(_serial_port.get_executor().context());
+    auto& io_ctx = io_context();
     if (!io_ctx.stopped()) {
         // Close the serial port from the io_context thread to avoid a data race
         // with a concurrent async_read_some() / async_write() reading the port's state.

--- a/cpp/src/mavsdk/core/tcp_client_connection.cpp
+++ b/cpp/src/mavsdk/core/tcp_client_connection.cpp
@@ -2,6 +2,8 @@
 #include "mavsdk_impl.hpp"
 #include "log.hpp"
 
+#include <cassert>
+
 #include <asio/buffer.hpp>
 #include <asio/connect.hpp>
 #include <asio/error.hpp>
@@ -66,6 +68,9 @@ ConnectionResult TcpClientConnection::start()
 
 ConnectionResult TcpClientConnection::stop()
 {
+    // This posts onto the io_context and waits, so it must not run on the io thread.
+    assert(!_mavsdk_impl.on_io_thread());
+
     // Signal handlers to stop re-arming BEFORE cancelling/closing.  An EOF
     // handler that was already queued (ec == eof, not operation_aborted) would
     // otherwise call start_reconnect() after we've cancelled the timer and
@@ -73,7 +78,7 @@ ConnectionResult TcpClientConnection::stop()
     _stopping = true;
     _connected = false;
 
-    auto& io_ctx = static_cast<asio::io_context&>(_socket.get_executor().context());
+    auto& io_ctx = io_context();
     if (!io_ctx.stopped()) {
         // Cancel and close from the io_context thread to avoid a data race with
         // a concurrent async_read_some() / async_connect() / async_write() /

--- a/cpp/src/mavsdk/core/tcp_server_connection.cpp
+++ b/cpp/src/mavsdk/core/tcp_server_connection.cpp
@@ -2,6 +2,8 @@
 #include "mavsdk_impl.hpp"
 #include "log.hpp"
 
+#include <cassert>
+
 #include <asio/buffer.hpp>
 #include <asio/error.hpp>
 #include <asio/ip/address.hpp>
@@ -88,13 +90,16 @@ ConnectionResult TcpServerConnection::start()
 
 ConnectionResult TcpServerConnection::stop()
 {
+    // This posts onto the io_context and waits, so it must not run on the io thread.
+    assert(!_mavsdk_impl.on_io_thread());
+
     // Signal handlers to stop re-arming.  Must be set before closing sockets so
     // that any handler seeing operation_aborted (or a stale non-error code) does
     // not re-arm a new async_accept / async_read_some.
     _stopping = true;
     _client_connected = false;
 
-    auto& io_ctx = static_cast<asio::io_context&>(_acceptor.get_executor().context());
+    auto& io_ctx = io_context();
     if (!io_ctx.stopped()) {
         // Close the acceptor and client socket ON the io_context thread.  This
         // serialises the close with do_accept() / do_receive() — both of which

--- a/cpp/src/mavsdk/core/tcp_server_connection.hpp
+++ b/cpp/src/mavsdk/core/tcp_server_connection.hpp
@@ -12,6 +12,9 @@
 
 namespace mavsdk {
 
+// A TCP server that serves exactly one client at a time: there is a single _client_socket,
+// and do_accept() only accepts the next connection once the current client has gone away.
+// A second client trying to connect meanwhile waits in the listen backlog.
 class TcpServerConnection : public Connection {
 public:
     TcpServerConnection(

--- a/cpp/src/mavsdk/core/udp_connection.cpp
+++ b/cpp/src/mavsdk/core/udp_connection.cpp
@@ -2,6 +2,8 @@
 #include "mavsdk_impl.hpp"
 #include "log.hpp"
 
+#include <cassert>
+
 #include <asio/buffer.hpp>
 #include <asio/error.hpp>
 #include <asio/ip/address.hpp>
@@ -92,8 +94,11 @@ ConnectionResult UdpConnection::setup_port()
 
 ConnectionResult UdpConnection::stop()
 {
+    // This posts onto the io_context and waits, so it must not run on the io thread.
+    assert(!_mavsdk_impl.on_io_thread());
+
     if (_socket.is_open()) {
-        auto& io_ctx = static_cast<asio::io_context&>(_socket.get_executor().context());
+        auto& io_ctx = io_context();
 
         if (!io_ctx.stopped()) {
             // Close the socket from the io_context thread to avoid a data race


### PR DESCRIPTION
Parts 3.6, 3.7, 3.8 and 3.10 of an Asio/threading review. Stacked on #3049.

`RawConnection` was the one exception to the "everything happens on the io thread" invariant. `pass_received_raw_bytes()` called straight into the parsers on whatever thread the user handed the bytes in on, and `_mavlink_receiver` / `_libmav_receiver` hold parser state with no synchronisation at all, so two threads feeding raw bytes concurrently corrupted it. `receive()` now posts the bytes onto the io_context, and `stop()` drains the io_context first so no posted handler can outlive the connection.

With that hole closed, the receive path can `dispatch()` instead of `post()`: socket and serial connections already parse on the io thread, so this saves a deferred turn plus a `mavlink_message_t` copy per received message, and still posts for anything that does arrive from elsewhere.

`send_message()` deliberately keeps `post()` — dispatching would let an io-thread send jump ahead of user-thread sends already queued. Its return value is now documented as "queued", not "sent", since that is all it has been able to mean since sending became asynchronous.

Also:

- `server_component_by_id_with_lock()` filled in a null entry for an existing component id but then fell through and appended a **second** entry for the same id.
- `set_callback_executor()` started and joined `_process_user_callbacks_thread` with nothing guarding it, so two concurrent calls raced; and it ran the user's executor with `_callback_executor_mutex` held, so a slow executor blocked the io thread inside the lock. The executor is now held as a `shared_ptr`, taken under the lock and invoked outside it.
- `Connection` gained `io_context()` and `drain_io_context()` helpers, replacing the `static_cast` of `socket.get_executor().context()` back to an `io_context&` in each transport. Each `stop()` asserts it is not running on the io thread — it posts and waits, so it would wait for itself.
- `MavsdkImpl::on_io_thread()` records the io thread's own id rather than relying on asio's `running_in_this_thread()`, whose thread-local is per-DSO here.
- Comments for why `_systems` is walked without `_mutex`, and for `TcpServerConnection` serving one client at a time.

### Testing

426/426 unit tests, 102/102 system tests.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW