### PR TITLE
core: deliver the first heartbeat to the system it just created

### DIFF
--- a/cpp/src/mavsdk/core/mavlink_message_handler.cpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.cpp
@@ -43,6 +43,15 @@ void MavlinkMessageHandler::register_one_impl(
     });
 }
 
+void MavlinkMessageHandler::register_one_on_io_thread(
+    uint16_t msg_id, const Callback& callback, const void* cookie)
+{
+    // See the header for why this exists and when it is allowed.
+    assert(!_processing);
+    note_table_thread();
+    _table.push_back(Entry{msg_id, {}, callback, cookie});
+}
+
 void MavlinkMessageHandler::unregister_one(uint16_t msg_id, const void* cookie)
 {
     unregister_impl({msg_id}, cookie);

--- a/cpp/src/mavsdk/core/mavlink_message_handler.hpp
+++ b/cpp/src/mavsdk/core/mavlink_message_handler.hpp
@@ -34,6 +34,15 @@ public:
     };
 
     void register_one(uint16_t msg_id, const Callback& callback, const void* cookie);
+    // Direct, synchronous registration, for an owner that is created ON the io thread while
+    // handling a message it must itself receive -- a SystemImpl built by the very heartbeat
+    // that discovered the system. The posted register_one() would land an io turn too late
+    // and drop that first message.
+    //
+    // Must be called on the io thread, and not from within a message callback: growing the
+    // table underneath process_message()'s loop would invalidate its iteration. Same
+    // constraints as unregister_all_on_io_thread().
+    void register_one_on_io_thread(uint16_t msg_id, const Callback& callback, const void* cookie);
     void register_one_with_component_id(
         uint16_t msg_id, uint8_t component_id, const Callback& callback, const void* cookie);
     void unregister_one(uint16_t msg_id, const void* cookie);

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -71,17 +71,23 @@ void SystemImpl::init(uint8_t system_id, uint8_t comp_id)
     // We use this as a default.
     _target_address.component_id = MAV_COMP_ID_AUTOPILOT1;
 
-    _mavlink_message_handler.register_one(
+    // Registered synchronously rather than with the usual posted register_one(): init() runs
+    // on the io thread, from MavsdkImpl::process_message(), while it is handling the very
+    // message that caused this system to be created. A posted registration would land an io
+    // turn later, so that first message -- normally the heartbeat that would mark the system
+    // connected -- would arrive before the handler existed and be dropped, leaving discovery
+    // to wait for the next one.
+    _mavlink_message_handler.register_one_on_io_thread(
         MAVLINK_MSG_ID_HEARTBEAT,
         [this](const mavlink_message_t& message) { process_heartbeat(message); },
         this);
 
-    _mavlink_message_handler.register_one(
+    _mavlink_message_handler.register_one_on_io_thread(
         MAVLINK_MSG_ID_STATUSTEXT,
         [this](const mavlink_message_t& message) { process_statustext(message); },
         this);
 
-    _mavlink_message_handler.register_one(
+    _mavlink_message_handler.register_one_on_io_thread(
         MAVLINK_MSG_ID_AUTOPILOT_VERSION,
         [this](const mavlink_message_t& message) { process_autopilot_version(message); },
         this);

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(system_tests_runner
     heartbeat_watchdog.cpp
     plugin_lifetime_churn.cpp
     mavsdk_outlived.cpp
+    first_heartbeat.cpp
     telemetry_home_position.cpp
     request_message_rapid.cpp
     fs_helpers.cpp

--- a/cpp/src/system_tests/first_heartbeat.cpp
+++ b/cpp/src/system_tests/first_heartbeat.cpp
@@ -1,0 +1,51 @@
+#include "mavsdk.hpp"
+#include "mavlink_include.hpp"
+
+#include <vector>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+// The first heartbeat from an unknown system is what creates the System for it. It also has
+// to be delivered to that System, otherwise nothing marks it connected and discovery waits
+// for the next one -- a whole heartbeat interval, typically a second, for no reason.
+
+namespace {
+
+std::vector<char> make_heartbeat()
+{
+    mavlink_message_t message;
+    mavlink_msg_heartbeat_pack_chan(
+        1,
+        MAV_COMP_ID_AUTOPILOT1,
+        MAVLINK_COMM_NUM_BUFFERS - 1,
+        &message,
+        MAV_TYPE_QUADROTOR,
+        MAV_AUTOPILOT_PX4,
+        MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+        0,
+        MAV_STATE_STANDBY);
+
+    std::vector<uint8_t> buffer(MAVLINK_MAX_PACKET_LEN);
+    const auto length = mavlink_msg_to_send_buffer(buffer.data(), &message);
+
+    return std::vector<char>(buffer.begin(), buffer.begin() + length);
+}
+
+} // namespace
+
+TEST(FirstHeartbeat, SingleHeartbeatConnectsSystem)
+{
+    Mavsdk mavsdk{Mavsdk::Configuration{ComponentType::GroundStation}};
+    ASSERT_EQ(mavsdk.add_any_connection("raw://"), ConnectionResult::Success);
+
+    const auto heartbeat = make_heartbeat();
+
+    // Exactly one. If the System that this creates does not also receive it, nothing calls
+    // set_connected() and first_autopilot() below waits for a heartbeat that never comes.
+    mavsdk.pass_received_raw_bytes(heartbeat.data(), heartbeat.size());
+
+    auto maybe_system = mavsdk.first_autopilot(2.0);
+    ASSERT_TRUE(maybe_system) << "a single heartbeat did not connect the system";
+    EXPECT_TRUE(maybe_system.value()->is_connected());
+}


### PR DESCRIPTION
Stacked on #3057. This is the incidental find from that PR, fixed.

### The problem

`SystemImpl::init()` runs on the io thread, from `MavsdkImpl::process_message()`, while that is handling the very message which caused the system to be created. Its handler registrations went through the usual **posted** `register_one()`, so they landed an io turn later — after the current message had already been dispatched.

The heartbeat that discovered the system was therefore never delivered *to* that system. Nothing called `set_connected()`, and discovery waited for the next heartbeat: a full interval, typically a second, for nothing.

### The fix

Register the three handlers synchronously. `register_one_on_io_thread()` mirrors the `unregister_all_on_io_thread()` that already exists for the same reason in reverse, and carries the same two constraints, asserted and documented:

- must run on the io thread
- never from inside a message callback, since growing the table underneath `process_message()`'s loop would invalidate its iteration

Neither is a problem here: there is exactly one `System` construction site and it is on the io thread, and the table being written belongs to the system being created, so nothing is iterating it yet.

### Testing

`system_tests/first_heartbeat.cpp` injects exactly one heartbeat and expects a connected system. **Without the fix it times out at 2087 ms; with it, it passes in 85 ms.**

The effect is visible across the whole suite too — with discovery no longer costing an extra heartbeat interval every time:

| | system tests |
|---|---|
| before | ~260 s (105 tests) |
| after | **173 s** (106 tests) |

106/106 plain, 106/106 under TSan with **0 warnings**, 427/427 unit.

The TSan run is the one that matters here, since this replaces a posted table mutation with a direct one — exactly what the posted design exists to avoid. The `_processing` assert and `note_table_thread()` cover the constraints, and the sanitizer agrees.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW