### PR TITLE
Generate Requires.private only for static pkg-config installs

### DIFF
--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -109,8 +109,29 @@ configure_file(MAVSDKConfig.cmake.in
     "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/MAVSDKConfig.cmake" @ONLY)
 
 # Pkg-config
+set(MAVSDK_PC_REQUIRES_PRIVATE "")
+if(NOT BUILD_SHARED_LIBS)
+    set(_mavsdk_pc_requires_private "nlohmann_json tinyxml2")
+    if(NOT BUILD_WITHOUT_CURL)
+        set(_mavsdk_pc_requires_private "libcurl ${_mavsdk_pc_requires_private}")
+    endif()
+
+    set(MAVSDK_PC_REQUIRES_PRIVATE "Requires.private: ${_mavsdk_pc_requires_private}")
+endif()
+
 configure_file(mavsdk.pc.in
     "${PROJECT_BINARY_DIR}/mavsdk.pc" @ONLY)
+
+if(BUILD_TESTING)
+    add_test(
+        NAME mavsdk_pkg_config_metadata
+        COMMAND ${CMAKE_COMMAND}
+            -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+            -DBUILD_WITHOUT_CURL=${BUILD_WITHOUT_CURL}
+            -DPC_FILE=${PROJECT_BINARY_DIR}/mavsdk.pc
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/validate_mavsdk_pc.cmake
+    )
+endif()
 
 include(CMakePackageConfigHelpers)
 # Supply version to config

--- a/cpp/src/mavsdk.pc.in
+++ b/cpp/src/mavsdk.pc.in
@@ -6,6 +6,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: MAVSDK
 Description: API and library for MAVLink compatible systems written in C++17
 Version: @MAVSDK_VERSION_STRING@
-Requires.private: libcurl nlohmann_json tinyxml2
+@MAVSDK_PC_REQUIRES_PRIVATE@
 Libs: -L"${libdir}" -lmavsdk
 Cflags: -I"${includedir}" -I"${includedir}/mavsdk"

--- a/cpp/src/validate_mavsdk_pc.cmake
+++ b/cpp/src/validate_mavsdk_pc.cmake
@@ -1,0 +1,20 @@
+file(STRINGS "${PC_FILE}" requires_private_line REGEX "^Requires\\.private:")
+
+if(BUILD_SHARED_LIBS)
+    if(requires_private_line)
+        message(FATAL_ERROR "Shared builds must not emit Requires.private in ${PC_FILE}: ${requires_private_line}")
+    endif()
+    return()
+endif()
+
+set(expected_requires_private "nlohmann_json tinyxml2")
+if(NOT BUILD_WITHOUT_CURL)
+    set(expected_requires_private "libcurl ${expected_requires_private}")
+endif()
+
+if(NOT requires_private_line STREQUAL "Requires.private: ${expected_requires_private}")
+    message(
+        FATAL_ERROR
+        "Static builds must emit 'Requires.private: ${expected_requires_private}' in ${PC_FILE}, got '${requires_private_line}'"
+    )
+endif()


### PR DESCRIPTION
## Summary

- emit `Requires.private` only for static MAVSDK builds
- omit curl from static metadata when `BUILD_WITHOUT_CURL=ON`
- add a CMake-only validator wired into CTest

## Why

Shared-library `mavsdk.pc` files advertised bundled implementation dependencies, forcing downstream `pkg-config` consumers to resolve packages they do not link directly. Static consumers still need those private dependencies. This fixes #3018.

## Verification

- shared valid/invalid metadata cases
- static with curl and static without curl cases
- validator path containing spaces
- `git show --check`

The full third-party superbuild was not completed; the focused install-metadata matrix passed.

Fixes #3018