### PR TITLE
core: replace the FTP burst thread with a timer chain

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -1,0 +1,133 @@
+# Threading in libmavsdk core
+
+This is the one place that states the rules the core relies on. The per-file comments explain
+individual decisions; this explains the shape they add up to. If you are adding code to
+`core/` or to a plugin impl, read this first.
+
+## The threads
+
+| Thread | Created in | What runs on it |
+|---|---|---|
+| **io thread** | `MavsdkImpl` ctor (`mavsdk_impl.cpp`) | `asio::io_context::run()`. All socket and serial I/O, MAVLink parsing, message routing, plugin protocol state machines, and every internal timer. |
+| **user-callback thread** | `MavsdkImpl` ctor | Drains `LockedQueue<UserCallback>` and invokes user-facing subscription callbacks. Replaced by a user-supplied executor if `Mavsdk::set_callback_executor()` is used. |
+| **HTTP loader thread** | `HttpLoader` | Component-metadata downloads only. Talks to the rest of the SDK through callbacks. |
+| user threads | — | Anything calling the public API. Blocking API calls park here on a `std::future`. |
+
+Everything else — including the FTP burst read, which used to have a thread of its own — runs
+on the io thread.
+
+## The core invariant
+
+> Shared mutable state is only touched on the io thread. Everything else posts onto it.
+
+That is what removes most of the locking. Concretely:
+
+- `MavlinkMessageHandler::_table` is only touched on the io thread. `register_*` and
+  `unregister_*` post their mutation, so there is no lock at all, ordering falls out of post
+  FIFO, and it is safe to (un)register from inside a callback.
+- `MavlinkParameterSubscription` uses the same pattern for its subscription list.
+- `CallbackListImpl` posts mutations without waiting (so they are safe to call under a lock)
+  and posts-and-waits for reads (so arguments stay alive), with an inline fast path when
+  already on the io thread.
+- The work queues in `MavlinkCommandSender`, the mission transfer classes, the FTP client and
+  the parameter clients are io-thread-only; enqueuing from elsewhere is posted.
+
+`MavlinkMessageHandler` and `MavlinkParameterSubscription` each have a debug-only
+`note_*_thread()` that records the accessing `std::thread::id` and asserts if it ever changes.
+That catches invariant violations that an `asio::executor::running_in_this_thread()` assert
+would miss: with header-only Asio and hidden visibility, that thread-local is instantiated
+per DSO, so it is not trustworthy from inside libmavsdk when a test binary drives the
+io_context from outside. `MavsdkImpl::on_io_thread()` compares against the io thread's own
+recorded id and is reliable; use that when you need the check.
+
+## post vs. dispatch
+
+- **`asio::post`** when order matters relative to work already queued, or when you must not
+  run inline. `MavsdkImpl::send_message()` posts on purpose: dispatching would let a send
+  made from the io thread jump ahead of user-thread sends already in the queue.
+- **`asio::dispatch`** when running inline is fine and the caller is usually already on the io
+  thread. The receive path (`MavsdkImpl::receive_message()` /
+  `receive_libmav_message()`) dispatches, which costs nothing for socket and serial
+  connections and still posts for anything arriving on another thread.
+
+## Unregistering: which variant guarantees what
+
+Two variants exist everywhere, and the difference matters:
+
+| Variant | Guarantee | Use it when |
+|---|---|---|
+| `unregister_all()`, `TimeoutHandler::remove()`, `CallEveryHandler::remove()` | The callback will not be *started* again. One that is running right now keeps running. | You are inside a callback, or you hold a lock the callback also takes. |
+| `unregister_all_blocking()`, `remove_blocking()`, `unsubscribe_blocking()` | Once it returns, the callback is neither running nor going to run. | The owner is about to be destroyed. |
+
+**A destructor, `deinit()` or `disable()` must use the blocking variant.** The non-blocking one
+leaves a window in which the io thread dispatches into a half-destroyed object.
+
+The blocking variants wait, so they must not be called while holding a lock the callback
+itself takes. Where a teardown path needs the lock anyway, read what you need under the lock,
+release it, and do the blocking removal afterwards — `LogFilesImpl::deinit()`,
+`LogStreamingImpl::deinit()` and `~MavlinkRequestMessage()` all do exactly that. Removing an
+entry from within its own callback does not wait on itself, so that case is fine.
+
+`MavlinkMessageHandler::unregister_all_blocking()` additionally must not be called from
+inside a message callback, because it removes directly and would invalidate the dispatch loop
+in `process_message()`. Use the posted `unregister_all()` there.
+
+## Timers
+
+Everything time-based is driven from the io thread:
+
+- `MavsdkImpl::schedule_timers_poll()` — every 5 ms, runs `TimeoutHandler::run_once()` and
+  `CallEveryHandler::run_once()`.
+- `MavsdkImpl::schedule_do_work()` — every 10 ms, `ServerComponentImpl::do_work()` for every
+  server component.
+- `SystemImpl::schedule_system_work()` — every 10 ms when connected, 100 ms otherwise; runs
+  `do_work()` on the command sender, timesync, mission transfer, FTP and parameter clients,
+  plus the 5 s ping.
+
+These are fixed-cadence polls rather than deadline-driven timers, so timeout resolution is
+capped at the 5 ms tick and an idle instance still wakes up regularly. That is a known
+trade-off, not an invariant.
+
+## Locks that remain
+
+Locks are for state genuinely reachable from user threads. The order is documented where the
+members are declared in `mavsdk_impl.hpp`; the summary:
+
+- `_configuration_update_mutex` is the outermost lock and is never taken by the io thread.
+- `_mutex` (connections and systems) is taken before `_server_components_mutex`.
+- `_configuration_mutex` and `HeartbeatWatchdog::_mutex` are leaves: never held while taking
+  another lock.
+- `_our_system_id` and friends are cached as atomics so the getters need no lock. Otherwise
+  `send_heartbeats()` would take `_server_components_mutex` then `_mutex`, inverting the io
+  thread's order.
+
+Per-connection and per-system locks (`_send_mutex`, `_remote_mutex`, `_components_mutex`,
+`_plugin_impls_mutex`, …) are local to their object and do not participate in the order above.
+
+## Teardown
+
+The order in `MavsdkImpl` is deliberate and load-bearing:
+
+1. `_io_context` and its work guard are the **first** members declared, so they are destroyed
+   **last** and every other member can still safely post during its own destruction.
+2. `~MavsdkImpl` stops the io_context and joins the io thread *before* stopping the callback
+   queue and clearing systems and connections.
+3. `remove_connection()` extracts the `unique_ptr` under `_mutex` and destroys it *outside*
+   the lock, so a user thread cannot hold `_mutex` while waiting on an io thread that wants
+   `_mutex`.
+4. Each connection's `stop()` posts the close onto the io thread and waits (serialising it
+   against in-flight socket access), then posts a second empty handler and waits for that too,
+   so the `operation_aborted` completions have drained before members are destroyed.
+   Because it waits on the io thread, `stop()` must not be called *from* it — there are
+   asserts for this.
+
+## Rules of thumb
+
+- Do not touch io-thread-owned state from a user thread. Post the mutation instead.
+- Do not call a blocking MAVSDK API from inside a MAVSDK callback: the callback thread is the
+  one that would have to deliver the result.
+- Do not hold a lock across I/O or across a post-and-wait.
+- If a destructor stops callbacks, it uses a blocking unregister — and if it needs a lock to
+  find out *what* to unregister, it does that first and unregisters after releasing it.
+- A `sleep_for()` is not a synchronisation primitive. If you feel the need for one, the
+  blocking variant of whatever you just called is what you actually wanted.

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.cpp
@@ -14,7 +14,8 @@ namespace mavsdk {
 namespace fs = std::filesystem;
 
 MavlinkFtpServer::MavlinkFtpServer(ServerComponentImpl& server_component_impl) :
-    _server_component_impl(server_component_impl)
+    _server_component_impl(server_component_impl),
+    _burst_timer(server_component_impl.io_context())
 {
     if (const char* env_p = std::getenv("MAVSDK_FTP_DEBUGGING")) {
         if (std::string(env_p) == "1") {
@@ -847,34 +848,46 @@ void MavlinkFtpServer::_work_burst(const PayloadHeader& payload)
     _session_info.burst_chunk_size = payload.size;
     _burst_seq = payload.seq_number + 1;
 
-    if (_session_info.burst_thread.joinable()) {
-        _session_info.burst_stop = true;
-        _session_info.burst_thread.join();
-    }
-
-    _session_info.burst_stop = false;
+    // Cancel a burst that may still be running for the previous request.
+    _burst_timer.cancel();
+    _session_info.burst_active = true;
 
     // Schedule sending out burst messages.
-    _session_info.burst_thread = std::thread([this]() {
-        while (!_session_info.burst_stop) {
-            // Try to grab the lock rather than blocking on it. If another thread holds
-            // _mutex to stop and join us, blocking here would deadlock; instead we fall
-            // back to observing burst_stop (atomic) and exit.
-            std::unique_lock<std::mutex> burst_lock(_mutex, std::try_to_lock);
-            if (!burst_lock.owns_lock()) {
-                std::this_thread::yield();
-                continue;
-            }
-            if (_session_info.burst_stop) {
-                break;
-            }
-            if (_send_burst_packet()) {
-                break;
-            }
-        }
-    });
+    _schedule_burst_packet(std::chrono::milliseconds(0));
 
-    // Don't send response as that's done in the call every burst call above.
+    // Don't send response as that's done from the burst timer above.
+}
+
+void MavlinkFtpServer::_schedule_burst_packet(std::chrono::milliseconds delay)
+{
+    _burst_timer.expires_after(delay);
+    _burst_timer.async_wait([this](const asio::error_code& ec) {
+        if (ec) {
+            // Cancelled, e.g. by a new burst request or by _reset().
+            return;
+        }
+
+        std::unique_lock<std::mutex> lock(_mutex, std::try_to_lock);
+        if (!lock.owns_lock()) {
+            // Someone is working on the session right now. Come back in a moment rather
+            // than blocking the io thread waiting for them.
+            _schedule_burst_packet(std::chrono::milliseconds(1));
+            return;
+        }
+
+        if (!_session_info.burst_active) {
+            return;
+        }
+
+        if (_send_burst_packet()) {
+            _session_info.burst_active = false;
+            return;
+        }
+
+        // No delay: send as fast as we can, just not all in one go without letting any
+        // other handler on the io_context run.
+        _schedule_burst_packet(std::chrono::milliseconds(0));
+    });
 }
 
 // Requires _mutex to be held. Returns true if sending is complete.
@@ -997,10 +1010,8 @@ void MavlinkFtpServer::_reset()
         _session_info.ofstream.close();
     }
 
-    _session_info.burst_stop = true;
-    if (_session_info.burst_thread.joinable()) {
-        _session_info.burst_thread.join();
-    }
+    _session_info.burst_active = false;
+    _burst_timer.cancel();
 }
 
 void MavlinkFtpServer::_work_reset(const PayloadHeader& payload)

--- a/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_ftp_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cinttypes>
 #include <fstream>
 #include <unordered_map>
@@ -10,7 +11,8 @@
 #include <utility>
 #include <variant>
 #include <vector>
-#include <thread>
+
+#include <asio/steady_timer.hpp>
 
 #include "mavlink_include.hpp"
 
@@ -139,6 +141,8 @@ private:
 
     bool _send_burst_packet(); // Requires _mutex to be held.
     void _make_burst_packet(PayloadHeader& packet);
+    // Arm _burst_timer to send the next burst packet on the io_context thread.
+    void _schedule_burst_packet(std::chrono::milliseconds delay);
 
     std::mutex _mutex{};
     struct SessionInfo {
@@ -147,16 +151,19 @@ private:
         uint8_t burst_chunk_size{0};
         std::ifstream ifstream;
         std::ofstream ofstream;
-        // Atomic so the burst worker can observe a stop request without holding
-        // _mutex, which lets a thread that holds _mutex join the worker without
-        // deadlocking (the worker would otherwise block trying to re-acquire _mutex).
-        std::atomic<bool> burst_stop{false};
-        std::thread burst_thread;
+        // Whether a burst read is in progress. Guarded by _mutex.
+        bool burst_active{false};
     } _session_info{};
 
+    // Drives a burst read one packet per io_context turn. A burst used to run on its own
+    // thread that spun on try_lock() and sent as fast as it could; chaining a timer here
+    // instead keeps the sending on the io thread and lets everything else -- including the
+    // FTP message that terminates the burst -- get a turn in between.
+    asio::steady_timer _burst_timer;
+
     uint8_t _network_id = 0;
-    // Written from the message-processing thread and read from the burst thread
-    // (via _send_mavlink_ftp_message), so keep these atomic.
+    // Written from the message-processing thread and read wherever a message is built, so
+    // keep these atomic.
     std::atomic<uint8_t> _target_system_id{0};
     std::atomic<uint8_t> _target_component_id{0};
     std::string _root_dir{};


### PR DESCRIPTION
Part 3.9 of an Asio/threading review, plus the write-up. Stacked on #3050.

A burst read spun up a dedicated `std::thread` per session that looped on `try_to_lock(_mutex)` + `yield()` until it got the lock, then sent burst packets as fast as it could. That burns a core while it waits, and it was the last place in `core/` that wrote MAVLink from a thread other than the io thread — which is also why `burst_stop` had to be atomic and why `_target_system_id` / `_target_component_id` are atomics.

`_work_burst()` already runs on the io thread, so the burst can just chain a zero-delay `steady_timer` there instead: one packet per io_context turn, so everything else — including the FTP message that terminates the burst — still gets a turn in between. Stopping is `_burst_timer.cancel()` rather than setting a flag and joining, which also takes the join out of `_reset()`, where it was called with `_mutex` held.

The lock is still taken with `try_to_lock`, but a failure now re-arms the timer for 1 ms instead of spinning, so a user thread holding `_mutex` cannot block the io thread either.

### `core/THREADING.md`

Also adds a short document writing down what the per-file comments have been saying individually: the two threads, the "shared state is io-thread-only, post to mutate" invariant, `post` vs `dispatch`, which unregister variant guarantees what, the lock order, and the teardown ordering the rest depends on.

The intent is that a new contributor can tell when they are about to break one of these, rather than having to reconstruct the rules from comments spread over a dozen files.

### Testing

426/426 unit tests, 102/102 system tests, including the full `Ftp.*` suite (burst downloads, lossy burst downloads, stop-and-retry).

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW