### PR TITLE
core: abort with an explanation when something outlives its Mavsdk

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -144,6 +144,21 @@ use-after-free waiting to happen.
 **If you add anything else the io thread reaches through a raw pointer into user-owned memory,
 it needs the same treatment.**
 
+## Object lifetime
+
+`System`, `ServerComponent` and every plugin hold a reference back into `MavsdkImpl`, so none
+of them may outlive the `Mavsdk` instance they came from. That is not just a rule about
+*using* them afterwards: `~SystemImpl` itself reaches back in (`remove_call_every_blocking()`,
+`unregister_timeout_handler_blocking()`), so a leaked `System` is a use-after-free even if it
+is never touched again.
+
+Since there is no harmless version of getting it wrong, `~MavsdkImpl` looks for outstanding
+references and aborts with an explanation rather than leaving a segfault to surface elsewhere
+later — see `MavsdkImpl::abort_if_references_outlive_us()` and
+`system_tests/mavsdk_outlived.cpp`. Note that a couple of those references are our own
+(`_default_server_component` points at an entry that is also in `_server_components`), so the
+check compares against a baseline rather than against 1.
+
 ## Locks that remain
 
 Locks are for state genuinely reachable from user threads. The order is documented where the

--- a/cpp/src/mavsdk/core/include/mavsdk/mavsdk.hpp
+++ b/cpp/src/mavsdk/core/include/mavsdk/mavsdk.hpp
@@ -170,6 +170,11 @@ public:
      * @brief Get a vector of systems which have been discovered or set-up.
      *
      * @return The vector of systems which are available.
+     *
+     * @note The returned System must not outlive this Mavsdk instance. It holds a reference
+     *       back into it, so using a System after its Mavsdk is gone is a use-after-free,
+     *       and so is merely letting it be destroyed. The same applies to any plugin
+     *       constructed from it.
      */
     std::vector<std::shared_ptr<System>> systems() const;
 
@@ -184,6 +189,11 @@ public:
      *                  A negative timeout will wait forever.
      *
      * @return A system or nothing if nothing was discovered within the timeout.
+     *
+     * @note The returned System must not outlive this Mavsdk instance. It holds a reference
+     *       back into it, so using a System after its Mavsdk is gone is a use-after-free,
+     *       and so is merely letting it be destroyed. The same applies to any plugin
+     *       constructed from it.
      */
     std::optional<std::shared_ptr<System>> first_autopilot(double timeout_s) const;
 
@@ -513,6 +523,10 @@ public:
      *
      * @return A valid shared pointer to a server component if it was successful, an empty pointer
      * otherwise.
+     *
+     * @note The returned ServerComponent must not outlive this Mavsdk instance. It holds a
+     *       reference back into it, so using one after its Mavsdk is gone is a
+     *       use-after-free, and so is merely letting it be destroyed.
      */
     std::shared_ptr<ServerComponent> server_component(unsigned instance = 0);
 

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -1,5 +1,7 @@
 #include "mavsdk_impl.hpp"
 
+#include <cstdio>
+#include <cstdlib>
 #include <asio/dispatch.hpp>
 #include <asio/post.hpp>
 
@@ -156,8 +158,76 @@ MavsdkImpl::~MavsdkImpl()
         pair.second->_system_impl->signal_exit();
     }
 
+    abort_if_references_outlive_us();
+
     _systems.clear();
     _connections.clear();
+}
+
+void MavsdkImpl::abort_if_references_outlive_us()
+{
+    // Everything handed out by systems(), first_autopilot() and server_component() keeps a
+    // raw reference back to this MavsdkImpl, so none of it may outlive us. There is no
+    // harmless version of getting this wrong: SystemImpl's *destructor* alone reaches back
+    // in here (remove_call_every_blocking(), unregister_timeout_handler_blocking()), so even
+    // a reference that is never used again is a use-after-free when it finally goes away.
+    //
+    // Since it is fatal either way, say so here -- where we can still name the mistake --
+    // rather than leaving a segfault somewhere else later.
+    unsigned dangling_systems = 0;
+    unsigned dangling_system_impls = 0;
+    unsigned dangling_server_components = 0;
+
+    for (auto& pair : _systems) {
+        // One reference is the entry in _systems itself.
+        if (pair.second.use_count() > 1) {
+            ++dangling_systems;
+        }
+        // And one is System's own member. Anything beyond that is a plugin, or a caller who
+        // kept what System::system_impl() handed them.
+        if (pair.second->_system_impl.use_count() > 1) {
+            ++dangling_system_impls;
+        }
+    }
+
+    for (auto& pair : _server_components) {
+        if (pair.second == nullptr) {
+            continue;
+        }
+        // One reference is the entry in _server_components. _default_server_component points
+        // at one of them as well, so that entry legitimately has two of our own.
+        const auto ours = (pair.second == _default_server_component) ? 2 : 1;
+        if (pair.second.use_count() > ours) {
+            ++dangling_server_components;
+        }
+    }
+
+    if (dangling_systems == 0 && dangling_system_impls == 0 && dangling_server_components == 0) {
+        return;
+    }
+
+    LogErr("Mavsdk is being destroyed while things it handed out are still alive:");
+    if (dangling_systems > 0) {
+        LogErr(
+            "  - {} System(s) still referenced (from systems() or first_autopilot())",
+            dangling_systems);
+    }
+    if (dangling_system_impls > 0) {
+        LogErr("  - {} System(s) still referenced by a plugin", dangling_system_impls);
+    }
+    if (dangling_server_components > 0) {
+        LogErr("  - {} ServerComponent(s) still referenced", dangling_server_components);
+    }
+    // One complete sentence per line, so each stands on its own in a log and can be grepped.
+    LogErr("A System, a ServerComponent or a plugin must not outlive the Mavsdk instance.");
+    LogErr("They hold a reference back into it, so using one afterwards -- or merely letting "
+           "it be destroyed -- is a use-after-free.");
+    LogErr("Keep the Mavsdk instance alive at least as long as everything obtained from it.");
+    LogErr("Aborting now: continuing would crash later and much less clearly.");
+
+    fflush(stdout);
+    fflush(stderr);
+    std::abort();
 }
 
 std::string MavsdkImpl::version()

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -393,6 +393,14 @@ public:
     // Whether the caller is the io_context thread. Only meant for asserts and for picking
     // between an inline and a posted path, not for synchronisation.
     bool on_io_thread() const;
+
+private:
+    // Called at the very end of ~MavsdkImpl: complains and aborts if a System, a
+    // ServerComponent or a plugin is still alive, since all of them hold a reference back
+    // into this object. See the definition for why this is fatal rather than merely wrong.
+    void abort_if_references_outlive_us();
+
+public:
 };
 
 } // namespace mavsdk

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(system_tests_runner
     geofence_download.cpp
     heartbeat_watchdog.cpp
     plugin_lifetime_churn.cpp
+    mavsdk_outlived.cpp
     telemetry_home_position.cpp
     request_message_rapid.cpp
     fs_helpers.cpp

--- a/cpp/src/system_tests/mavsdk_outlived.cpp
+++ b/cpp/src/system_tests/mavsdk_outlived.cpp
@@ -1,0 +1,107 @@
+#include "mavsdk.hpp"
+#include "mavlink_include.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+// Everything Mavsdk hands out -- System, ServerComponent, and any plugin built on one --
+// holds a reference back into MavsdkImpl, so none of it may outlive the Mavsdk instance.
+// ~MavsdkImpl detects that and aborts rather than leaving a use-after-free to surface
+// somewhere else later; see MavsdkImpl::abort_if_references_outlive_us().
+//
+// These check that the detector actually fires, and with the message it is supposed to.
+// Without them the check is untested, and the risk with a check like this is not that it
+// fails to fire but that it fires when it should not -- the rest of the suite covers that
+// side, by constructing systems and plugins in a hundred different shapes without tripping
+// it.
+//
+// Death tests fork, which is not safe in a threaded program, so ask for the "threadsafe"
+// style: gtest re-executes this binary for the child instead of forking.
+
+namespace {
+
+std::vector<char> make_heartbeat()
+{
+    mavlink_message_t message;
+    mavlink_msg_heartbeat_pack_chan(
+        1,
+        MAV_COMP_ID_AUTOPILOT1,
+        MAVLINK_COMM_NUM_BUFFERS - 1,
+        &message,
+        MAV_TYPE_QUADROTOR,
+        MAV_AUTOPILOT_PX4,
+        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+        0,
+        MAV_STATE_STANDBY);
+
+    std::vector<uint8_t> buffer(MAVLINK_MAX_PACKET_LEN);
+    const auto length = mavlink_msg_to_send_buffer(buffer.data(), &message);
+
+    return std::vector<char>(buffer.begin(), buffer.begin() + length);
+}
+
+} // namespace
+
+TEST(MavsdkOutlived, AbortsWhenSystemIsStillHeld)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    EXPECT_DEATH(
+        {
+            std::shared_ptr<System> leaked;
+            {
+                Mavsdk mavsdk{Mavsdk::Configuration{ComponentType::GroundStation}};
+                mavsdk.add_any_connection("raw://");
+
+                const auto heartbeat = make_heartbeat();
+
+                // Keep them coming rather than sending one: the first heartbeat is what
+                // creates the system, and SystemImpl::init() registers its own HEARTBEAT
+                // handler with a posted registration, so that first message is not yet
+                // delivered to it and does not mark the system connected. A real autopilot
+                // sends at 1 Hz, so this is what actually happens anyway.
+                std::atomic<bool> stop{false};
+                std::thread beater([&]() {
+                    while (!stop) {
+                        mavsdk.pass_received_raw_bytes(heartbeat.data(), heartbeat.size());
+                        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                    }
+                });
+
+                auto maybe_system = mavsdk.first_autopilot(5.0);
+                stop = true;
+                beater.join();
+
+                // No ASSERT here: inside a death-test statement it expands to a return,
+                // which gtest rejects. If the system never showed up, `leaked` stays empty
+                // and the missing abort fails the test on its own.
+                if (maybe_system) {
+                    leaked = maybe_system.value();
+                }
+            }
+            // Leaving that scope destroys the Mavsdk instance while `leaked` still refers
+            // into it, which has to be caught here rather than when `leaked` goes away.
+        },
+        "must not outlive the Mavsdk instance");
+}
+
+TEST(MavsdkOutlived, AbortsWhenServerComponentIsStillHeld)
+{
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    EXPECT_DEATH(
+        {
+            std::shared_ptr<ServerComponent> leaked;
+            {
+                Mavsdk mavsdk{Mavsdk::Configuration{ComponentType::Autopilot}};
+                leaked = mavsdk.server_component();
+            }
+        },
+        "must not outlive the Mavsdk instance");
+}

--- a/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
+++ b/docs/en/cpp/api_reference/classmavsdk_1_1_mavsdk.md
@@ -377,6 +377,9 @@ std::vector< std::shared_ptr< System > > mavsdk::Mavsdk::systems() const
 
 Get a vector of systems which have been discovered or set-up.
 
+::: info
+The returned [System](classmavsdk_1_1_system.md) must not outlive this [Mavsdk](classmavsdk_1_1_mavsdk.md) instance. It holds a reference back into it, so using a [System](classmavsdk_1_1_system.md) after its [Mavsdk](classmavsdk_1_1_mavsdk.md) is gone is a use-after-free, and so is merely letting it be destroyed. The same applies to any plugin constructed from it.
+:::
 
 **Returns**
 
@@ -392,6 +395,11 @@ Get the first autopilot that has been discovered.
 
 ::: info
 This requires a MAVLink component with component ID 1 sending heartbeats.
+:::
+
+
+::: info
+The returned [System](classmavsdk_1_1_system.md) must not outlive this [Mavsdk](classmavsdk_1_1_mavsdk.md) instance. It holds a reference back into it, so using a [System](classmavsdk_1_1_system.md) after its [Mavsdk](classmavsdk_1_1_mavsdk.md) is gone is a use-after-free, and so is merely letting it be destroyed. The same applies to any plugin constructed from it.
 :::
 
 **Parameters**
@@ -558,6 +566,9 @@ std::shared_ptr< ServerComponent > mavsdk::Mavsdk::server_component(unsigned ins
 
 Get server component with default type of [Mavsdk](classmavsdk_1_1_mavsdk.md) instance.
 
+::: info
+The returned [ServerComponent](classmavsdk_1_1_server_component.md) must not outlive this [Mavsdk](classmavsdk_1_1_mavsdk.md) instance. It holds a reference back into it, so using one after its [Mavsdk](classmavsdk_1_1_mavsdk.md) is gone is a use-after-free, and so is merely letting it be destroyed.
+:::
 
 **Parameters**
 


### PR DESCRIPTION
Stacked on #3056. This is hole 2 from the threading review: `System`, `ServerComponent` and every plugin hold a raw reference back into `MavsdkImpl`, nothing said so, and nothing checked.

### Why abort rather than just log

I'd normally argue against a library killing the host process. The argument doesn't hold here, and the reason is specific:

`~SystemImpl` reaches back into `MavsdkImpl` *by itself* — `remove_call_every_blocking()`, `unregister_timeout_handler_blocking()`. So this isn't only about *using* a leaked `System`; merely letting one be destroyed after its `Mavsdk` is already a use-after-free. There is no "held it but never touched it" case that works today.

That means aborting breaks no working program. It only converts programs that would have segfaulted somewhere unrelated later into ones that stop immediately, at the point where we can still name the mistake:

```
Mavsdk is being destroyed while things it handed out are still alive:
  - 1 System(s) still referenced (from systems() or first_autopilot())
A System, a ServerComponent or a plugin must not outlive the Mavsdk instance.
They hold a reference back into it, so using one afterwards -- or merely letting it
be destroyed -- is a use-after-free.
Keep the Mavsdk instance alive at least as long as everything obtained from it.
Aborting now: continuing would crash later and much less clearly.
```

### The false positive this nearly shipped with

The first run tripped on `Mavsdk.version` in the unit tests. `_default_server_component` points at an entry that is *also* in `_server_components`, so `use_count()` is legitimately 2 with zero user references. The check now compares against a baseline that accounts for our own references.

Worth stating plainly: had I gone straight to `abort()` without running the suite, this would have killed every MAVSDK program on shutdown. The whole system suite now runs clean through the check across ~100 different construction shapes, which is the real evidence the baseline is right.

### Testing both directions

- `system_tests/mavsdk_outlived.cpp` proves the check *fires*, for a leaked `System` and a leaked `ServerComponent`. Death tests in `threadsafe` style (forking a threaded program isn't safe), and no `ASSERT_*` inside the death statement — that expands to a `return`, which gtest rejects outright.
- The rest of the suite proves it *doesn't* fire when it shouldn't, which for a check like this is the more important half.

105/105 system tests, 105/105 under TSan with 0 warnings, 427/427 unit.

### Documentation

The rule is now on `systems()`, `first_autopilot()` and `server_component()` in the public header, plus an "Object lifetime" section in `core/THREADING.md`.

### Incidental find, not fixed here

Getting the System death test working turned up that `SystemImpl::init()` registers its HEARTBEAT handler with a *posted* registration — so the very first heartbeat, the one that creates the system, arrives before that system's own handler is in the table and doesn't mark it connected. The second one does.

Harmless at 1 Hz and long-standing, but it means discovery is structurally one heartbeat slower than it looks. Fixing it would mean making that registration synchronous, which cuts against the posted-mutation invariant, so I left it alone — happy to look at it separately if you think it's worth it.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW