### PR TITLE
core: never drop the user callbacks somebody is waiting for

### DIFF
--- a/cpp/src/mavsdk/core/THREADING.md
+++ b/cpp/src/mavsdk/core/THREADING.md
@@ -144,6 +144,31 @@ use-after-free waiting to happen.
 **If you add anything else the io thread reaches through a raw pointer into user-owned memory,
 it needs the same treatment.**
 
+## User callbacks: two classes
+
+Everything the user sees arrives through one bounded queue drained by the user-callback
+thread, and *blocking API calls depend on it*. `Action::arm()` waits on a promise that is
+only satisfied when the command-result callback runs, so a result that gets dropped is not a
+gap in data -- it is `arm()` never returning.
+
+So the queue distinguishes two kinds of work:
+
+| | Use | Dropped? |
+|---|---|---|
+| `call_user_callback()` | Anything somebody may be waiting for: command results, mission and parameter completions, one-shot requests. | **Never.** These are one per user action, so they cannot run the queue away. |
+| `call_user_callback_droppable()` | A subscription delivering a stream, where the newest value is what matters. | Yes, once `MAX_DROPPABLE_USER_CALLBACKS` of them are queued. |
+
+Must-deliver is the default, so a new call site is safe until somebody deliberately opts into
+dropping. When the droppable bound is reached, the **oldest** droppable entry is evicted
+rather than the new one refused, so a subscriber that cannot keep up sees fresh data with
+gaps instead of falling further and further behind.
+
+Drops are counted and reported at most every few seconds with a running total, rather than
+per drop -- whatever causes drops causes a great many of them.
+
+`system_tests/callback_queue_overflow.cpp` pins the property that matters: a slow subscriber
+must not stop a blocking call from returning.
+
 ## Object lifetime
 
 `System`, `ServerComponent` and every plugin hold a reference back into `MavsdkImpl`, so none

--- a/cpp/src/mavsdk/core/locked_queue.hpp
+++ b/cpp/src/mavsdk/core/locked_queue.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <queue>
 #include <mutex>
 #include <memory>
@@ -17,6 +18,41 @@ public:
         std::lock_guard<std::mutex> lock(_mutex);
         _queue.push_back(item_ptr);
         _condition_var.notify_one();
+    }
+
+    // Outcome of push_back_bounded().
+    enum class BoundedPush {
+        Pushed, // There was room.
+        PushedAfterDropping, // Room was made by dropping an older droppable item.
+        Rejected, // No room and nothing droppable to evict, so the item was not pushed.
+    };
+
+    // Push, but keep the queue to max_size entries worth of droppable work. When it is
+    // already that long, make room by dropping the *oldest* item that pred accepts --
+    // oldest, so that what does get through stays current rather than lagging further and
+    // further behind. If nothing in the queue may be dropped, the new item is refused
+    // instead, and the caller decides what that means.
+    template<class Predicate>
+    BoundedPush push_back_bounded(std::shared_ptr<T> item_ptr, size_t max_size, Predicate pred)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        auto result = BoundedPush::Pushed;
+
+        if (_queue.size() >= max_size) {
+            auto it = std::find_if(_queue.begin(), _queue.end(), [&](const auto& entry) {
+                return entry != nullptr && pred(*entry);
+            });
+            if (it == _queue.end()) {
+                return BoundedPush::Rejected;
+            }
+            _queue.erase(it);
+            result = BoundedPush::PushedAfterDropping;
+        }
+
+        _queue.push_back(item_ptr);
+        _condition_var.notify_one();
+        return result;
     }
 
     size_t size()

--- a/cpp/src/mavsdk/core/log.hpp
+++ b/cpp/src/mavsdk/core/log.hpp
@@ -37,6 +37,11 @@
 
 #define call_user_callback(...) call_user_callback_located(FILENAME, __LINE__, __VA_ARGS__)
 
+// For a subscription delivering a stream, where an old value may be discarded if the
+// subscriber cannot keep up. Never use it where something waits for the callback.
+#define call_user_callback_droppable(...) \
+    call_user_callback_droppable_located(FILENAME, __LINE__, __VA_ARGS__)
+
 #define LogDebug(...) \
     ::mavsdk::log_message(::mavsdk::log::Level::Debug, FILENAME, __LINE__, __VA_ARGS__)
 #define LogInfo(...) \

--- a/cpp/src/mavsdk/core/mavsdk_impl.cpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.cpp
@@ -1592,6 +1592,21 @@ void MavsdkImpl::set_callback_executor(std::function<void(std::function<void()>)
 void MavsdkImpl::call_user_callback_located(
     const std::string& filename, const int linenumber, const std::function<void()>& func)
 {
+    enqueue_user_callback(filename, linenumber, func, false);
+}
+
+void MavsdkImpl::call_user_callback_droppable_located(
+    const std::string& filename, const int linenumber, const std::function<void()>& func)
+{
+    enqueue_user_callback(filename, linenumber, func, true);
+}
+
+void MavsdkImpl::enqueue_user_callback(
+    const std::string& filename,
+    const int linenumber,
+    const std::function<void()>& func,
+    bool droppable)
+{
     // Don't enqueue callbacks if we're shutting down
     if (_should_exit) {
         return;
@@ -1610,32 +1625,74 @@ void MavsdkImpl::call_user_callback_located(
         return;
     }
 
-    auto callback_size = _user_callback_queue.size();
+    const auto callback_size = _user_callback_queue.size();
 
     if (_callback_tracker) {
         _callback_tracker->record_queued(filename, linenumber);
         _callback_tracker->maybe_print_stats(callback_size);
     }
 
-    if (callback_size >= 100) {
-        return;
+    // We only need to keep track of filename and linenumber if we're actually debugging this.
+    auto user_callback =
+        _callback_debugging ? UserCallback{func, filename, linenumber} : UserCallback{func};
+    user_callback.droppable = droppable;
 
-    } else if (callback_size == 99) {
-        LogErr(
-            "User callback queue overflown\nSee: https://mavsdk.mavlink.io/main/en/cpp/troubleshooting.html#user_callbacks");
-        return;
+    auto ptr = std::make_shared<UserCallback>(std::move(user_callback));
 
-    } else if (callback_size >= 10) {
-        LogWarn(
-            "User callback queue slow (queue size: {}).\nSee: https://mavsdk.mavlink.io/main/en/cpp/troubleshooting.html#user_callbacks",
-            callback_size);
+    if (!droppable) {
+        // Somebody may be blocked waiting for this one, so it goes in regardless of how far
+        // behind the subscriber is. These are one per user action rather than one per
+        // message, so the queue cannot run away on them.
+        _user_callback_queue.push_back(ptr);
+        return;
     }
 
-    // We only need to keep track of filename and linenumber if we're actually debugging this.
-    UserCallback user_callback =
-        _callback_debugging ? UserCallback{func, filename, linenumber} : UserCallback{func};
+    const auto result = _user_callback_queue.push_back_bounded(
+        ptr, MAX_DROPPABLE_USER_CALLBACKS, [](const UserCallback& queued) {
+            return queued.droppable;
+        });
 
-    _user_callback_queue.push_back(std::make_shared<UserCallback>(user_callback));
+    switch (result) {
+        case LockedQueue<UserCallback>::BoundedPush::Pushed:
+            break;
+        case LockedQueue<UserCallback>::BoundedPush::PushedAfterDropping:
+            // An older value of this stream made way for the new one.
+            note_user_callbacks_dropped();
+            break;
+        case LockedQueue<UserCallback>::BoundedPush::Rejected:
+            // The queue is entirely callbacks that must be delivered, so this stream value
+            // is the one that gives way.
+            note_user_callbacks_dropped();
+            break;
+    }
+}
+
+void MavsdkImpl::note_user_callbacks_dropped()
+{
+    const auto total = ++_user_callbacks_dropped;
+
+    const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+
+    // Rate limited, and it reports the running total rather than the individual drop: the
+    // old code warned on every enqueue once the queue passed ten, which drowned out the one
+    // message that mattered, and then went silent exactly when data started disappearing.
+    constexpr int64_t report_interval_ms = 5000;
+
+    auto last_ms = _user_callbacks_report_ms.load(std::memory_order_relaxed);
+    if (now_ms - last_ms < report_interval_ms) {
+        return;
+    }
+    if (!_user_callbacks_report_ms.compare_exchange_strong(last_ms, now_ms)) {
+        // Somebody else is reporting right now.
+        return;
+    }
+
+    LogErr(
+        "Dropping subscription callbacks ({} so far): a subscriber is not keeping up.\n"
+        "See: https://mavsdk.mavlink.io/main/en/cpp/troubleshooting.html#user_callbacks",
+        total);
 }
 
 void MavsdkImpl::process_user_callbacks_thread()

--- a/cpp/src/mavsdk/core/mavsdk_impl.hpp
+++ b/cpp/src/mavsdk/core/mavsdk_impl.hpp
@@ -151,7 +151,15 @@ public:
     TimeoutHandler timeout_handler;
     CallEveryHandler call_every_handler;
 
+    // Queue a callback for the user callback thread. Never dropped: blocking API calls wait
+    // on promises that are only satisfied by one of these, so losing one hangs the caller.
     void call_user_callback_located(
+        const std::string& filename, int linenumber, const std::function<void()>& func);
+
+    // Same, but for a subscription delivering a stream, where the newest value matters and
+    // an old one may be discarded if the subscriber cannot keep up. Use this only where
+    // losing a callback is a gap in data, never where somebody is waiting for it.
+    void call_user_callback_droppable_located(
         const std::string& filename, int linenumber, const std::function<void()>& func);
 
     void set_timeout_s(double timeout_s) { _timeout_s = timeout_s; }
@@ -305,6 +313,10 @@ private:
             linenumber(linenumber_)
         {}
 
+        // Whether this callback may be discarded when the queue is backed up. See
+        // call_user_callback_droppable_located().
+        bool droppable{false};
+
         std::function<void()> func{};
         std::string filename{};
         int linenumber{};
@@ -366,6 +378,22 @@ private:
     // so a caller can keep it alive across the invocation without copying the std::function.
     std::mutex _callback_executor_mutex{};
     std::shared_ptr<const CallbackExecutor> _callback_executor{};
+
+    // How much droppable work the user callback queue holds before it starts discarding the
+    // oldest of it. Callbacks that must be delivered are never counted out by this.
+    static constexpr size_t MAX_DROPPABLE_USER_CALLBACKS = 100;
+
+    void enqueue_user_callback(
+        const std::string& filename,
+        int linenumber,
+        const std::function<void()>& func,
+        bool droppable);
+
+    // Count drops and say so, at most every few seconds: whatever causes drops causes a lot
+    // of them, and a line per drop buries the message.
+    void note_user_callbacks_dropped();
+    std::atomic<uint64_t> _user_callbacks_dropped{0};
+    std::atomic<int64_t> _user_callbacks_report_ms{0};
 
     std::atomic<bool> _should_exit{false};
 

--- a/cpp/src/mavsdk/core/server_component_impl.cpp
+++ b/cpp/src/mavsdk/core/server_component_impl.cpp
@@ -334,6 +334,12 @@ void ServerComponentImpl::call_user_callback_located(
     _mavsdk_impl.call_user_callback_located(filename, linenumber, func);
 }
 
+void ServerComponentImpl::call_user_callback_droppable_located(
+    const std::string& filename, const int linenumber, const std::function<void()>& func)
+{
+    _mavsdk_impl.call_user_callback_droppable_located(filename, linenumber, func);
+}
+
 TimeoutHandler::Cookie ServerComponentImpl::register_timeout_handler(
     const std::function<void()>& callback, double duration_s)
 {

--- a/cpp/src/mavsdk/core/server_component_impl.hpp
+++ b/cpp/src/mavsdk/core/server_component_impl.hpp
@@ -169,6 +169,11 @@ public:
     void call_user_callback_located(
         const std::string& filename, const int linenumber, const std::function<void()>& func);
 
+    // For a subscription delivering a stream: may be discarded when the user cannot keep up.
+    // Never use it where somebody waits for the callback -- see MavsdkImpl.
+    void call_user_callback_droppable_located(
+        const std::string& filename, const int linenumber, const std::function<void()>& func);
+
     // Autopilot version data
     void add_capabilities(uint64_t capabilities);
     void set_flight_sw_version(uint32_t flight_sw_version);

--- a/cpp/src/mavsdk/core/system_impl.cpp
+++ b/cpp/src/mavsdk/core/system_impl.cpp
@@ -1414,6 +1414,12 @@ void SystemImpl::call_user_callback_located(
     _mavsdk_impl.call_user_callback_located(filename, linenumber, func);
 }
 
+void SystemImpl::call_user_callback_droppable_located(
+    const std::string& filename, const int linenumber, const std::function<void()>& func)
+{
+    _mavsdk_impl.call_user_callback_droppable_located(filename, linenumber, func);
+}
+
 void SystemImpl::param_changed(const std::string& name)
 {
     // Copy the callbacks out under the lock and invoke them afterwards, so a callback

--- a/cpp/src/mavsdk/core/system_impl.hpp
+++ b/cpp/src/mavsdk/core/system_impl.hpp
@@ -326,6 +326,11 @@ public:
     void call_user_callback_located(
         const std::string& filename, int linenumber, const std::function<void()>& func);
 
+    // For a subscription delivering a stream: may be discarded when the user cannot keep up.
+    // Never use it where somebody waits for the callback -- see MavsdkImpl.
+    void call_user_callback_droppable_located(
+        const std::string& filename, int linenumber, const std::function<void()>& func);
+
     void send_autopilot_version_request();
 
     MavlinkMissionTransferClient& mission_transfer_client() { return _mission_transfer_client; }

--- a/cpp/src/mavsdk/plugins/calibration/calibration_impl.cpp
+++ b/cpp/src/mavsdk/plugins/calibration/calibration_impl.cpp
@@ -89,8 +89,15 @@ void CalibrationImpl::call_callback(
     const Calibration::ProgressData progress_data)
 {
     if (callback) {
-        _system_impl->call_user_callback(
-            [callback, result, progress_data]() { callback(result, progress_data); });
+        auto deliver = [callback, result, progress_data]() { callback(result, progress_data); };
+
+        // Result::Next is an intermediate progress update, so it may be dropped if the
+        // subscriber cannot keep up. Anything else is the outcome somebody is waiting for.
+        if (result == Calibration::Result::Next) {
+            _system_impl->call_user_callback_droppable(deliver);
+        } else {
+            _system_impl->call_user_callback(deliver);
+        }
     }
 }
 

--- a/cpp/src/mavsdk/plugins/ftp/ftp_impl.cpp
+++ b/cpp/src/mavsdk/plugins/ftp/ftp_impl.cpp
@@ -47,12 +47,20 @@ void FtpImpl::download_async(
         [callback, this](
             MavlinkFtpClient::ClientResult result, MavlinkFtpClient::ProgressData progress_data) {
             if (callback) {
-                _system_impl->call_user_callback(
-                    [temp_callback = callback, result, progress_data, this]() {
-                        temp_callback(
-                            result_from_mavlink_ftp_result(result),
-                            progress_data_from_mavlink_ftp_progress_data(progress_data));
-                    });
+                auto deliver = [temp_callback = callback, result, progress_data, this]() {
+                    temp_callback(
+                        result_from_mavlink_ftp_result(result),
+                        progress_data_from_mavlink_ftp_progress_data(progress_data));
+                };
+
+                // ClientResult::Next is an intermediate progress update. A large transfer
+                // emits a great many of them, and losing one only costs a percentage, while
+                // the final result is what a blocking download()/upload() waits for.
+                if (result == MavlinkFtpClient::ClientResult::Next) {
+                    _system_impl->call_user_callback_droppable(deliver);
+                } else {
+                    _system_impl->call_user_callback(deliver);
+                }
             }
         });
 }
@@ -68,12 +76,20 @@ void FtpImpl::upload_async(
         [callback, this](
             MavlinkFtpClient::ClientResult result, MavlinkFtpClient::ProgressData progress_data) {
             if (callback) {
-                _system_impl->call_user_callback(
-                    [temp_callback = callback, result, progress_data, this]() {
-                        temp_callback(
-                            result_from_mavlink_ftp_result(result),
-                            progress_data_from_mavlink_ftp_progress_data(progress_data));
-                    });
+                auto deliver = [temp_callback = callback, result, progress_data, this]() {
+                    temp_callback(
+                        result_from_mavlink_ftp_result(result),
+                        progress_data_from_mavlink_ftp_progress_data(progress_data));
+                };
+
+                // ClientResult::Next is an intermediate progress update. A large transfer
+                // emits a great many of them, and losing one only costs a percentage, while
+                // the final result is what a blocking download()/upload() waits for.
+                if (result == MavlinkFtpClient::ClientResult::Next) {
+                    _system_impl->call_user_callback_droppable(deliver);
+                } else {
+                    _system_impl->call_user_callback(deliver);
+                }
             }
         });
 }

--- a/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
+++ b/cpp/src/mavsdk/plugins/log_files/log_files_impl.cpp
@@ -462,8 +462,15 @@ void LogFilesImpl::process_log_data(const mavlink_message_t& message)
         // Update progress
         const auto cb = _download_data.user_callback;
         if (cb) {
-            _system_impl->call_user_callback(
-                [cb, progress_data, result]() { cb(result, progress_data); });
+            auto deliver = [cb, progress_data, result]() { cb(result, progress_data); };
+
+            // Result::Next is a chunk-progress update; the final result is what the blocking
+            // download_log_file() is waiting for and must not be dropped.
+            if (result == LogFiles::Result::Next) {
+                _system_impl->call_user_callback_droppable(deliver);
+            } else {
+                _system_impl->call_user_callback(deliver);
+            }
         }
     } else {
         // Check for missing bins when we might have all bins for this chunk

--- a/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission/mission_impl.cpp
@@ -167,7 +167,9 @@ void MissionImpl::upload_mission_with_progress_async(
             });
         },
         [this, callback](float progress) {
-            _system_impl->call_user_callback([callback, progress]() {
+            // Progress only: the final result comes from the other callback above, so a
+            // subscriber falling behind should lose percentages rather than block the queue.
+            _system_impl->call_user_callback_droppable([callback, progress]() {
                 if (callback) {
                     callback(Mission::Result::Next, Mission::ProgressData{progress});
                 }
@@ -275,7 +277,8 @@ void MissionImpl::download_mission_with_progress_async(
             });
         },
         [this, callback](float progress) {
-            _system_impl->call_user_callback([callback, progress]() {
+            // Progress only, as above.
+            _system_impl->call_user_callback_droppable([callback, progress]() {
                 Mission::ProgressDataOrMission progress_data_or_mission{};
                 progress_data_or_mission.has_progress = true;
                 progress_data_or_mission.progress = progress;

--- a/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
+++ b/cpp/src/mavsdk/plugins/mission_raw/mission_raw_impl.cpp
@@ -220,7 +220,8 @@ void MissionRawImpl::upload_mission_with_progress_async(
             }
         },
         [this, callback](float progress) {
-            _system_impl->call_user_callback([callback, progress]() {
+            // Progress only: the final result comes from the other callback above.
+            _system_impl->call_user_callback_droppable([callback, progress]() {
                 if (callback) {
                     callback(MissionRaw::Result::Next, MissionRaw::ProgressData{progress});
                 }

--- a/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/cpp/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -753,7 +753,7 @@ void TelemetryImpl::process_position_velocity_ned(const mavlink_message_t& messa
     set_position_velocity_ned(position_velocity);
 
     _position_velocity_ned_subscriptions.queue(position_velocity_ned(), [this](const auto& func) {
-        _system_impl->call_user_callback(func);
+        _system_impl->call_user_callback_droppable(func);
     });
 
     set_health_local_position(true);
@@ -790,13 +790,14 @@ void TelemetryImpl::process_global_position_int(const mavlink_message_t& message
     }
 
     _position_subscriptions.queue(
-        position(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        position(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 
-    _velocity_ned_subscriptions.queue(
-        velocity_ned(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _velocity_ned_subscriptions.queue(velocity_ned(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 
     _heading_subscriptions.queue(
-        heading(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        heading(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_home_position(const mavlink_message_t& message)
@@ -826,7 +827,7 @@ void TelemetryImpl::process_home_position(const mavlink_message_t& message)
     set_health_home_position(true);
 
     _home_position_subscriptions.queue(
-        home(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        home(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_attitude(const mavlink_message_t& message)
@@ -847,12 +848,13 @@ void TelemetryImpl::process_attitude(const mavlink_message_t& message)
     angular_velocity_body.yaw_rad_s = attitude.yawspeed;
     set_attitude_angular_velocity_body(angular_velocity_body);
 
-    _attitude_euler_angle_subscriptions.queue(
-        attitude_euler(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _attitude_euler_angle_subscriptions.queue(attitude_euler(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 
     _attitude_angular_velocity_body_subscriptions.queue(
         attitude_angular_velocity_body(),
-        [this](const auto& func) { _system_impl->call_user_callback(func); });
+        [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_attitude_quaternion(const mavlink_message_t& message)
@@ -878,12 +880,12 @@ void TelemetryImpl::process_attitude_quaternion(const mavlink_message_t& message
     set_attitude_angular_velocity_body(angular_velocity_body);
 
     _attitude_quaternion_angle_subscriptions.queue(attitude_quaternion(), [this](const auto& func) {
-        _system_impl->call_user_callback(func);
+        _system_impl->call_user_callback_droppable(func);
     });
 
     _attitude_angular_velocity_body_subscriptions.queue(
         attitude_angular_velocity_body(),
-        [this](const auto& func) { _system_impl->call_user_callback(func); });
+        [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_altitude(const mavlink_message_t& message)
@@ -903,7 +905,7 @@ void TelemetryImpl::process_altitude(const mavlink_message_t& message)
     set_altitude(new_altitude);
 
     _altitude_subscriptions.queue(
-        altitude(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        altitude(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_wind(const mavlink_message_t& message)
@@ -924,7 +926,7 @@ void TelemetryImpl::process_wind(const mavlink_message_t& message)
     set_wind(new_wind);
 
     _wind_subscriptions.queue(
-        wind(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        wind(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_imu_reading_ned(const mavlink_message_t& message)
@@ -947,7 +949,7 @@ void TelemetryImpl::process_imu_reading_ned(const mavlink_message_t& message)
     set_imu_reading_ned(new_imu);
 
     _imu_reading_ned_subscriptions.queue(
-        imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        imu(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_scaled_imu(const mavlink_message_t& message)
@@ -972,8 +974,9 @@ void TelemetryImpl::process_scaled_imu(const mavlink_message_t& message)
 
     set_scaled_imu(new_imu);
 
-    _scaled_imu_subscriptions.queue(
-        scaled_imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _scaled_imu_subscriptions.queue(scaled_imu(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_raw_imu(const mavlink_message_t& message)
@@ -996,7 +999,7 @@ void TelemetryImpl::process_raw_imu(const mavlink_message_t& message)
     set_raw_imu(new_imu);
 
     _raw_imu_subscriptions.queue(
-        raw_imu(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        raw_imu(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_gps_raw_int(const mavlink_message_t& message)
@@ -1057,10 +1060,12 @@ void TelemetryImpl::process_gps_raw_int(const mavlink_message_t& message)
     set_raw_gps(raw_gps_info);
 
     {
-        _gps_info_subscriptions.queue(
-            gps_info(), [this](const auto& func) { _system_impl->call_user_callback(func); });
-        _raw_gps_subscriptions.queue(
-            raw_gps(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        _gps_info_subscriptions.queue(gps_info(), [this](const auto& func) {
+            _system_impl->call_user_callback_droppable(func);
+        });
+        _raw_gps_subscriptions.queue(raw_gps(), [this](const auto& func) {
+            _system_impl->call_user_callback_droppable(func);
+        });
     }
 }
 
@@ -1077,8 +1082,9 @@ void TelemetryImpl::process_ground_truth(const mavlink_message_t& message)
 
     set_ground_truth(new_ground_truth);
 
-    _ground_truth_subscriptions.queue(
-        ground_truth(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _ground_truth_subscriptions.queue(ground_truth(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_extended_sys_state(const mavlink_message_t& message)
@@ -1094,11 +1100,13 @@ void TelemetryImpl::process_extended_sys_state(const mavlink_message_t& message)
         set_vtol_state(vtol_state);
     }
 
-    _landed_state_subscriptions.queue(
-        landed_state(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _landed_state_subscriptions.queue(landed_state(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 
-    _vtol_state_subscriptions.queue(
-        vtol_state(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _vtol_state_subscriptions.queue(vtol_state(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 
     if (extended_sys_state.landed_state == MAV_LANDED_STATE_IN_AIR ||
         extended_sys_state.landed_state == MAV_LANDED_STATE_TAKEOFF ||
@@ -1110,7 +1118,7 @@ void TelemetryImpl::process_extended_sys_state(const mavlink_message_t& message)
     // If landed_state is undefined, we use what we have received last.
 
     _in_air_subscriptions.queue(
-        in_air(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        in_air(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 void TelemetryImpl::process_fixedwing_metrics(const mavlink_message_t& message)
 {
@@ -1127,8 +1135,9 @@ void TelemetryImpl::process_fixedwing_metrics(const mavlink_message_t& message)
 
     set_fixedwing_metrics(new_fixedwing_metrics);
 
-    _fixedwing_metrics_subscriptions.queue(
-        fixedwing_metrics(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _fixedwing_metrics_subscriptions.queue(fixedwing_metrics(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
@@ -1144,8 +1153,9 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
         set_battery(new_battery);
 
         {
-            _battery_subscriptions.queue(
-                battery(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+            _battery_subscriptions.queue(battery(), [this](const auto& func) {
+                _system_impl->call_user_callback_droppable(func);
+            });
         }
     }
 
@@ -1188,13 +1198,15 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
 
     set_rc_status({rc_ok}, std::nullopt);
 
-    _rc_status_subscriptions.queue(
-        rc_status(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _rc_status_subscriptions.queue(rc_status(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 
     const bool armable = sys_status.onboard_control_sensors_health & MAV_SYS_STATUS_PREARM_CHECK;
     set_health_armable(armable);
-    _health_all_ok_subscriptions.queue(
-        health_all_ok(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _health_all_ok_subscriptions.queue(health_all_ok(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 bool TelemetryImpl::sys_status_present_enabled_health(
@@ -1272,8 +1284,9 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     set_battery(new_battery);
 
     {
-        _battery_subscriptions.queue(
-            battery(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        _battery_subscriptions.queue(battery(), [this](const auto& func) {
+            _system_impl->call_user_callback_droppable(func);
+        });
     }
 }
 
@@ -1289,17 +1302,18 @@ void TelemetryImpl::process_heartbeat(const mavlink_message_t& message)
     set_armed(((heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED) ? true : false));
 
     _armed_subscriptions.queue(
-        armed(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        armed(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 
     _flight_mode_subscriptions.queue(
         telemetry_flight_mode_from_flight_mode(_system_impl->get_flight_mode()),
-        [this](const auto& func) { _system_impl->call_user_callback(func); });
+        [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 
     _health_subscriptions.queue(
-        health(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        health(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 
-    _health_all_ok_subscriptions.queue(
-        health_all_ok(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _health_all_ok_subscriptions.queue(health_all_ok(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::receive_statustext(const MavlinkStatustextHandler::Statustext& statustext)
@@ -1341,8 +1355,9 @@ void TelemetryImpl::receive_statustext(const MavlinkStatustextHandler::Statustex
 
     set_status_text(new_status_text);
 
-    _status_text_subscriptions.queue(
-        status_text(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _status_text_subscriptions.queue(status_text(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_rc_channels(const mavlink_message_t& message)
@@ -1354,8 +1369,9 @@ void TelemetryImpl::process_rc_channels(const mavlink_message_t& message)
         set_rc_status(std::nullopt, {rc_channels.rssi});
     }
 
-    _rc_status_subscriptions.queue(
-        rc_status(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _rc_status_subscriptions.queue(rc_status(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_unix_epoch_time(const mavlink_message_t& message)
@@ -1365,8 +1381,9 @@ void TelemetryImpl::process_unix_epoch_time(const mavlink_message_t& message)
 
     set_unix_epoch_time_us(system_time.time_unix_usec);
 
-    _unix_epoch_time_subscriptions.queue(
-        unix_epoch_time(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _unix_epoch_time_subscriptions.queue(unix_epoch_time(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 void TelemetryImpl::process_actuator_control_target(const mavlink_message_t& message)
@@ -1387,7 +1404,7 @@ void TelemetryImpl::process_actuator_control_target(const mavlink_message_t& mes
 
     _actuator_control_target_subscriptions.queue(
         actuator_control_target(),
-        [this](const auto& func) { _system_impl->call_user_callback(func); });
+        [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_actuator_output_status(const mavlink_message_t& message)
@@ -1407,7 +1424,7 @@ void TelemetryImpl::process_actuator_output_status(const mavlink_message_t& mess
     set_actuator_output_status(active, actuators);
 
     _actuator_output_status_subscriptions.queue(actuator_output_status(), [this](const auto& func) {
-        _system_impl->call_user_callback(func);
+        _system_impl->call_user_callback_droppable(func);
     });
 }
 
@@ -1457,7 +1474,7 @@ void TelemetryImpl::process_odometry(const mavlink_message_t& message)
     set_odometry(odometry_struct);
 
     _odometry_subscriptions.queue(
-        odometry(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+        odometry(), [this](const auto& func) { _system_impl->call_user_callback_droppable(func); });
 }
 
 void TelemetryImpl::process_distance_sensor(const mavlink_message_t& message)
@@ -1477,8 +1494,9 @@ void TelemetryImpl::process_distance_sensor(const mavlink_message_t& message)
 
     set_distance_sensor(distance_sensor_struct);
 
-    _distance_sensor_subscriptions.queue(
-        distance_sensor(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _distance_sensor_subscriptions.queue(distance_sensor(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 Telemetry::EulerAngle
@@ -1709,8 +1727,9 @@ void TelemetryImpl::process_scaled_pressure(const mavlink_message_t& message)
 
     set_scaled_pressure(scaled_pressure_struct);
 
-    _scaled_pressure_subscriptions.queue(
-        scaled_pressure(), [this](const auto& func) { _system_impl->call_user_callback(func); });
+    _scaled_pressure_subscriptions.queue(scaled_pressure(), [this](const auto& func) {
+        _system_impl->call_user_callback_droppable(func);
+    });
 }
 
 Telemetry::LandedState

--- a/cpp/src/system_tests/CMakeLists.txt
+++ b/cpp/src/system_tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(system_tests_runner
     plugin_lifetime_churn.cpp
     mavsdk_outlived.cpp
     first_heartbeat.cpp
+    callback_queue_overflow.cpp
     telemetry_home_position.cpp
     request_message_rapid.cpp
     fs_helpers.cpp

--- a/cpp/src/system_tests/callback_queue_overflow.cpp
+++ b/cpp/src/system_tests/callback_queue_overflow.cpp
@@ -1,0 +1,115 @@
+#include "log.hpp"
+#include "mavsdk.hpp"
+#include "plugins/action/action.hpp"
+#include "plugins/action_server/action_server.hpp"
+#include "plugins/telemetry/telemetry.hpp"
+#include "plugins/telemetry_server/telemetry_server.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <future>
+#include <thread>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+using namespace std::chrono_literals;
+
+// User callbacks are delivered through one bounded queue, and blocking API calls depend on
+// it: Action::arm() waits on a promise that is only satisfied when the command-result
+// callback runs. So a subscriber that cannot keep up must not be able to push that result
+// out of the queue -- if it does, arm() never returns.
+//
+// This floods the queue with telemetry deliveries behind a deliberately slow subscriber and
+// then checks that arm() still completes.
+
+namespace {
+
+constexpr auto slow_callback_duration = 20ms;
+
+// Published continuously rather than in one burst: a burst drains while the command is in
+// flight, and the queue has to still be saturated at the moment the command result is
+// queued, since that is what the overflow policy acts on.
+
+TelemetryServer::Position make_position()
+{
+    TelemetryServer::Position position{};
+    position.latitude_deg = 47.3977;
+    position.longitude_deg = 8.5456;
+    position.absolute_altitude_m = 488.0f;
+    position.relative_altitude_m = 10.0f;
+    return position;
+}
+
+} // namespace
+
+TEST(CallbackQueueOverflow, SlowSubscriberDoesNotStallBlockingCall)
+{
+    Mavsdk mavsdk_groundstation{Mavsdk::Configuration{ComponentType::GroundStation}};
+    Mavsdk mavsdk_autopilot{Mavsdk::Configuration{ComponentType::Autopilot}};
+
+    ASSERT_EQ(
+        mavsdk_groundstation.add_any_connection("udpin://0.0.0.0:17010"),
+        ConnectionResult::Success);
+    ASSERT_EQ(
+        mavsdk_autopilot.add_any_connection("udpout://127.0.0.1:17010"), ConnectionResult::Success);
+
+    auto action_server = ActionServer{mavsdk_autopilot.server_component()};
+    auto telemetry_server = TelemetryServer{mavsdk_autopilot.server_component()};
+    EXPECT_EQ(action_server.set_armable(true, true), ActionServer::Result::Success);
+
+    auto maybe_system = mavsdk_groundstation.first_autopilot(10.0);
+    ASSERT_TRUE(maybe_system);
+    auto system = maybe_system.value();
+
+    auto telemetry = Telemetry{system};
+    auto action = Action{system};
+
+    // A subscriber that cannot keep up. Every delivery holds the callback thread for a
+    // while, so the queue behind it grows.
+    //
+    // The counter is shared rather than captured by reference: callbacks that are already
+    // queued keep their own copy of this lambda and run until the Mavsdk instance is torn
+    // down, which happens after every local declared below it here goes away. Capturing a
+    // stack variable would be a use-after-scope, and unsubscribing would not save it --
+    // deliveries already on the queue hold their own copy of the callback.
+    auto positions_received = std::make_shared<std::atomic<unsigned>>(0);
+    telemetry.subscribe_position([positions_received](Telemetry::Position) {
+        std::this_thread::sleep_for(slow_callback_duration);
+        ++(*positions_received);
+    });
+
+    std::atomic<bool> stop_publishing{false};
+    std::atomic<unsigned> positions_published{0};
+    std::thread publisher([&]() {
+        TelemetryServer::VelocityNed velocity{};
+        TelemetryServer::Heading heading{};
+        heading.heading_deg = 90.0;
+        while (!stop_publishing) {
+            telemetry_server.publish_position(make_position(), velocity, heading);
+            ++positions_published;
+            std::this_thread::sleep_for(1ms);
+        }
+    });
+
+    // Give the queue time to back up behind the slow subscriber and stay that way.
+    std::this_thread::sleep_for(2s);
+
+    // The command result has to get through regardless of how backed up the telemetry is.
+    // Run arm() on its own thread so a regression shows up as a failure here rather than
+    // hanging the whole suite.
+    auto arm_result = std::async(std::launch::async, [&action]() { return action.arm(); });
+
+    const auto arrived = arm_result.wait_for(20s);
+    stop_publishing = true;
+    publisher.join();
+
+    ASSERT_EQ(arrived, std::future_status::ready)
+        << "arm() never returned: its result callback was dropped from the user callback queue";
+    EXPECT_EQ(arm_result.get(), Action::Result::Success);
+
+    LogInfo(
+        "Published {}, delivered {} position updates",
+        positions_published.load(),
+        positions_received->load());
+}


### PR DESCRIPTION
Stacked on #3058. This is hole 3 from the threading review — and investigating it turned out to make it more serious than "lossy by design".

### It's a liveness bug, not just dropped telemetry

Everything the user sees arrives through one bounded queue, and **blocking API calls depend on it**:

```cpp
Action::Result ActionImpl::arm() const
{
    auto prom = std::promise<Action::Result>();
    auto fut = prom.get_future();
    arm_async([&prom](Action::Result result) { prom.set_value(result); });
    return fut.get();                                  // no timeout
}
```

`arm_async` → `send_command_async` → `MavlinkCommandSender::call_callback` → `call_user_callback` → **the bounded queue**. So once the queue was full, the command result was dropped, the promise was never satisfied, and `arm()` never returned.

And the queue overflows precisely when the application is busy — which is when it's most likely to be issuing commands.

`system_tests/callback_queue_overflow.cpp` reproduces it with a deliberately slow position subscriber, a publisher keeping the queue saturated, and `arm()` on its own thread so a regression fails rather than hangs the suite:

| | result |
|---|---|
| before | `arm() never returned: its result callback was dropped from the user callback queue` |
| after | 2104 positions published, 111 delivered, **`arm()` succeeded** |

### Two classes

| | Use | Dropped? |
|---|---|---|
| `call_user_callback()` | Anything somebody may be waiting for: command results, mission and parameter completions. | **Never** — one per user action, so they can't run the queue away. |
| `call_user_callback_droppable()` | A subscription delivering a stream, where the newest value is what matters. | Yes, past the bound. |

Must-deliver is the **default**, so the ~230 existing call sites are safe without being touched and only high-rate paths opt in. In Telemetry that's 37 stream deliveries marked droppable, leaving the two `get_gps_global_origin` one-shots as must-deliver.

When the bound is reached the **oldest** droppable entry is evicted rather than the new one refused, so a struggling subscriber sees fresh data with gaps instead of falling steadily further behind. If the queue somehow holds nothing droppable, the new stream value gives way rather than displacing a completion.

### Drops are now visible

Counted, and reported at most every five seconds with a running total.

The old logging did the opposite of what was useful: a warning on **every** enqueue once the queue passed ten (up to eighty-nine lines in a burst), a single error at exactly ninety-nine, then silent dropping from a hundred. Loudest before anything was lost, quiet once it was.

### Testing

107/107 system tests, 107/107 under TSan with **0 warnings**, 427/427 unit.

### Deliberately not included

A public getter for the drop count. It would be genuinely useful, but it is a public API commitment, so it seemed better to ask than to slip it in — say the word and I'll add it.

Also worth its own conversation: `fut.get()` with no timeout means *any* reason a callback fails to arrive is a permanent hang, not just this one. This PR removes the reason we know about; it doesn't make the pattern robust.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW