### PR TITLE
CI: print a symbolized backtrace for core dumps from failing tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -295,11 +295,18 @@ jobs:
         run: cmake --build examples/build -j$(nproc)
       - name: unit tests
         run: ./build/release/src/unit_tests/unit_tests_runner
+        env:
+          MALLOC_PERTURB_: "165"
       - name: system tests
         run: ./build/release/src/system_tests/system_tests_runner
         timeout-minutes: 15
+        env:
+          MALLOC_PERTURB_: "165"
       - name: test (mavsdk_server)
         run: ./build/release/src/mavsdk_server/test/unit_tests_mavsdk_server
+      - name: analyze core dumps
+        if: failure()
+        run: tools/analyze_core_dumps.sh build/release
       - name: upload core dumps
         if: failure()
         uses: actions/upload-artifact@v7
@@ -508,9 +515,16 @@ jobs:
         run: cmake --build build/release -- -j$(nproc)
       - name: unit tests
         run: ./build/release/src/unit_tests/unit_tests_runner
+        env:
+          MALLOC_PERTURB_: "165"
       - name: system tests
         run: ./build/release/src/system_tests/system_tests_runner
         timeout-minutes: 15
+        env:
+          MALLOC_PERTURB_: "165"
+      - name: analyze core dumps
+        if: failure()
+        run: tools/analyze_core_dumps.sh build/release
       - name: upload core dumps
         if: failure()
         uses: actions/upload-artifact@v7

--- a/cpp/tools/analyze_core_dumps.sh
+++ b/cpp/tools/analyze_core_dumps.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Print a symbolized backtrace for any core dumps a failing test run left behind.
+#
+# Without this, a crash in CI shows up as a bare "Segmentation fault (core dumped)" and the
+# only way to find out what happened is to download the core plus the matching binaries and
+# reconstruct the container's libraries by hand. The core is still uploaded as an artifact
+# for deeper digging; this just makes the common case readable straight from the log.
+#
+# Usage: tools/analyze_core_dumps.sh [build-dir]   (default: build/release)
+
+set -u
+
+build_dir=${1:-build/release}
+
+shopt -s nullglob
+cores=(/tmp/core.*)
+if [ ${#cores[@]} -eq 0 ]; then
+    echo "No core dumps found."
+    exit 0
+fi
+
+if ! command -v gdb > /dev/null 2>&1; then
+    echo "gdb not installed, installing it to analyze $((${#cores[@]})) core dump(s)..."
+    if command -v apt-get > /dev/null 2>&1; then
+        (apt-get update -qq && apt-get install -y -qq gdb) > /dev/null 2>&1 ||
+            (sudo apt-get update -qq && sudo apt-get install -y -qq gdb) > /dev/null 2>&1
+    elif command -v apk > /dev/null 2>&1; then
+        apk add --no-cache gdb > /dev/null 2>&1 || sudo apk add --no-cache gdb > /dev/null 2>&1
+    fi
+fi
+
+if ! command -v gdb > /dev/null 2>&1; then
+    echo "Could not install gdb; the core dumps are still uploaded as an artifact."
+    exit 0
+fi
+
+# The core pattern is /tmp/core.%h.%e.%t, so %e gives the executable -- truncated to 15
+# characters by the kernel, which is why this matches on a prefix.
+find_binary() {
+    local core_name exe_field candidate
+    core_name=$(basename "$1")
+    exe_field=$(echo "$core_name" | cut -d. -f3)
+
+    for candidate in \
+        "$build_dir/src/system_tests/system_tests_runner" \
+        "$build_dir/src/unit_tests/unit_tests_runner" \
+        "$build_dir/src/system_tests/standalone_param_test" \
+        "$build_dir/src/system_tests/standalone_ftp_test"; do
+        if [ -x "$candidate" ] && [ "${exe_field}" = "$(basename "$candidate" | cut -c1-15)" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+for core in "${cores[@]}"; do
+    echo
+    echo "================================================================"
+    echo "Core dump: $core"
+    echo "================================================================"
+
+    binary=$(find_binary "$core") || {
+        echo "Could not work out which binary produced this core, skipping."
+        continue
+    }
+    echo "Binary: $binary"
+    echo
+
+    # 'thread apply all bt' covers the ordinary case. The stack dump below covers the one it
+    # cannot: when the crash is a jump through a corrupted pointer, frame #0 is '?? ()' and
+    # gdb has nothing to unwind from, but the return addresses are still sitting on the
+    # stack and 'info symbol' on them reconstructs the call chain by hand.
+    gdb -nx -batch \
+        -ex "set auto-load safe-path /" \
+        -ex "set print frame-arguments scalars" \
+        -ex "thread apply all bt full" \
+        -ex "echo \n=== crashing thread: registers and raw stack ===\n" \
+        -ex "info registers rip rsp rbp" \
+        -ex "x/64a \$rsp" \
+        "$binary" "$core" 2>&1 || true
+done


### PR DESCRIPTION
Independent of the threading stack (#3049–#3054), based on `main` so it can go in on its own.

### Why

A crash in CI currently looks like this, and nothing more:

```
[ RUN      ] Camera.DefinitionUncompressed
...
Segmentation fault (core dumped)
##[error]Process completed with exit code 139.
```

The core and the test binaries *are* uploaded as artifacts, which is good — but turning them into a stack means downloading both, reconstructing the container's libraries into a sysroot (the core references paths and glibc/libstdc++ versions the host does not have), and driving gdb by hand. I just did that for a Debian 12 failure and it took a while.

### What

On failure, install gdb and print `thread apply all bt full` for every `/tmp/core.*` the run left behind. Artifacts are still uploaded for deeper digging; this makes the common case readable straight from the log.

The script also dumps the crashing thread's registers and raw stack, which covers the case gdb's unwinder cannot. When a crash is a jump through a corrupted pointer, frame #0 is `?? ()` and there is nothing to unwind from — but the return addresses are still sitting on the stack, and gdb symbolizes them in the `x/64a` output:

```
#0  0x000000025912aae4 in ?? ()
=== crashing thread: registers and raw stack ===
0x7ffe132ccbe0: ... <mavsdk::Camera::Camera(std::shared_ptr<mavsdk::System>)+88>
0x7ffe132ccc10: ... <Camera_DefinitionUncompressed_Test::TestBody()+1910>
```

That is what identified the recent Debian 12 crash as heap corruption reached through `Camera::Camera()` → `operator new`, rather than a fault in the constructor itself. Without it there is no way to tell those apart from the log.

### MALLOC_PERTURB_

Also set for the unit and system test runs in the same two jobs. glibc then fills freed memory with a fixed byte pattern, so a use-after-free read tends to fail loudly and near the bug instead of quietly working most of the time.

It costs nothing at build time and, unlike `MALLOC_CHECK_`, does not change the heap layout — so it should not hide the very corruption it is meant to surface. It may well surface pre-existing latent issues; that is the point, but worth knowing before merging.

### Scope

Only the two jobs that already collect core dumps are covered (`ubuntu-superbuild` and `deb-package`). Enabling it elsewhere is a matter of adding the same "configure core dumps" step those two have — happy to widen it if you want more chances to catch a rare crash.

### Testing

Ran the script against the actual core dump and binaries from https://github.com/mavlink/MAVSDK/actions/runs/33327086338/job/99299064821, and it reproduces the stack above. Also checked the no-core-dumps path exits 0 quietly, so the step is harmless on a non-crash failure.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW