### PR TITLE
core: drive the work queues from events instead of polling

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -83,17 +83,35 @@ Everything time-based is driven from the io thread:
   when they move the earliest deadline earlier, which re-arms from whatever thread they were
   called on. The wait is capped at `MAX_TIMERS_POLL_WAIT` so that a wakeup we somehow miss
   can only make a timer late, never stall it.
-- `MavsdkImpl::schedule_do_work()` — every 10 ms, `ServerComponentImpl::do_work()` for every
-  server component.
-- `SystemImpl::schedule_system_work()` — every 10 ms when connected, 100 ms otherwise; runs
-  `do_work()` on the command sender, timesync, mission transfer, FTP and parameter clients,
-  plus the 5 s ping.
+- `SystemImpl::schedule_ping()` — the 5 s ping, as a `CallEveryHandler` entry.
+- `Timesync` registers its own `CallEveryHandler` entry in `enable()`.
 
-The two `do_work()` chains are still fixed-cadence polls that run whether or not their work
-queues have anything in them. Making them event-driven means giving every work queue
-(command sender, parameter clients, mission transfer, FTP) a "something was enqueued" signal
-and its own retry deadline, which is a larger change than the timer one above. Known
-trade-off, not an invariant.
+Nothing polls any more. The protocol handlers used to be driven by two fixed-cadence
+`do_work()` chains (`ServerComponentImpl` at 10 ms, `SystemImpl` at 10/100 ms) that ran
+whether or not their queues had anything in them. Each work queue now runs its own
+`do_work()` when something happens to it instead:
+
+- **On enqueue** — every queue already did this (`if (was_empty) do_work();` inside the
+  posted enqueue). `MavlinkCommandSender` is the exception and kicks unconditionally,
+  because its `do_work()` walks the whole queue rather than just the front item.
+- **On completion** — the FTP client, the parameter client and the parameter server already
+  posted `do_work()` wherever they retired an item.
+
+Two places did not, and needed the poll to make progress:
+
+- `MavlinkMissionTransferClient` / `...Server` only retire the front item once it reports
+  `is_done()`, and nothing told them when that became true. `WorkItem::set_done()` now
+  notifies the owner. It runs with the item's `_mutex` held (every caller reaches it through
+  `callback_and_reset()`, which holds it), so the notification must only *post* — never
+  block, and never call `do_work()` inline, since retiring the item drops the last reference
+  to the object we are standing on.
+- `MavlinkCommandSender::do_work()` skips a queued command while another with the same
+  command id is in flight, and nothing re-ran it when the first one finished. Both
+  `receive_command_ack()` and `receive_timeout()` now post one.
+
+**If you add a work queue, or a path that retires an item, it has to kick `do_work()`
+itself.** There is no periodic sweep left to cover for a missing one — the symptom is work
+that sits in the queue forever.
 
 ## Locks that remain
 

--- a/cpp/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/cpp/src/mavsdk/core/mavlink_command_sender.cpp
@@ -113,11 +113,11 @@ void MavlinkCommandSender::queue_command_async(
                 return;
             }
         }
-        const bool was_empty = _work_queue.empty();
         _work_queue.push_back(new_work);
-        if (was_empty) {
-            do_work();
-        }
+        // Unconditional, unlike the other work queues: do_work() here walks the whole queue
+        // and sends everything not sent yet, so a command queued behind another one still
+        // needs it to run.
+        do_work();
     });
 }
 
@@ -150,11 +150,11 @@ void MavlinkCommandSender::queue_command_async(
                 return;
             }
         }
-        const bool was_empty = _work_queue.empty();
         _work_queue.push_back(new_work);
-        if (was_empty) {
-            do_work();
-        }
+        // Unconditional, unlike the other work queues: do_work() here walks the whole queue
+        // and sends everything not sent yet, so a command queued behind another one still
+        // needs it to run.
+        do_work();
     });
 }
 
@@ -306,6 +306,10 @@ void MavlinkCommandSender::receive_command_ack(const mavlink_message_t& message)
             call_callback(temp_callback, temp_result.first, temp_result.second);
         }
 
+        // This command may have been blocking another queued one with the same command id,
+        // which do_work() skips while the first is in flight.
+        asio::post(_io_context, [this] { do_work(); });
+
         return;
     }
 
@@ -412,6 +416,10 @@ void MavlinkCommandSender::receive_timeout(const CommandIdentification& identifi
     if (temp_callback != nullptr) {
         call_callback(temp_callback, temp_result.first, temp_result.second);
     }
+
+    // Same as in receive_command_ack(): giving up on a command can unblock another queued
+    // one with the same command id.
+    asio::post(_io_context, [this] { do_work(); });
 
     if (!found_command) {
         LogWarn(

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client.cpp
@@ -56,6 +56,11 @@ MavlinkMissionTransferClient::upload_items_async(
         _autopilot_callback());
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -93,6 +98,11 @@ MavlinkMissionTransferClient::download_items_async(
         target_system_id);
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -117,6 +127,11 @@ void MavlinkMissionTransferClient::clear_items_async(
         target_system_id);
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -139,6 +154,11 @@ void MavlinkMissionTransferClient::set_current_item_async(
         target_system_id);
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -192,6 +212,29 @@ bool MavlinkMissionTransferClient::WorkItem::has_started()
 {
     std::lock_guard<std::mutex> lock(_mutex);
     return _started;
+}
+
+void MavlinkMissionTransferClient::WorkItem::set_done_callback(std::function<void()> callback)
+{
+    // Set on the io thread when the item is enqueued, before anything can start it.
+    _done_callback = std::move(callback);
+}
+
+void MavlinkMissionTransferClient::WorkItem::set_done()
+{
+    // No lock here: every caller reaches this through callback_and_reset(), which already
+    // holds _mutex. That is also why the callback must only post and never block -- it runs
+    // with _mutex held, and the do_work() it schedules calls is_done(), which takes it.
+    // Posting is required for a second reason: retiring this item drops the last reference
+    // to it, which must not happen while we are still on its stack.
+    if (_done) {
+        return;
+    }
+    _done = true;
+
+    if (_done_callback) {
+        _done_callback();
+    }
 }
 
 bool MavlinkMissionTransferClient::WorkItem::is_done()
@@ -587,7 +630,7 @@ void MavlinkMissionTransferClient::UploadWorkItem::callback_and_reset(Result res
         _callback(result);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 
 void MavlinkMissionTransferClient::UploadWorkItem::update_progress(float progress)
@@ -835,7 +878,7 @@ void MavlinkMissionTransferClient::DownloadWorkItem::callback_and_reset(Result r
         _callback(result, _items);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 
 void MavlinkMissionTransferClient::DownloadWorkItem::update_progress(float progress)
@@ -984,7 +1027,7 @@ void MavlinkMissionTransferClient::ClearWorkItem::callback_and_reset(Result resu
         _callback(result);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 
 void MavlinkMissionTransferClient::set_int_messages_supported(bool supported)
@@ -1106,6 +1149,6 @@ void MavlinkMissionTransferClient::SetCurrentWorkItem::callback_and_reset(Result
         _callback(result);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_client.hpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_client.hpp
@@ -87,6 +87,11 @@ public:
         bool has_started();
         bool is_done();
 
+        // Called once, on the io thread, when this item has finished, so that the queue
+        // owner can retire it and start the next one instead of polling is_done(). Set by
+        // the owner when the item is enqueued.
+        void set_done_callback(std::function<void()> callback);
+
         WorkItem(const WorkItem&) = delete;
         WorkItem(WorkItem&&) = delete;
         WorkItem& operator=(const WorkItem&) = delete;
@@ -98,8 +103,13 @@ public:
         TimeoutHandler& _timeout_handler;
         uint8_t _type;
         double _timeout_s;
+        // Mark this item finished and notify the owner. Must be the last thing a work item
+        // does: the notification lets the owner drop the last reference to it.
+        void set_done();
+
         bool _started{false};
         bool _done{false};
+        std::function<void()> _done_callback{};
         std::mutex _mutex{};
         bool _debugging;
     };

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.cpp
@@ -45,6 +45,11 @@ MavlinkMissionTransferServer::receive_incoming_items_async(
         _debugging);
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -76,6 +81,11 @@ MavlinkMissionTransferServer::send_outgoing_items_async(
         _debugging);
 
     asio::post(_io_context, [this, ptr]() {
+        // do_work() only retires the front item once it reports done, so the item has to
+        // say when that happens -- otherwise the queue sits on a finished item until
+        // something else happens to call do_work().
+        ptr->set_done_callback([this]() { asio::post(_io_context, [this] { do_work(); }); });
+
         const bool was_empty = _work_queue.empty();
         _work_queue.push_back(ptr);
         if (was_empty) {
@@ -131,6 +141,29 @@ bool MavlinkMissionTransferServer::WorkItem::has_started()
 {
     std::lock_guard<std::mutex> lock(_mutex);
     return _started;
+}
+
+void MavlinkMissionTransferServer::WorkItem::set_done_callback(std::function<void()> callback)
+{
+    // Set on the io thread when the item is enqueued, before anything can start it.
+    _done_callback = std::move(callback);
+}
+
+void MavlinkMissionTransferServer::WorkItem::set_done()
+{
+    // No lock here: every caller reaches this through callback_and_reset(), which already
+    // holds _mutex. That is also why the callback must only post and never block -- it runs
+    // with _mutex held, and the do_work() it schedules calls is_done(), which takes it.
+    // Posting is required for a second reason: retiring this item drops the last reference
+    // to it, which must not happen while we are still on its stack.
+    if (_done) {
+        return;
+    }
+    _done = true;
+
+    if (_done_callback) {
+        _done_callback();
+    }
 }
 
 bool MavlinkMissionTransferServer::WorkItem::is_done()
@@ -335,7 +368,7 @@ void MavlinkMissionTransferServer::ReceiveIncomingMission::callback_and_reset(Re
         _callback(result, _type, _items);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 
 MavlinkMissionTransferServer::SendOutgoingMission::SendOutgoingMission(
@@ -667,7 +700,7 @@ void MavlinkMissionTransferServer::SendOutgoingMission::callback_and_reset(Resul
         _callback(result);
     }
     _callback = nullptr;
-    _done = true;
+    set_done();
 }
 
 } // namespace mavsdk

--- a/cpp/src/mavsdk/core/mavlink_mission_transfer_server.hpp
+++ b/cpp/src/mavsdk/core/mavlink_mission_transfer_server.hpp
@@ -85,6 +85,11 @@ public:
         bool has_started();
         bool is_done();
 
+        // Called once, on the io thread, when this item has finished, so that the queue
+        // owner can retire it and start the next one instead of polling is_done(). Set by
+        // the owner when the item is enqueued.
+        void set_done_callback(std::function<void()> callback);
+
         WorkItem(const WorkItem&) = delete;
         WorkItem(WorkItem&&) = delete;
         WorkItem& operator=(const WorkItem&) = delete;
@@ -96,8 +101,13 @@ public:
         TimeoutHandler& _timeout_handler;
         uint8_t _type;
         double _timeout_s;
+        // Mark this item finished and notify the owner. Must be the last thing a work item
+        // does: the notification lets the owner drop the last reference to it.
+        void set_done();
+
         bool _started{false};
         bool _done{false};
+        std::function<void()> _done_callback{};
         std::mutex _mutex{};
         bool _debugging;
     };

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -113,9 +113,6 @@ MavsdkImpl::MavsdkImpl(const Mavsdk::Configuration& configuration) :
     // thread, armed for whichever of them is due next.
     schedule_timers_poll();
 
-    // Start the recurring timer that drives ServerComponent::do_work() on the io_context thread.
-    schedule_do_work();
-
     // Start the Asio io_context on its own thread.  All async I/O completions,
     // message dispatch, and timer callbacks are dispatched here.
     _io_thread = std::make_unique<std::thread>([this]() {
@@ -1419,30 +1416,6 @@ bool MavsdkImpl::is_any_system_connected() const
     std::vector<std::shared_ptr<System>> connected_systems = systems();
     return std::any_of(connected_systems.cbegin(), connected_systems.cend(), [](auto& system) {
         return system->is_connected();
-    });
-}
-
-void MavsdkImpl::schedule_do_work()
-{
-    // Drive ServerComponent protocol-handler state machines (command sender, parameter client,
-    // mission transfer, FTP client, …) on the io_context thread every 10 ms.
-    // Using dispatch() would execute immediately on first call but we want a timer-driven cadence,
-    // so async_wait is correct here — same pattern as schedule_timers_poll().
-    _do_work_timer.expires_after(std::chrono::milliseconds(10));
-    _do_work_timer.async_wait([this](const asio::error_code& ec) {
-        if (ec) {
-            // Cancelled (e.g. during shutdown) — do not reschedule.
-            return;
-        }
-        {
-            std::lock_guard lock(_server_components_mutex);
-            for (auto& it : _server_components) {
-                if (it.second != nullptr) {
-                    it.second->_impl->do_work();
-                }
-            }
-        }
-        schedule_do_work();
     });
 }
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -382,10 +382,6 @@ private:
     // deadline change we somehow did not get woken for can make a timer fire.
     static constexpr std::chrono::milliseconds MAX_TIMERS_POLL_WAIT{100};
 
-    // Recurring timer that drives ServerComponent::do_work() on the io_context thread.
-    asio::steady_timer _do_work_timer{_io_context};
-    void schedule_do_work();
-
     std::unique_ptr<std::thread> _io_thread{};
     // The io thread's own id, recorded by the thread itself when it starts. Asserts use
     // this instead of asio's running_in_this_thread(), whose thread-local is instantiated

--- a/cpp/src/mavsdk/core/server_component_impl.cpp
+++ b/cpp/src/mavsdk/core/server_component_impl.cpp
@@ -161,12 +161,6 @@ void ServerComponentImpl::process_libmav_message(const Mavsdk::MavlinkMessage& m
         message, [this](const std::function<void()>& callback) { callback(); });
 }
 
-void ServerComponentImpl::do_work()
-{
-    _mavlink_parameter_server.do_work();
-    _mission_transfer_server.do_work();
-}
-
 Sender& ServerComponentImpl::sender()
 {
     return _our_sender;

--- a/cpp/src/mavsdk/core/server_component_impl.hpp
+++ b/cpp/src/mavsdk/core/server_component_impl.hpp
@@ -189,7 +189,6 @@ public:
     }
     MavlinkFtpServer& mavlink_ftp_server() { return _mavlink_ftp_server; }
 
-    void do_work();
 
     Sender& sender();
 

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -28,7 +28,6 @@ SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
     // ctor parameter rather than the not-yet-bound _mavsdk_impl reference.
     _mavlink_message_handler(mavsdk_impl.io_context()),
     _mavsdk_impl(mavsdk_impl),
-    _system_work_timer(mavsdk_impl.io_context()),
     _command_sender(*this),
     _timesync(*this),
     _ping(*this),
@@ -49,13 +48,14 @@ SystemImpl::SystemImpl(MavsdkImpl& mavsdk_impl) :
         }
     }
 
-    schedule_system_work();
+    schedule_ping();
 }
 
 SystemImpl::~SystemImpl()
 {
     _should_exit = true;
-    _system_work_timer.cancel();
+    // Blocking, so the ping tick cannot be running while we tear the rest down.
+    remove_call_every_blocking(_ping_cookie);
     // Use blocking version to ensure any in-flight callbacks complete before destruction.
     _mavlink_message_handler.unregister_all_blocking(this);
     // Clear all libmav message callbacks
@@ -414,38 +414,19 @@ void SystemImpl::heartbeats_timed_out()
     set_disconnected();
 }
 
-void SystemImpl::schedule_system_work()
+void SystemImpl::schedule_ping()
 {
-    // Run do_work() on all protocol handlers at 100 Hz when connected, 10 Hz otherwise.
-    // By running on the io_context thread we eliminate all data races on the work queues.
-    auto delay = _connected ? std::chrono::milliseconds(10) : std::chrono::milliseconds(100);
-    _system_work_timer.expires_after(delay);
-    _system_work_timer.async_wait([this](const asio::error_code& ec) {
-        if (ec) {
-            // Timer was cancelled (shutdown) — stop rescheduling.
-            return;
-        }
-
-        {
-            std::lock_guard<std::mutex> lock(_mavlink_parameter_clients_mutex);
-            for (auto& entry : _mavlink_parameter_clients) {
-                entry.parameter_client->do_work();
-            }
-        }
-        _command_sender.do_work();
-        _timesync.do_work();
-        _mission_transfer_client.do_work();
-        _mavlink_ftp_client.do_work();
-
-        if (_mavsdk_impl.time.elapsed_since_s(_last_ping_time) >= SystemImpl::_ping_interval_s) {
+    // The protocol handlers (command sender, parameter clients, mission transfer, FTP) used
+    // to be driven from here at 10 ms whether or not they had anything queued. They now run
+    // their do_work() when something is enqueued and when an item finishes, so all that is
+    // left on a timer is the ping, which is genuinely periodic.
+    _ping_cookie = add_call_every(
+        [this]() {
             if (_connected && _autopilot != Autopilot::ArduPilot) {
                 _ping.run_once();
             }
-            _last_ping_time = _mavsdk_impl.time.steady_time();
-        }
-
-        schedule_system_work();
-    });
+        },
+        static_cast<float>(SystemImpl::_ping_interval_s));
 }
 
 std::string SystemImpl::component_name(uint8_t component_id)

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -342,11 +342,7 @@ public:
 
     double timeout_s() const;
 
-    void signal_exit()
-    {
-        _should_exit = true;
-        _system_work_timer.cancel();
-    }
+    void signal_exit() { _should_exit = true; }
 
 private:
     static bool is_autopilot(uint8_t comp_id);
@@ -362,7 +358,7 @@ private:
     static std::string component_name(uint8_t component_id);
     static ComponentType component_type(uint8_t component_id);
 
-    void schedule_system_work();
+    void schedule_ping();
 
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
     make_command_flight_mode(FlightMode mode, uint8_t component_id);
@@ -420,8 +416,7 @@ private:
     // Libmav message handling using CallbackList for thread safety
     CallbackList<Mavsdk::MavlinkMessage> _libmav_message_callbacks{io_context()};
 
-    asio::steady_timer _system_work_timer;
-    SteadyTimePoint _last_ping_time{};
+    CallEveryHandler::Cookie _ping_cookie{};
     std::atomic<bool> _should_exit{false};
 
     std::atomic<bool> _connected{false};

--- a/cpp/src/mavsdk/core/timesync.cpp
+++ b/cpp/src/mavsdk/core/timesync.cpp
@@ -11,35 +11,45 @@ Timesync::Timesync(SystemImpl& parent) : _system_impl(parent) {}
 
 Timesync::~Timesync()
 {
-    // Blocking, so that no message can be dispatched into us while we are destroyed.
+    // Blocking variants, so that neither the tick nor a message can be dispatched into us
+    // while we are being destroyed.
+    _system_impl.remove_call_every_blocking(_send_cookie);
     _system_impl.unregister_all_mavlink_message_handlers_blocking(this);
 }
 
 void Timesync::enable()
 {
+    if (_is_enabled) {
+        // System::enable_timesync() is public API and used to be idempotent, so keep it that
+        // way: registering the tick twice would double the timesync rate and leak a cookie.
+        return;
+    }
+
     _is_enabled = true;
     _system_impl.register_mavlink_message_handler(
         MAVLINK_MSG_ID_TIMESYNC,
         [this](const mavlink_message_t& message) { process_timesync(message); },
         this);
+
+    // This used to be a do_work() that compared elapsed time on every pass of the system
+    // work poll. It is just a fixed interval, so let CallEveryHandler keep the time.
+    _send_cookie = _system_impl.add_call_every(
+        [this]() { send_timesync_tick(); }, static_cast<float>(TIMESYNC_SEND_INTERVAL_S));
 }
 
-void Timesync::do_work()
+void Timesync::send_timesync_tick()
 {
     if (!_is_enabled) {
         return;
     }
 
-    if (_system_impl.get_time().elapsed_since_s(_last_time) >= TIMESYNC_SEND_INTERVAL_S) {
-        if (_system_impl.is_connected()) {
-            uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                  _system_impl.get_autopilot_time().now().time_since_epoch())
-                                  .count();
-            send_timesync(0, now_ns);
-        } else {
-            _autopilot_timesync_acquired = false;
-        }
-        _last_time = _system_impl.get_time().steady_time();
+    if (_system_impl.is_connected()) {
+        uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              _system_impl.get_autopilot_time().now().time_since_epoch())
+                              .count();
+        send_timesync(0, now_ns);
+    } else {
+        _autopilot_timesync_acquired = false;
     }
 }
 

--- a/cpp/src/mavsdk/core/timesync.hpp
+++ b/cpp/src/mavsdk/core/timesync.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "call_every_handler.hpp"
 #include "mavsdk_time.hpp"
 #include "mavlink_include.hpp"
 
@@ -13,7 +14,6 @@ public:
     ~Timesync();
 
     void enable();
-    void do_work();
 
     Timesync(const Timesync&) = delete;
     Timesync& operator=(const Timesync&) = delete;
@@ -25,8 +25,10 @@ private:
     void send_timesync(uint64_t tc1, uint64_t ts1);
     void set_timesync_offset(int64_t offset_ns, uint64_t start_transfer_local_time_ns);
 
+    void send_timesync_tick();
+
     static constexpr double TIMESYNC_SEND_INTERVAL_S = 5.0;
-    SteadyTimePoint _last_time{};
+    CallEveryHandler::Cookie _send_cookie{};
 
     static constexpr uint64_t MAX_CONS_HIGH_RTT = 5;
     static constexpr uint64_t MAX_RTT_SAMPLE_MS = 10;


### PR DESCRIPTION
The follow-up promised in #3052. Stacked on it.

The protocol handlers were driven by two fixed-cadence timers that ran whether or not anything was queued:

- `ServerComponentImpl::do_work()` every 10 ms
- `SystemImpl`'s chain every 10 ms connected / 100 ms otherwise — command sender, timesync, mission transfer, FTP and parameter clients, plus the 5 s ping

Both are gone.

### It was mostly already event-driven

This turned out much smaller than expected. Every enqueue path already did `if (was_empty) do_work();` inside its posted lambda, and the FTP client, the parameter client and the parameter server already posted `do_work()` wherever they retired an item. Only two things actually needed the poll:

**`MavlinkMissionTransferClient` / `...Server`** only retire the front item once it reports `is_done()`, and nothing told them when that became true — the 10 ms poll was what noticed. `WorkItem::set_done()` now notifies the owner.

Two things worth knowing about that notification, both commented at the definition:
- it does **not** take `_mutex`, because every caller reaches it through `callback_and_reset()`, which already holds it (I got this wrong first and deadlocked the mission-transfer unit tests)
- it must only **post**, never call `do_work()` inline — retiring the item drops the last reference to the object we are standing on

**`MavlinkCommandSender::do_work()`** walks the whole queue rather than just the front item, and skips a command while another with the same command id is in flight. So its enqueue kick is now unconditional, and `receive_command_ack()` / `receive_timeout()` post one when they retire an item that may have been blocking another.

### The genuinely periodic bits

Timesync and the ping were the only real periodic work in those loops, and they are now `CallEveryHandler` entries — which are deadline-driven after #3052, so they cost nothing while idle. `Timesync::enable()` keeps its old idempotence explicitly, since `System::enable_timesync()` is public API and registering the tick twice would double the rate.

### Measured

An idle instance holding one unused `udpin` connection, counting context switches across all threads over 10 s:

| | wakeups/s |
|---|---|
| `async-resolve` (before this series) | 291.4 |
| deadline-driven timers (#3052) | 108.5 |
| this PR | 10.3 |

The residual 10/s is `MAX_TIMERS_POLL_WAIT`, the 100 ms safety cap on the timer poll from #3052. If we end up trusting the wakeup contract, raising that cap is where the next order of magnitude is.

### The risk, stated plainly

There is no periodic sweep left to cover for a missing kick. If a new work queue — or a new path that retires an item — forgets to run `do_work()`, the symptom is work sitting in the queue forever rather than being a bit late. `THREADING.md` says so explicitly.

I considered keeping a slow (1 Hz) safety-net poll so a missed kick degrades to latency instead of a stall. I left it out because a hidden 1 s stall is worse to debug than an obvious hang, but I'm happy to add it if you'd rather have the belt and braces.

### Testing

427/427 unit tests, 102/102 system tests. Suite runtime unchanged (258 s vs 258 s on the branch below), which is the main signal that nothing quietly fell back to a slower path.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW