### PR TITLE
core: fix the race on the log callback

### DIFF
--- a/cpp/src/mavsdk/core/CMakeLists.txt
+++ b/cpp/src/mavsdk/core/CMakeLists.txt
@@ -266,6 +266,7 @@ install(DIRECTORY ${MAVLINK_INCLUDE_DIR}/mavlink
 
 list(APPEND UNIT_TEST_SOURCES
     ${PROJECT_SOURCE_DIR}/mavsdk/core/callback_list_test.cpp
+    ${PROJECT_SOURCE_DIR}/mavsdk/core/log_race_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/call_every_handler_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/cli_arg_test.cpp
     ${PROJECT_SOURCE_DIR}/mavsdk/core/file_cache_test.cpp

--- a/cpp/src/mavsdk/core/log.cpp
+++ b/cpp/src/mavsdk/core/log.cpp
@@ -1,6 +1,7 @@
 #include "log.hpp"
 #include "unused.hpp"
 
+#include <memory>
 #include <mutex>
 
 #if defined(WINDOWS)
@@ -25,6 +26,13 @@ namespace mavsdk {
 static std::mutex callback_mutex_{};
 static log::Callback callback_{nullptr};
 
+// What emit_log() actually uses. Held as a shared_ptr so the logging path can take a
+// reference to the callback under callback_mutex_ and then invoke it with the lock released:
+// the callback is user code, and calling it under the lock would deadlock the moment it logs
+// anything itself. Copying the std::function on every log line instead would mean an
+// allocation per line, whereas copying the shared_ptr is one atomic increment.
+static std::shared_ptr<const log::Callback> callback_in_use_{nullptr};
+
 // Dedicated mutex for logging operations - moved from header to avoid inlining issues
 static std::mutex log_mutex_{};
 
@@ -33,6 +41,9 @@ MAVSDK_TEST_EXPORT std::mutex& get_log_mutex()
     return log_mutex_;
 }
 
+// Note that this hands out a reference to the stored callback, so it is only safe as long as
+// nobody calls subscribe() concurrently. It is kept because it is public API; the logging
+// path deliberately does not use it, see callback_in_use_ and emit_log().
 MAVSDK_PUBLIC log::Callback& log::get_callback()
 {
     std::lock_guard<std::mutex> lock(callback_mutex_);
@@ -43,6 +54,7 @@ void log::subscribe(const log::Callback& callback)
 {
     std::lock_guard<std::mutex> lock(callback_mutex_);
     callback_ = callback;
+    callback_in_use_ = callback ? std::make_shared<const log::Callback>(callback) : nullptr;
 }
 
 MAVSDK_TEST_EXPORT void set_color(Color color)
@@ -97,7 +109,17 @@ MAVSDK_TEST_EXPORT void set_color(Color color)
 
 void emit_log(log::Level level, const std::string& message, const char* filename, int line)
 {
-    if (log::get_callback() && log::get_callback()(level, message, filename, line)) {
+    // Fetched once, and invoked with the lock released. Fetching twice -- once to test it
+    // and once to call it -- let a subscribe() in between turn the second fetch into an
+    // empty std::function, and calling one of those throws, which with -fno-exceptions ends
+    // the process.
+    std::shared_ptr<const log::Callback> callback;
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex_);
+        callback = callback_in_use_;
+    }
+
+    if (callback && (*callback)(level, message, filename, line)) {
         return;
     }
 

--- a/cpp/src/mavsdk/core/log_race_test.cpp
+++ b/cpp/src/mavsdk/core/log_race_test.cpp
@@ -1,0 +1,45 @@
+#include "log.hpp"
+#include "log_callback.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <gtest/gtest.h>
+
+using namespace mavsdk;
+
+// emit_log() has to read the subscribed callback while another thread may be replacing it
+// through log::subscribe(). Getting that wrong is not just a data race on the std::function:
+// emit_log() used to fetch it twice, once to test it and once to call it, so a subscribe()
+// landing in between could invoke an empty std::function -- which throws, and MAVSDK is built
+// with -fno-exceptions.
+//
+// Both callbacks here suppress output, so the test does not also flood the log while it runs.
+TEST(LogRace, SubscribeWhileLogging)
+{
+    std::atomic<bool> stop{false};
+
+    std::thread logger([&stop]() {
+        while (!stop) {
+            LogDebug("racing the log callback");
+        }
+    });
+
+    std::thread swapper([&stop]() {
+        while (!stop) {
+            log::subscribe(
+                [](log::Level, const std::string&, const std::string&, int) { return true; });
+            log::subscribe(
+                [](log::Level, const std::string&, const std::string&, int) { return true; });
+        }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    stop = true;
+    logger.join();
+    swapper.join();
+
+    // Leave the default logging in place for everything that runs after this.
+    log::subscribe({});
+}


### PR DESCRIPTION
Stacked on #3060. This is the logging-API race I noticed while doing that one and flagged rather than folded in.

### The bug

```cpp
log::Callback& log::get_callback() {
    std::lock_guard lock(callback_mutex_);
    return callback_;                    // reference escapes; lock released here
}

if (log::get_callback() && log::get_callback()(level, message, filename, line))
//  ^^^ locks, unlocks       ^^^ locks, unlocks, then invokes OUTSIDE the lock
```

The mutex protects *fetching* the reference, not *using* it. ThreadSanitizer is unambiguous once anything actually races them:

- **Write** at `log::subscribe` (`log.cpp:45`), holding mutex **M0**
- **Previous read** at `emit_log` (`log.cpp:100`), holding mutex **M1**

Two different mutexes (`callback_mutex_` vs `log_mutex_`) exclude nothing. It has never shown up in CI simply because no test subscribes concurrently with logging.

There is a second, sharper problem: `get_callback()` is called **twice**, once to test and once to call. A `subscribe()` in between makes the second fetch empty, and invoking an empty `std::function` throws — with `-fno-exceptions` that ends the process rather than being merely undefined.

### The fix keeps the original intent

Not holding the lock across the call is *right*, and I kept it. The callback is user code: calling it under `callback_mutex_` deadlocks the moment it logs anything itself, and would serialise all logging across threads for the duration of arbitrary user code.

What was missing is that the value has to be taken *away* from under the lock rather than referenced through it. `emit_log()` now copies a `shared_ptr` to the callback once, under the lock, and invokes it after releasing — a `shared_ptr` rather than the `std::function` because this runs per log line, so the cost is an atomic increment instead of a possible allocation.

`log::get_callback()` is public API (`MAVSDK_PUBLIC` in `include/mavsdk/log_callback.hpp`), so its signature is untouched. It is now unused inside the library, and its comment says what it is: safe only while nobody subscribes concurrently.

### Testing

`core/log_race_test.cpp` drives it directly, one thread logging while another swaps the callback:

| | TSan |
|---|---|
| before | **1 race**, exit 66 |
| after | **0**, exit 0 |

Both of its callbacks suppress output, so the test does not flood the log while it runs (89 lines total).

428/428 unit under TSan, 107/107 system, 107/107 system under TSan, all with 0 warnings.

https://claude.ai/code/session_01UaEgDqHZFhTXdNQQKjRuAW