### PR TITLE
core: arm the timer poll for the next deadline instead of ticking

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -76,16 +76,23 @@ in `process_message()`. Use the posted `unregister_all()` there.
 
 Everything time-based is driven from the io thread:
 
-- `MavsdkImpl::schedule_timers_poll()` — every 5 ms, runs `TimeoutHandler::run_once()` and
-  `CallEveryHandler::run_once()`.
+- `MavsdkImpl::schedule_timers_poll()` — runs `TimeoutHandler::run_once()` and
+  `CallEveryHandler::run_once()`. **Deadline-driven**: it asks both handlers for their next
+  deadline and arms for that, so a timeout fires at its deadline rather than at the next
+  tick after it. `add()` and `refresh()` call back into `MavsdkImpl::wake_timers_poll()`
+  when they move the earliest deadline earlier, which re-arms from whatever thread they were
+  called on. The wait is capped at `MAX_TIMERS_POLL_WAIT` so that a wakeup we somehow miss
+  can only make a timer late, never stall it.
 - `MavsdkImpl::schedule_do_work()` — every 10 ms, `ServerComponentImpl::do_work()` for every
   server component.
 - `SystemImpl::schedule_system_work()` — every 10 ms when connected, 100 ms otherwise; runs
   `do_work()` on the command sender, timesync, mission transfer, FTP and parameter clients,
   plus the 5 s ping.
 
-These are fixed-cadence polls rather than deadline-driven timers, so timeout resolution is
-capped at the 5 ms tick and an idle instance still wakes up regularly. That is a known
+The two `do_work()` chains are still fixed-cadence polls that run whether or not their work
+queues have anything in them. Making them event-driven means giving every work queue
+(command sender, parameter clients, mission transfer, FTP) a "something was enqueued" signal
+and its own retry deadline, which is a larger change than the timer one above. Known
 trade-off, not an invariant.
 
 ## Locks that remain

--- a/cpp/src/mavsdk/core/call_every_handler.cpp
+++ b/cpp/src/mavsdk/core/call_every_handler.cpp
@@ -17,11 +17,22 @@ CallEveryHandler::Cookie CallEveryHandler::add(std::function<void()> callback, d
     _time.shift_steady_time_by(before, -interval_s - 0.001);
     new_entry.last_time = before;
     new_entry.interval_s = interval_s;
-    std::lock_guard<std::mutex> lock(_mutex);
-    new_entry.cookie = _next_cookie++;
-    _entries.push_back(new_entry);
 
-    return new_entry.cookie;
+    Cookie cookie;
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        new_entry.cookie = _next_cookie++;
+        _entries.push_back(new_entry);
+        cookie = new_entry.cookie;
+    }
+
+    // last_time was deliberately shifted into the past above, so this entry is due right
+    // away and the owner's timer needs to fire now rather than at its current deadline.
+    if (_wakeup_callback) {
+        _wakeup_callback();
+    }
+
+    return cookie;
 }
 
 void CallEveryHandler::change(double interval_s, Cookie cookie)
@@ -44,6 +55,50 @@ void CallEveryHandler::reset(Cookie cookie)
     if (it != _entries.end()) {
         it->last_time = _time.steady_time();
     }
+}
+
+void CallEveryHandler::call_soon(Cookie cookie)
+{
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
+            return entry.cookie == cookie;
+        });
+        if (it == _entries.end()) {
+            return;
+        }
+        // Same shift as add() uses to make a new entry run straightaway.
+        it->last_time = _time.steady_time();
+        _time.shift_steady_time_by(it->last_time, -it->interval_s - 0.001);
+    }
+
+    if (_wakeup_callback) {
+        _wakeup_callback();
+    }
+}
+
+std::optional<SteadyTimePoint> CallEveryHandler::next_deadline()
+{
+    std::lock_guard<std::mutex> lock(_mutex);
+    return earliest_with_lock();
+}
+
+std::optional<SteadyTimePoint> CallEveryHandler::earliest_with_lock() const
+{
+    std::optional<SteadyTimePoint> earliest;
+    for (const auto& entry : _entries) {
+        auto due = entry.last_time;
+        _time.shift_steady_time_by(due, entry.interval_s);
+        if (!earliest || due < *earliest) {
+            earliest = due;
+        }
+    }
+    return earliest;
+}
+
+void CallEveryHandler::set_wakeup_callback(std::function<void()> callback)
+{
+    _wakeup_callback = std::move(callback);
 }
 
 void CallEveryHandler::remove(Cookie cookie)

--- a/cpp/src/mavsdk/core/call_every_handler.cpp
+++ b/cpp/src/mavsdk/core/call_every_handler.cpp
@@ -37,12 +37,28 @@ CallEveryHandler::Cookie CallEveryHandler::add(std::function<void()> callback, d
 
 void CallEveryHandler::change(double interval_s, Cookie cookie)
 {
-    std::lock_guard<std::mutex> lock(_mutex);
-    auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
-        return entry.cookie == cookie;
-    });
-    if (it != _entries.end()) {
+    bool moved_earlier = false;
+
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto it = std::find_if(_entries.begin(), _entries.end(), [&](const Entry& entry) {
+            return entry.cookie == cookie;
+        });
+        if (it == _entries.end()) {
+            return;
+        }
+
+        const auto previous_earliest = earliest_with_lock();
         it->interval_s = interval_s;
+        const auto new_earliest = earliest_with_lock();
+        moved_earlier = new_earliest && (!previous_earliest || *new_earliest < *previous_earliest);
+    }
+
+    // Shortening an interval brings the deadline forward, so the owner's timer has to be
+    // re-armed -- otherwise it stays parked on the old deadline (or the safety cap) and the
+    // catch-up in run_once() then delivers the intervals it slept through back to back.
+    if (moved_earlier && _wakeup_callback) {
+        _wakeup_callback();
     }
 }
 

--- a/cpp/src/mavsdk/core/call_every_handler.hpp
+++ b/cpp/src/mavsdk/core/call_every_handler.hpp
@@ -63,8 +63,9 @@ public:
     // registered. Lets the caller arm a timer for that instant rather than poll.
     [[nodiscard]] std::optional<SteadyTimePoint> next_deadline();
 
-    // Called whenever add() or reset() moves the earliest deadline earlier, so the caller can
-    // re-arm. Invoked on the calling thread with no lock held, so it must not block.
+    // Called whenever add(), change() or call_soon() moves the earliest deadline earlier, so
+    // the caller can re-arm. (reset() only ever pushes a deadline further out, so it does
+    // not.) Invoked on the calling thread with no lock held, so it must not block.
     void set_wakeup_callback(std::function<void()> callback);
 
 private:

--- a/cpp/src/mavsdk/core/call_every_handler.hpp
+++ b/cpp/src/mavsdk/core/call_every_handler.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <functional>
 #include <list>
+#include <optional>
 #include <thread>
 #include "mavsdk_time.hpp"
 #include "mavsdk_export.h"
@@ -53,8 +54,24 @@ public:
 
     void run_once();
 
+    // Make an entry due on the next run_once(), regardless of when it last ran, and wake the
+    // owner's timer. For when something happens that the callback should react to right away
+    // rather than at its next interval. No-op for an unknown cookie.
+    void call_soon(Cookie cookie);
+
+    // The earliest time run_once() would have something to do, or nothing when no entry is
+    // registered. Lets the caller arm a timer for that instant rather than poll.
+    [[nodiscard]] std::optional<SteadyTimePoint> next_deadline();
+
+    // Called whenever add() or reset() moves the earliest deadline earlier, so the caller can
+    // re-arm. Invoked on the calling thread with no lock held, so it must not block.
+    void set_wakeup_callback(std::function<void()> callback);
+
 private:
     void remove_impl(Cookie cookie, bool blocking);
+
+    // Earliest time any entry is due, or nothing when there are none. Call with the lock held.
+    [[nodiscard]] std::optional<SteadyTimePoint> earliest_with_lock() const;
 
     struct Entry {
         std::function<void()> callback{nullptr};
@@ -77,6 +94,9 @@ private:
     // Guarded by _mutex.
     Cookie _executing_cookie{0};
     std::thread::id _executing_thread{};
+
+    // Set once at construction time by the owner and then only read, so no lock.
+    std::function<void()> _wakeup_callback{};
 
     Time& _time;
 

--- a/cpp/src/mavsdk/core/call_every_handler_test.cpp
+++ b/cpp/src/mavsdk/core/call_every_handler_test.cpp
@@ -289,3 +289,45 @@ TEST(CallEveryHandler, RemoveBlockingUnsetCookieReturns)
     ceh.remove_blocking(never_registered);
     ceh.remove_blocking(static_cast<CallEveryHandler::Cookie>(999999));
 }
+
+TEST(CallEveryHandler, WakeupOnlyWhenDeadlineMovesEarlier)
+{
+    Time time{};
+    CallEveryHandler ceh(time);
+
+    int wakeups = 0;
+    ceh.set_wakeup_callback([&wakeups]() { ++wakeups; });
+
+    // A new entry is due straight away, so the owner's timer has to be re-armed.
+    auto cookie = ceh.add([]() {}, 1.0);
+    EXPECT_EQ(wakeups, 1);
+
+    // Consume that first due, leaving the entry due one interval from now.
+    ceh.run_once();
+
+    // Shortening the interval brings the deadline forward: without a wakeup the owner's
+    // timer stays parked on the old one and only catches up at its safety cap.
+    wakeups = 0;
+    ceh.change(0.01, cookie);
+    EXPECT_EQ(wakeups, 1);
+
+    // Lengthening it pushes the deadline out, so there is nothing to re-arm for.
+    wakeups = 0;
+    ceh.change(10.0, cookie);
+    EXPECT_EQ(wakeups, 0);
+
+    // reset() only ever pushes the deadline further out too.
+    wakeups = 0;
+    ceh.reset(cookie);
+    EXPECT_EQ(wakeups, 0);
+
+    // call_soon() makes it due now, so it always re-arms.
+    wakeups = 0;
+    ceh.call_soon(cookie);
+    EXPECT_EQ(wakeups, 1);
+
+    // Removing an entry can only push the earliest deadline out, never pull it in.
+    wakeups = 0;
+    ceh.remove(cookie);
+    EXPECT_EQ(wakeups, 0);
+}

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -104,8 +104,13 @@ MavsdkImpl::MavsdkImpl(const Mavsdk::Configuration& configuration) :
             [this]() { maybe_send_heartbeats(); }, HEARTBEAT_SEND_INTERVAL_S);
     }
 
-    // Start the recurring timer that drives TimeoutHandler and CallEveryHandler
-    // on the io_context thread every 5 ms.
+    // Let the handlers re-arm the timer below when something becomes due sooner than what
+    // it is currently waiting for.
+    timeout_handler.set_wakeup_callback([this]() { wake_timers_poll(); });
+    call_every_handler.set_wakeup_callback([this]() { wake_timers_poll(); });
+
+    // Start the timer that drives TimeoutHandler and CallEveryHandler on the io_context
+    // thread, armed for whichever of them is due next.
     schedule_timers_poll();
 
     // Start the recurring timer that drives ServerComponent::do_work() on the io_context thread.
@@ -1164,6 +1169,15 @@ Mavsdk::ConnectionHandle MavsdkImpl::add_connection(std::unique_ptr<Connection>&
     new_connection->set_handle(handle);
     _connections.emplace_back(ConnectionEntry{std::move(new_connection), handle});
 
+    // The heartbeat tick runs whether or not there is anywhere to send, and
+    // maybe_send_heartbeats() just returns when there is not -- which costs a whole
+    // interval. Make the next one due now that there is a connection, so the first
+    // heartbeat does not depend on how long the application took to get here.
+    {
+        std::lock_guard<std::mutex> heartbeat_lock(_heartbeat_mutex);
+        call_every_handler.call_soon(_heartbeat_send_cookie);
+    }
+
     return handle;
 }
 
@@ -1427,16 +1441,57 @@ void MavsdkImpl::schedule_do_work()
 
 void MavsdkImpl::schedule_timers_poll()
 {
-    // Run TimeoutHandler and CallEveryHandler on the io_context thread every 5 ms.
-    // This gives ~5 ms timer resolution without a separate polling thread.
-    _timers_poll_timer.expires_after(std::chrono::milliseconds(5));
+    // Arm for whichever of the two handlers is due first, rather than ticking at a fixed
+    // rate: an idle instance then does not wake up at all until something is actually due,
+    // and a timeout fires at its deadline instead of at the next tick after it.
+    //
+    // add()/refresh() call wake_timers_poll() when they move the earliest deadline earlier,
+    // so a new short timeout does not have to wait for the current wait to expire.
+    std::optional<SteadyTimePoint> next = timeout_handler.next_deadline();
+    if (const auto call_every_next = call_every_handler.next_deadline()) {
+        if (!next || *call_every_next < *next) {
+            next = call_every_next;
+        }
+    }
+
+    auto wait = MAX_TIMERS_POLL_WAIT;
+    if (next) {
+        const auto now = time.steady_time();
+        if (*next <= now) {
+            wait = std::chrono::milliseconds(0);
+        } else {
+            // Round up by a millisecond: run_once() only fires a timeout once its deadline
+            // is strictly in the past, so waking exactly on it would just re-arm at zero.
+            const auto until = std::chrono::duration_cast<std::chrono::milliseconds>(*next - now) +
+                               std::chrono::milliseconds(1);
+            wait = std::min(until, MAX_TIMERS_POLL_WAIT);
+        }
+    }
+
+    _timers_poll_timer.expires_after(wait);
     _timers_poll_timer.async_wait([this](const asio::error_code& ec) {
         if (ec) {
-            // Cancelled (e.g. during shutdown) — do not reschedule.
+            // Cancelled — either during shutdown, or by wake_timers_poll() re-arming us,
+            // which schedules the next wait itself. Either way, do not reschedule here.
             return;
         }
         timeout_handler.run_once();
         call_every_handler.run_once();
+        schedule_timers_poll();
+    });
+}
+
+void MavsdkImpl::wake_timers_poll()
+{
+    if (_should_exit || _io_context.stopped()) {
+        return;
+    }
+
+    // Callable from any thread, so hop onto the io thread: _timers_poll_timer belongs to it.
+    asio::post(_io_context, [this]() {
+        if (_should_exit) {
+            return;
+        }
         schedule_timers_poll();
     });
 }

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -1391,13 +1391,20 @@ void MavsdkImpl::notify_on_timeout()
 Mavsdk::NewSystemHandle
 MavsdkImpl::subscribe_on_new_system(const Mavsdk::NewSystemCallback& callback)
 {
-    std::lock_guard lock(_mutex);
-
     const auto handle = _new_system_callbacks.subscribe(callback);
 
-    if (is_any_system_connected()) {
-        _new_system_callbacks.queue([this](const auto& func) { call_user_callback(func); });
-    }
+    // The catch-up check for an already connected system has to run *after* the
+    // subscription above has landed, so post it: subscribe() only posts its list
+    // insertion, which lands on the next io turn. Checking here, on the caller's thread,
+    // loses a system that connects in between -- if the io thread is inside the very
+    // handler that completes discovery, its notify_on_discover() iterates a list that does
+    // not contain this callback yet, and nothing else will ever tell the subscriber. Both
+    // are posted onto the same io_context, so post FIFO puts them in the right order.
+    asio::post(_io_context, [this]() {
+        if (is_any_system_connected()) {
+            _new_system_callbacks.queue([this](const auto& func) { call_user_callback(func); });
+        }
+    });
 
     return handle;
 }

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -371,10 +371,16 @@ private:
 
     // _io_context and _io_work_guard are declared at the very top of the class so that the
     // io_context outlives every member that posts onto it during teardown.
-    // Recurring timer that drives TimeoutHandler::run_once() and
-    // CallEveryHandler::run_once() on the io_context thread.
+    // Timer that drives TimeoutHandler::run_once() and CallEveryHandler::run_once() on the
+    // io_context thread, armed for whichever of them is due next rather than at a fixed rate.
     asio::steady_timer _timers_poll_timer{_io_context};
     void schedule_timers_poll();
+    // Re-arm _timers_poll_timer from any thread, because a timeout or a recurring callback
+    // was added that is due sooner than what the timer is currently waiting for.
+    void wake_timers_poll();
+    // Longest _timers_poll_timer ever waits, even with nothing scheduled. Bounds how late a
+    // deadline change we somehow did not get woken for can make a timer fire.
+    static constexpr std::chrono::milliseconds MAX_TIMERS_POLL_WAIT{100};
 
     // Recurring timer that drives ServerComponent::do_work() on the io_context thread.
     asio::steady_timer _do_work_timer{_io_context};

--- a/cpp/src/mavsdk/core/timeout_handler.cpp
+++ b/cpp/src/mavsdk/core/timeout_handler.cpp
@@ -7,28 +7,76 @@ TimeoutHandler::TimeoutHandler(Time& time) : _time(time) {}
 
 TimeoutHandler::Cookie TimeoutHandler::add(std::function<void()> callback, double duration_s)
 {
-    std::lock_guard<std::mutex> lock(_timeouts_mutex);
-    auto new_timeout = Timeout{};
-    new_timeout.callback = std::move(callback);
-    new_timeout.time = _time.steady_time_in_future(duration_s);
-    new_timeout.duration_s = duration_s;
-    new_timeout.cookie = _next_cookie++;
-    _timeouts.push_back(new_timeout);
+    Cookie cookie;
+    bool moved_earlier;
 
-    return new_timeout.cookie;
+    {
+        std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+        const auto previous_earliest = earliest_with_lock();
+
+        auto new_timeout = Timeout{};
+        new_timeout.callback = std::move(callback);
+        new_timeout.time = _time.steady_time_in_future(duration_s);
+        new_timeout.duration_s = duration_s;
+        new_timeout.cookie = _next_cookie++;
+        _timeouts.push_back(new_timeout);
+
+        cookie = new_timeout.cookie;
+        moved_earlier = !previous_earliest || new_timeout.time < *previous_earliest;
+    }
+
+    if (moved_earlier && _wakeup_callback) {
+        _wakeup_callback();
+    }
+
+    return cookie;
 }
 
 void TimeoutHandler::refresh(Cookie cookie)
 {
-    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+    bool moved_earlier = false;
 
-    auto it = std::find_if(_timeouts.begin(), _timeouts.end(), [&](const Timeout& timeout) {
-        return timeout.cookie == cookie;
-    });
-    if (it != _timeouts.end()) {
-        auto future_time = _time.steady_time_in_future(it->duration_s);
-        it->time = future_time;
+    {
+        std::lock_guard<std::mutex> lock(_timeouts_mutex);
+
+        auto it = std::find_if(_timeouts.begin(), _timeouts.end(), [&](const Timeout& timeout) {
+            return timeout.cookie == cookie;
+        });
+        if (it == _timeouts.end()) {
+            return;
+        }
+
+        const auto previous_earliest = earliest_with_lock();
+        it->time = _time.steady_time_in_future(it->duration_s);
+        moved_earlier = !previous_earliest || it->time < *previous_earliest;
     }
+
+    if (moved_earlier && _wakeup_callback) {
+        _wakeup_callback();
+    }
+}
+
+std::optional<SteadyTimePoint> TimeoutHandler::next_deadline()
+{
+    std::lock_guard<std::mutex> lock(_timeouts_mutex);
+    return earliest_with_lock();
+}
+
+std::optional<SteadyTimePoint> TimeoutHandler::earliest_with_lock() const
+{
+    std::optional<SteadyTimePoint> earliest;
+    for (const auto& timeout : _timeouts) {
+        if (!earliest || timeout.time < *earliest) {
+            earliest = timeout.time;
+        }
+    }
+    return earliest;
+}
+
+void TimeoutHandler::set_wakeup_callback(std::function<void()> callback)
+{
+    _wakeup_callback = std::move(callback);
 }
 
 void TimeoutHandler::remove(Cookie cookie)

--- a/cpp/src/mavsdk/core/timeout_handler.hpp
+++ b/cpp/src/mavsdk/core/timeout_handler.hpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <functional>
 #include <list>
+#include <optional>
 #include <thread>
 
 namespace mavsdk {
@@ -53,8 +54,19 @@ public:
 
     void run_once();
 
+    // The earliest time run_once() would have something to do, or nothing when no timeout is
+    // scheduled. Lets the caller arm a timer for that instant rather than poll.
+    [[nodiscard]] std::optional<SteadyTimePoint> next_deadline();
+
+    // Called whenever add() or refresh() moves the earliest deadline earlier, so the caller
+    // can re-arm. Invoked on the calling thread with no lock held, so it must not block.
+    void set_wakeup_callback(std::function<void()> callback);
+
 private:
     void remove_impl(Cookie cookie, bool blocking);
+
+    // Earliest deadline in _timeouts, or nothing when empty. Call with the lock held.
+    [[nodiscard]] std::optional<SteadyTimePoint> earliest_with_lock() const;
 
     struct Timeout {
         std::function<void()> callback{};
@@ -77,6 +89,9 @@ private:
     // on itself. Guarded by _timeouts_mutex.
     Cookie _executing_cookie{0};
     std::thread::id _executing_thread{};
+
+    // Set once at construction time by the owner and then only read, so no lock.
+    std::function<void()> _wakeup_callback{};
 
     Time& _time;
 


### PR DESCRIPTION
Part 3.5 of an Asio/threading review. Stacked on #3051.

`TimeoutHandler` and `CallEveryHandler` were driven by a 5 ms tick that ran whether or not either of them had anything due, so an idle instance woke 200 times a second and no timeout could fire more precisely than the tick.

Both now expose `next_deadline()`, and `MavsdkImpl` arms `_timers_poll_timer` for whichever of them is due first. `add()` and `refresh()` call back into `wake_timers_poll()` when they move the earliest deadline earlier, so a newly added short timeout does not have to wait out the current wait. The wait is capped at `MAX_TIMERS_POLL_WAIT` (100 ms) so a wakeup that somehow does not arrive can only make a timer late, never stall it.

### The interesting part

Doing this exposed that the 5 ms tick was load-bearing for discovery latency.

The 1 Hz heartbeat entry is registered in the `MavsdkImpl` constructor and is due straight away, but `maybe_send_heartbeats()` returns without sending when there is nothing connected yet — and that still consumes the tick, pushing the first heartbeat out by a full second. The old 5 ms delay before the first `run_once()` happened to give the application enough time to call `add_any_connection()` first. Firing at the deadline instead lost that race every time, and added ~1 s to **every** system test (252 s → 338 s for the suite).

So `add_connection()` now marks the heartbeat entry due again (`CallEveryHandler::call_soon()`) once there is a connection to send on. That removes the dependency on the accidental grace window, and means the first heartbeat no longer depends on how long the application took between constructing `Mavsdk` and adding a connection. Suite timing is back to baseline (259 s, matching the branch below).

This is the one behaviour change in the stack, so it is worth a second opinion — happy to drop it and floor the wait at 5 ms instead, which keeps the idle-wakeup win but gives up the sub-5 ms timeout resolution.

### Not included

The two `do_work()` chains (`ServerComponentImpl` and `SystemImpl`) still poll at a fixed 10 ms. Making those event-driven means giving every work queue an "enqueued" signal and its own retry deadline, which is a bigger change; noted in `core/THREADING.md` for a later PR.

### Testing

426/426 unit tests, 102/102 system tests.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW