### PR TITLE
core: stop the io thread calling into plugins user code is destroying

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -31,6 +31,9 @@ That is what removes most of the locking. Concretely:
   already on the io thread.
 - The work queues in `MavlinkCommandSender`, the mission transfer classes, the FTP client and
   the parameter clients are io-thread-only; enqueuing from elsewhere is posted.
+- `SystemImpl::_plugin_impls` is io-thread-only, and so is every `enable()`/`disable()` call.
+  See **Plugin lifetime** below -- this one is load-bearing, because the entries are raw
+  pointers to objects that user code owns and destroys.
 
 `MavlinkMessageHandler` and `MavlinkParameterSubscription` each have a debug-only
 `note_*_thread()` that records the accessing `std::thread::id` and asserts if it ever changes.
@@ -113,6 +116,34 @@ Two places did not, and needed the poll to make progress:
 itself.** There is no periodic sweep left to cover for a missing one — the symptom is work
 that sits in the queue forever.
 
+## Plugin lifetime
+
+Plugins are the one place where the io thread holds a bare pointer to an object *user code*
+owns: `SystemImpl::_plugin_impls` is a `std::vector<PluginImplBase*>`, and the plugin is
+destroyed on whatever thread the user drops it on. Meanwhile the io thread calls `enable()` on
+every entry when the system connects and `disable()` when it times out.
+
+So the registry is io-thread-only, and the two ends are asymmetric on purpose:
+
+- `register_plugin()` **posts** the insertion (and the `if (_connected) enable()` that goes
+  with it). Posting rather than waiting means a plugin constructor can never block on the io
+  thread. Doing the `_connected` test there, rather than on the caller's thread, is what makes
+  it atomic against `set_connected()`/`set_disconnected()` — otherwise a plugin registering
+  just as the system connects gets `enable()`d twice, or not at all.
+- `unregister_plugin()` **posts and waits** for the removal, and only then calls `disable()`
+  and `deinit()`. Once the removal has run, the io thread cannot reach the plugin and any
+  `enable()`/`disable()` it had started has finished, because the removal is serialized behind
+  them on that same thread.
+
+Both of those matter. Before they were in place, ThreadSanitizer reported two races on a
+plugin's own members in `system_tests/plugin_lifetime_churn.cpp`: `register_plugin()` calling
+`enable()` on the caller's thread against the io thread's `disable()`, and the io thread's
+`enable()` against a user thread inside the plugin's destructor. The second is a
+use-after-free waiting to happen.
+
+**If you add anything else the io thread reaches through a raw pointer into user-owned memory,
+it needs the same treatment.**
+
 ## Locks that remain
 
 Locks are for state genuinely reachable from user threads. The order is documented where the
@@ -126,8 +157,8 @@ members are declared in `mavsdk_impl.hpp`; the summary:
   `send_heartbeats()` would take `_server_components_mutex` then `_mutex`, inverting the io
   thread's order.
 
-Per-connection and per-system locks (`_send_mutex`, `_remote_mutex`, `_components_mutex`,
-`_plugin_impls_mutex`, …) are local to their object and do not participate in the order above.
+Per-connection and per-system locks (`_send_mutex`, `_remote_mutex`, `_components_mutex`, …)
+are local to their object and do not participate in the order above.
 
 ## Teardown
 

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -664,14 +664,10 @@ void SystemImpl::set_connected()
             send_autopilot_version_request();
         }
 
-        // Enable plugins
-        std::vector<PluginImplBase*> plugin_impls_to_enable;
-        {
-            std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
-            plugin_impls_to_enable = _plugin_impls;
-        }
-
-        for (auto plugin_impl : plugin_impls_to_enable) {
+        // Enable plugins. No lock and no copy: _plugin_impls is only touched on this
+        // thread, and a plugin cannot go away underneath us because unregister_plugin()
+        // removes it from here, on this thread, before it tears the plugin down.
+        for (auto plugin_impl : _plugin_impls) {
             plugin_impl->enable();
         }
     }
@@ -691,11 +687,10 @@ void SystemImpl::set_disconnected()
     }
     _mavsdk_impl.notify_on_timeout();
 
-    {
-        std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
-        for (auto plugin_impl : _plugin_impls) {
-            plugin_impl->disable();
-        }
+    // Same as in set_connected(): the registry belongs to this thread, so no lock. Dropping
+    // it also removes the _plugin_impls_mutex -> plugin-lock nesting this used to create.
+    for (auto plugin_impl : _plugin_impls) {
+        plugin_impl->disable();
     }
 }
 
@@ -1330,38 +1325,81 @@ SystemImpl::make_command_msg_rate(uint16_t message_id, double rate_hz, uint8_t c
     return command;
 }
 
+void SystemImpl::run_on_io_thread(const std::function<void()>& task, bool wait)
+{
+    auto& io_context = _mavsdk_impl.io_context();
+
+    if (io_context.stopped() || _mavsdk_impl.on_io_thread()) {
+        // Either nothing else can be running any more, or we already are the thread that
+        // owns this state. Run inline -- posting and waiting would wait for ourselves.
+        task();
+        return;
+    }
+
+    if (!wait) {
+        asio::post(io_context, task);
+        return;
+    }
+
+    std::promise<void> done;
+    asio::post(io_context, [&task, &done]() {
+        task();
+        done.set_value();
+    });
+    done.get_future().wait();
+}
+
 void SystemImpl::register_plugin(PluginImplBase* plugin_impl)
 {
     assert(plugin_impl);
 
+    // init() only posts its registrations, so it is safe from any thread and keeps the
+    // ordering it has always had.
     plugin_impl->init();
 
-    {
-        std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
-        _plugin_impls.push_back(plugin_impl);
-    }
+    // _plugin_impls, and every enable()/disable() call, belong to the io thread -- see
+    // unregister_plugin() for why. Posted rather than posted-and-waited so that a plugin
+    // constructor can never block on the io thread: the only cost is that enable() lands an
+    // io turn later.
+    run_on_io_thread(
+        [this, plugin_impl]() {
+            _plugin_impls.push_back(plugin_impl);
 
-    // If we're connected already, let's enable it straightaway.
-    if (_connected) {
-        plugin_impl->enable();
-    }
+            // Testing _connected here rather than on the caller's thread makes the insertion
+            // and the test atomic with respect to set_connected()/set_disconnected(), which
+            // run on this same thread. Done on the caller's thread, a plugin registering just
+            // as the system connects could be enabled twice -- by this path and by
+            // set_connected()'s loop -- or by neither.
+            if (_connected) {
+                plugin_impl->enable();
+            }
+        },
+        false);
 }
 
 void SystemImpl::unregister_plugin(PluginImplBase* plugin_impl)
 {
     assert(plugin_impl);
 
+    // Take the plugin out of the registry first, and wait for that to happen. Once this
+    // returns, the io thread can no longer reach the plugin, and any enable()/disable() it
+    // had already started has finished -- the removal is serialized behind them on that same
+    // thread. Only then is it safe to tear the plugin down from here.
+    //
+    // This is what stops the io thread calling into a plugin that a user thread is
+    // destroying, and what stops unregister_plugin()'s disable() below from running
+    // concurrently with set_disconnected()'s.
+    run_on_io_thread(
+        [this, plugin_impl]() {
+            auto found = std::find(_plugin_impls.begin(), _plugin_impls.end(), plugin_impl);
+            if (found != _plugin_impls.end()) {
+                _plugin_impls.erase(found);
+            }
+        },
+        true);
+
     plugin_impl->disable();
     plugin_impl->deinit();
-
-    // Remove first, so it won't get enabled/disabled anymore.
-    {
-        std::lock_guard<std::mutex> lock(_plugin_impls_mutex);
-        auto found = std::find(_plugin_impls.begin(), _plugin_impls.end(), plugin_impl);
-        if (found != _plugin_impls.end()) {
-            _plugin_impls.erase(found);
-        }
-    }
 }
 
 void SystemImpl::call_user_callback_located(

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -360,6 +360,12 @@ private:
 
     void schedule_ping();
 
+    // Run task on the io thread. Runs inline when already there, or when the io_context has
+    // stopped and nothing else can be running. With wait set, does not return until the task
+    // has run -- which is what makes removal from _plugin_impls a real barrier against the io
+    // thread. Do not wait while holding a lock the io thread needs.
+    void run_on_io_thread(const std::function<void()>& task, bool wait);
+
     std::pair<MavlinkCommandSender::Result, MavlinkCommandSender::CommandLong>
     make_command_flight_mode(FlightMode mode, uint8_t component_id);
 
@@ -444,7 +450,11 @@ private:
     MavlinkFtpClient _mavlink_ftp_client;
     MavlinkComponentMetadata _mavlink_component_metadata;
 
-    std::mutex _plugin_impls_mutex{};
+    // Only touched on the io thread (or during teardown, once the io_context is stopped),
+    // so no mutex. register_plugin()/unregister_plugin() hop over there via
+    // run_on_io_thread(); set_connected()/set_disconnected() already run there. This is what
+    // keeps the io thread from calling enable()/disable() on a plugin that user code is
+    // destroying -- the entries are raw pointers to objects the user owns.
     std::vector<PluginImplBase*> _plugin_impls{};
 
     // We used set to maintain unique component ids

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(system_tests_runner
     telemetry_rc_status.cpp
     geofence_download.cpp
     heartbeat_watchdog.cpp
+    plugin_lifetime_churn.cpp
     telemetry_home_position.cpp
     request_message_rapid.cpp
     fs_helpers.cpp

--- a/cpp/src/system_tests/plugin_lifetime_churn.cpp
+++ b/cpp/src/system_tests/plugin_lifetime_churn.cpp
@@ -1,0 +1,111 @@
+#include "log.hpp"
+#include "mavsdk.hpp"
+#include "mavlink_include.hpp"
+#include "plugins/telemetry/telemetry.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+using namespace std::chrono_literals;
+
+// Plugins are owned by user code and destroyed on a user thread, while SystemImpl calls
+// enable()/disable() on them from the io thread when the system connects and disconnects.
+// SystemImpl keeps them as raw PluginImplBase*, so those two things have to be serialized
+// against each other -- otherwise the io thread can call into a plugin that a user thread is
+// in the middle of destroying, and unregister_plugin()'s disable() can run concurrently with
+// set_disconnected()'s.
+//
+// Nothing else in the suite creates and destroys plugins while the link goes up and down, so
+// this exercises that specific overlap. It is a race, so a plain build passing proves little;
+// the point is to give ThreadSanitizer something to look at. Run it under TSan (and ASan).
+
+namespace {
+
+// Short enough that a gap in the heartbeats disconnects us quickly, so the test can flap the
+// link many times without taking forever.
+constexpr double heartbeat_timeout_s = 0.05;
+constexpr auto silence_for_disconnect = 90ms;
+
+// Churn for a fixed duration rather than a fixed number of rounds, so that the plugin
+// lifetimes and the link flaps overlap for the whole run instead of one outlasting the other.
+constexpr auto churn_duration = 5s;
+
+std::vector<char> make_heartbeat()
+{
+    mavlink_message_t message;
+    mavlink_msg_heartbeat_pack_chan(
+        1, // system id of the "autopilot" we are pretending to hear from
+        MAV_COMP_ID_AUTOPILOT1,
+        MAVLINK_COMM_NUM_BUFFERS - 1,
+        &message,
+        MAV_TYPE_QUADROTOR,
+        MAV_AUTOPILOT_PX4,
+        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+        0,
+        MAV_STATE_STANDBY);
+
+    std::vector<uint8_t> buffer(MAVLINK_MAX_PACKET_LEN);
+    const auto length = mavlink_msg_to_send_buffer(buffer.data(), &message);
+
+    return std::vector<char>(buffer.begin(), buffer.begin() + length);
+}
+
+} // namespace
+
+TEST(PluginLifetime, ChurnPluginsWhileLinkFlaps)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    ASSERT_EQ(mavsdk_groundstation.add_any_connection("raw://"), ConnectionResult::Success);
+
+    mavsdk_groundstation.set_heartbeat_timeout_s(heartbeat_timeout_s);
+
+    const auto heartbeat = make_heartbeat();
+
+    std::atomic<bool> stop{false};
+    std::atomic<unsigned> flaps{0};
+
+    // Drive the link up and down: a burst of heartbeats connects the system (io thread runs
+    // set_connected() -> enable() on every plugin), then silence times it out
+    // (set_disconnected() -> disable() on every plugin).
+    std::thread flapper([&]() {
+        while (!stop) {
+            for (int i = 0; i < 2 && !stop; ++i) {
+                mavsdk_groundstation.pass_received_raw_bytes(heartbeat.data(), heartbeat.size());
+                std::this_thread::sleep_for(10ms);
+            }
+            std::this_thread::sleep_for(silence_for_disconnect);
+            ++flaps;
+        }
+    });
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system) << "system never showed up";
+    auto system = maybe_system.value();
+
+    // Meanwhile, create and destroy a plugin over and over on this thread. Telemetry is a
+    // good candidate: enable() registers a call_every and disable() removes it, so both
+    // touch the same members the io thread would.
+    unsigned rounds = 0;
+    const auto deadline = std::chrono::steady_clock::now() + churn_duration;
+    while (std::chrono::steady_clock::now() < deadline && !::testing::Test::HasFailure()) {
+        Telemetry telemetry{system};
+
+        // Keep each plugin alive for less than a flap cycle, and vary it, so that the
+        // destructor lands at many different points relative to the connect and disconnect
+        // transitions rather than settling into lockstep with them.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1 + (rounds % 17)));
+        ++rounds;
+    }
+
+    stop = true;
+    flapper.join();
+
+    LogInfo("Completed {} plugin rounds over {} link flaps", rounds, flaps.load());
+
+    // The system must still be usable: nothing should have been torn down that shouldn't be.
+    EXPECT_NE(system->get_system_id(), 0);
+}


### PR DESCRIPTION
Stacked on #3054. This is the remaining structural hole from the threading review: the one place where the io thread holds a bare pointer into memory that *user code* owns.

### The problem

`SystemImpl` keeps plugins as `std::vector<PluginImplBase*>`. They are owned by user code (`Telemetry telemetry{system};`) and destroyed on whatever thread the user drops them on — while the io thread calls `enable()` on every entry when the system connects and `disable()` when it times out. Nothing serialized those two things.

### Reproducing it first

`system_tests/plugin_lifetime_churn.cpp` creates and destroys a `Telemetry` plugin in a loop while a second thread flaps the link — injected heartbeats over a `raw://` connection plus a 50 ms heartbeat timeout give ~46 connect/disconnect transitions across ~500 plugin lifetimes in five seconds.

Against the unfixed code, ThreadSanitizer reports two races on `TelemetryImpl::_homepos_cookie`:

1. `register_plugin()` calling `enable()` **on the caller's thread**, against the io thread's `set_disconnected() → disable()`
2. the io thread's `set_connected() → enable()`, against the **main thread inside `~TelemetryImpl → unregister_plugin()`**

The second is the use-after-free, caught one step before it lands.

### The fix

`_plugin_impls`, and every `enable()`/`disable()` call, now belong to the io thread. The two ends are deliberately asymmetric:

- **`register_plugin()` posts** the insertion and the `if (_connected) enable()` that goes with it. Posting rather than waiting means a plugin constructor can never block on the io thread; the only cost is that `enable()` lands an io turn later. Testing `_connected` *there* rather than on the caller's thread also makes it atomic against `set_connected()`/`set_disconnected()` — done on the caller's thread, a plugin registering just as the system connects could be enabled twice (by both paths) or not at all (by neither). Neither of those is a crash, which is why they'd have been unpleasant to find.
- **`unregister_plugin()` posts the removal and waits**, then calls `disable()`/`deinit()`. Once the removal has run, the io thread cannot reach the plugin and any `enable()`/`disable()` it had started has finished, because the removal is serialized behind them on that same thread.

`set_connected()`/`set_disconnected()` then iterate directly, so `_plugin_impls_mutex` goes away — along with the `_plugin_impls_mutex → plugin-lock` nesting `set_disconnected()` used to create.

No plugin signatures change, so none of the 38 plugins needed editing. `ServerComponentImpl::register_plugin` keeps no registry at all (it just calls `init()`/`deinit()`), so the server side is unaffected.

### Worth a second opinion

- I chose **post** over **post-and-wait** for registration, which means a plugin is enabled one io turn after its constructor returns rather than synchronously. I checked that no plugin's `enable()` body blocks, so either variant is deadlock-free today; posting removes the possibility that a future one could. If you'd rather keep construction strictly synchronous, waiting is a one-line change.
- `unregister_plugin()` now waits on the io thread. That is the same rule as every other `*_blocking` in the codebase — the caller must not hold a lock the io thread needs — and plugin destructors are already subject to it via `deinit()`. But it moves the wait earlier, before `disable()`.
- Ordering changed from disable-then-erase to erase-then-disable. I believe that is strictly more correct, but it is a behaviour change.

### Testing

- New test: **2 TSan races before, 0 after**.
- Full system suite under TSan: **103/103, 0 warnings**.
- Plain: 103/103 system, 427/427 unit.

`core/THREADING.md` gains a "Plugin lifetime" section explaining why the asymmetry exists, so the next person doesn't "simplify" it back.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW