### PR TITLE
system_tests: stop the watchdog race test burying the log

### DIFF
--- a/cpp/src/system_tests/heartbeat_watchdog.cpp
+++ b/cpp/src/system_tests/heartbeat_watchdog.cpp
@@ -1,11 +1,13 @@
 #include "mavsdk.hpp"
 #include "mavlink_include.hpp"
 #include "mavlink_channels.hpp"
+#include "log_callback.hpp"
 
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <chrono>
+#include <string>
 #include <thread>
 
 using namespace mavsdk;
@@ -44,6 +46,37 @@ bool wait_for(Predicate predicate, std::chrono::milliseconds timeout = flow_time
     }
     return predicate();
 }
+
+// Swallows log messages containing a given phrase for as long as it is in scope.
+//
+// Only for output a test deliberately provokes in bulk. Feeding the watchdog logs once per
+// NeedsFeed -> Armed transition, which is right for an application -- it complements the
+// expiry warning -- but a test that thrashes that transition in a tight loop turns it into
+// tens of thousands of lines and buries everything else.
+class SuppressLogsContaining {
+public:
+    explicit SuppressLogsContaining(std::string phrase) : _phrase(std::move(phrase))
+    {
+        const auto phrase_copy = _phrase;
+        log::subscribe(
+            [phrase_copy](log::Level, const std::string& message, const std::string&, int) {
+                // Returning true drops the message, false lets the default logging have it.
+                return message.find(phrase_copy) != std::string::npos;
+            });
+    }
+
+    ~SuppressLogsContaining()
+    {
+        // An empty callback restores the default logging.
+        log::subscribe({});
+    }
+
+    SuppressLogsContaining(const SuppressLogsContaining&) = delete;
+    SuppressLogsContaining& operator=(const SuppressLogsContaining&) = delete;
+
+private:
+    std::string _phrase;
+};
 
 // Message ID of a raw MAVLink frame, or -1 if it does not look like one.
 int msgid_from_bytes(const char* bytes, size_t length)
@@ -181,6 +214,11 @@ TEST(HeartbeatWatchdog, GatesHeartbeatsOnTheWire)
 
 TEST(HeartbeatWatchdog, ConcurrentReconfigurationDoesNotDeadlock)
 {
+    // The loop below re-arms the watchdog as fast as it can, on purpose: this is a race
+    // test, and throttling it would cost the very interleaving it is looking for. Each
+    // re-arm logs, so silence that one message rather than slowing the test down.
+    SuppressLogsContaining suppress_watchdog_fed{"Heartbeat watchdog fed"};
+
     Mavsdk mavsdk{ground_station_configuration(true)};
     // Checked out after the Mavsdk, so the test packs on a different channel
     // than the library's own server component.


### PR DESCRIPTION
Stacked on #3059. Test-only.

`HeartbeatWatchdog.ConcurrentReconfigurationDoesNotDeadlock` produced **26375 lines of "Heartbeat watchdog fed" in a 540 ms run** — 26983 lines of output in total, which buries everything else in the suite log.

### The library is not at fault

`HeartbeatWatchdog::feed()` logs only on the `NeedsFeed → Armed` transition, so an application feeding at 1 Hz never sees it, and the message earns its place by complementing the expiry warning. It is this test that re-arms the watchdog as fast as it can.

### Why not just throttle the loop

That was the obvious fix and I think the wrong one. This is a race test hunting an ABBA deadlock between configuration updates and system discovery — sleeping in the loop would cost exactly the interleaving it exists to find, and quietly make the test worse at its job while looking tidier.

So the loop is untouched, and the expected message is swallowed for the duration instead, via an RAII guard around the public `log::subscribe()` hook.

### Result

| | before | after |
|---|---|---|
| that test's output | 26983 lines | **629** |
| "watchdog fed" in it | 26375 | **0** |

Whole suite still logs normally: 341 ordinary log lines elsewhere, and the single remaining "watchdog fed" is the deliberate one in `GatesHeartbeatsOnTheWire`, where it actually means something. 107/107 system, 427/427 unit.

### Noticed, not fixed

`emit_log()` calls `log::get_callback()` (which locks, returns a reference, unlocks) and then invokes it, so a concurrent `log::subscribe()` could reassign the `std::function` while it is being called. The guard here subscribes before any threads start and restores after joining, so it does not hit that — but it is a real race in the logging API and worth its own look.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW