### PR TITLE
Run the tests on Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -200,6 +200,18 @@ jobs:
           -S.
       - name: build
         run: cmake --build build -j4 --config ${{ matrix.config }} --target install
+      - name: unit tests
+        # The arm64 build is cross-compiled, so we can't run it here.
+        if: matrix.arch != 'arm64'
+        run: |
+          $env:PATH = "$PWD\install\bin;$env:PATH"
+          .\build\src\unit_tests\${{ matrix.config }}\unit_tests_runner.exe
+      - name: system tests
+        if: matrix.arch != 'arm64'
+        timeout-minutes: 10
+        run: |
+          $env:PATH = "$PWD\install\bin;$env:PATH"
+          .\build\src\system_tests\${{ matrix.config }}\system_tests_runner.exe
       - name: Create zip file from mavsdk libraries
         run: (cd install && 7z.exe a -tzip ../mavsdk-windows-${{ matrix.arch }}-${{ matrix.config }}.zip .)
       - name: Upload mavsdk library as artifact
@@ -217,6 +229,55 @@ jobs:
           asset_name: mavsdk-windows-${{ matrix.arch }}-${{ matrix.config }}.zip
           tag: ${{ github.ref }}
           overwrite: true
+
+  Windows-arm64-tests:
+    name: Windows arm64 tests (${{ matrix.config }})
+    runs-on: windows-11-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [Debug, RelWithDebInfo]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: git get version tags
+        run: git fetch --tags
+      - uses: actions/cache@v5
+        id: cache
+        with:
+          path: ./cpp/build/third_party/install
+          key: ${{ github.job }}-arm64-${{ matrix.config }}-${{ hashFiles('./cpp/third_party/**') }}-1
+      - name: disable superbuild on cache hit
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: |
+            echo "superbuild=-DSUPERBUILD=OFF" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/third_party/install" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: configure
+        # The platform is what openssl uses to pick its target, so set it even though
+        # it is what we would build natively anyway.
+        run: cmake -A ARM64
+          $env:superbuild
+          $env:cmake_prefix_path
+          -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+          -DCMAKE_INSTALL_PREFIX=install
+          -DBUILD_MAVSDK_SERVER=OFF
+          -DBUILD_SHARED_LIBS=ON
+          -DWERROR=ON
+          -Bbuild
+          -S.
+      - name: build
+        run: cmake --build build -j4 --config ${{ matrix.config }} --target install
+      - name: unit tests
+        run: |
+          $env:PATH = "$PWD\install\bin;$env:PATH"
+          .\build\src\unit_tests\${{ matrix.config }}\unit_tests_runner.exe
+      - name: system tests
+        timeout-minutes: 10
+        run: |
+          $env:PATH = "$PWD\install\bin;$env:PATH"
+          .\build\src\system_tests\${{ matrix.config }}\system_tests_runner.exe
 
   Windows-mavsdk-library-combine:
     name: Combine Windows mavsdk library artifacts

--- a/cpp/src/mavsdk/core/callback_list_test.cpp
+++ b/cpp/src/mavsdk/core/callback_list_test.cpp
@@ -282,7 +282,10 @@ TEST_F(CallbackListTest, SubscribeAndUnsubscribeWithinCallbacks2)
 {
     const int test_value1 = 42;
     const double test_value2 = 3.14;
-    const int thread_count = 50000;
+    // We want a lot of subscriptions happening at once, but one thread each would
+    // need more address space for the stacks than a 32-bit process has.
+    const int thread_count = 64;
+    const int subscriptions_per_thread = 800;
     std::atomic<int> nested_callback_count{0};
     CallbackList<int, double> cl{_io_context};
 
@@ -308,18 +311,20 @@ TEST_F(CallbackListTest, SubscribeAndUnsubscribeWithinCallbacks2)
     std::vector<std::thread> threads;
     for (int i = 0; i < thread_count; ++i) {
         threads.emplace_back([&]() {
-            // Add a burst of subscriptions in a multithreaded env all at once
-            auto handle_ptr = std::make_shared<std::optional<Handle<int, double>>>();
-            addSubCallback(handle_ptr); // this will get deferred sub
+            for (int j = 0; j < subscriptions_per_thread; ++j) {
+                // Add a burst of subscriptions in a multithreaded env all at once
+                auto handle_ptr = std::make_shared<std::optional<Handle<int, double>>>();
+                addSubCallback(handle_ptr); // this will get deferred sub
 
-            // safely put them in a vec for later comparison
-            std::lock_guard<std::mutex> guard(mutex_);
-            if (handle_ptr && handle_ptr->has_value()) {
-                if (!handle_set.insert(handle_ptr->value()).second) {
-                    EXPECT_TRUE(false); // handles are not unique
+                // safely put them in a vec for later comparison
+                std::lock_guard<std::mutex> guard(mutex_);
+                if (handle_ptr && handle_ptr->has_value()) {
+                    if (!handle_set.insert(handle_ptr->value()).second) {
+                        EXPECT_TRUE(false); // handles are not unique
+                    }
+                } else {
+                    EXPECT_TRUE(false); // handles not filled in
                 }
-            } else {
-                EXPECT_TRUE(false); // handles not filled in
             }
         });
     }

--- a/cpp/src/mavsdk/core/hostname_to_ip.cpp
+++ b/cpp/src/mavsdk/core/hostname_to_ip.cpp
@@ -16,6 +16,12 @@ namespace mavsdk {
 
 std::optional<std::string> resolve_hostname_to_ip(const std::string& hostname)
 {
+    // Windows resolves an empty hostname to the wildcard address because of AI_PASSIVE
+    // below, while Linux and macOS reject it. Reject it everywhere.
+    if (hostname.empty()) {
+        return {};
+    }
+
 #if defined(WINDOWS)
     WSADATA wsaData;
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {

--- a/cpp/src/mavsdk/core/udp_connection.cpp
+++ b/cpp/src/mavsdk/core/udp_connection.cpp
@@ -4,6 +4,11 @@
 
 #include <cassert>
 
+#if defined(WINDOWS)
+#include <winsock2.h>
+#include <mswsock.h>
+#endif
+
 #include <asio/buffer.hpp>
 #include <asio/error.hpp>
 #include <asio/ip/address.hpp>
@@ -82,6 +87,26 @@ ConnectionResult UdpConnection::setup_port()
     }
 
     _socket.set_option(asio::socket_base::reuse_address(true), ec);
+
+#if defined(WINDOWS)
+    // By default, Windows reports an ICMP port unreachable caused by one of our sends
+    // as an error on the next receive on this socket. Switch that off, otherwise a
+    // remote that goes away can take down a socket which is otherwise fine.
+    BOOL report_icmp_errors = FALSE;
+    DWORD bytes_returned = 0;
+    if (WSAIoctl(
+            _socket.native_handle(),
+            SIO_UDP_CONNRESET,
+            &report_icmp_errors,
+            sizeof(report_icmp_errors),
+            nullptr,
+            0,
+            &bytes_returned,
+            nullptr,
+            nullptr) == SOCKET_ERROR) {
+        LogWarn("Could not disable ICMP error reporting: {}", WSAGetLastError());
+    }
+#endif
 
     _socket.bind(local_endpoint, ec);
     if (ec) {
@@ -273,6 +298,16 @@ void UdpConnection::do_receive()
         _sender_endpoint,
         [this](const asio::error_code& ec, std::size_t recv_len) {
             if (ec) {
+                // These are errors about one datagram, not about the socket. Windows
+                // reports an ICMP unreachable from an earlier send this way, meaning a
+                // remote that has gone away would otherwise end our receiving for good.
+                if (ec == asio::error::connection_refused || ec == asio::error::connection_reset ||
+                    ec == asio::error::network_reset || ec == asio::error::message_size) {
+                    LogDebug("Ignoring error from async_receive_from: {}", ec.message());
+                    do_receive();
+                    return;
+                }
+
                 // operation_aborted happens when the socket is closed (stop()), which is normal.
                 if (ec != asio::error::operation_aborted) {
                     LogErr("Error from async_receive_from: {}", ec.message());

--- a/cpp/src/system_tests/fs_helpers.cpp
+++ b/cpp/src/system_tests/fs_helpers.cpp
@@ -9,6 +9,18 @@
 
 using namespace mavsdk;
 
+fs::path test_data_dir()
+{
+    std::error_code ec;
+    const auto temp_dir = fs::temp_directory_path(ec);
+    if (ec) {
+        LogErr("Could not determine temp directory: {}", ec.message());
+        return fs::path("mavsdk_systemtest_temp_data");
+    }
+
+    return temp_dir / "mavsdk_systemtest_temp_data";
+}
+
 bool create_temp_file(const fs::path& path, size_t len, uint8_t start)
 {
     const auto parent_path = path.parent_path();

--- a/cpp/src/system_tests/fs_helpers.hpp
+++ b/cpp/src/system_tests/fs_helpers.hpp
@@ -5,6 +5,9 @@
 
 namespace fs = std::filesystem;
 
+// Directory for test data, inside the temp directory of whatever system we run on.
+fs::path test_data_dir();
+
 bool create_temp_file(const fs::path& path, size_t len, uint8_t start = 0);
 
 bool reset_directories(const fs::path& path);

--- a/cpp/src/system_tests/ftp_compare_files.cpp
+++ b/cpp/src/system_tests/ftp_compare_files.cpp
@@ -14,9 +14,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const fs::path temp_file = "data.bin";
 static const fs::path temp_file_same = "data_copy.bin";

--- a/cpp/src/system_tests/ftp_create_dir.cpp
+++ b/cpp/src/system_tests/ftp_create_dir.cpp
@@ -13,9 +13,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const fs::path temp_dir = "folder";
 

--- a/cpp/src/system_tests/ftp_download_file.cpp
+++ b/cpp/src/system_tests/ftp_download_file.cpp
@@ -16,10 +16,8 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
-static const fs::path temp_dir_downloaded = "/tmp/mavsdk_systemtest_temp_data/downloaded";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
+static const fs::path temp_dir_downloaded = test_data_dir() / "downloaded";
 
 static const fs::path temp_file = "data.bin";
 

--- a/cpp/src/system_tests/ftp_download_file_burst.cpp
+++ b/cpp/src/system_tests/ftp_download_file_burst.cpp
@@ -16,10 +16,8 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
-static const fs::path temp_dir_downloaded = "/tmp/mavsdk_systemtest_temp_data/downloaded";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
+static const fs::path temp_dir_downloaded = test_data_dir() / "downloaded";
 
 static const fs::path temp_file = "data.bin";
 

--- a/cpp/src/system_tests/ftp_list_dir.cpp
+++ b/cpp/src/system_tests/ftp_list_dir.cpp
@@ -14,9 +14,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const std::string temp_dir = "folder";
 static const std::string temp_file = "file";

--- a/cpp/src/system_tests/ftp_remove_dir.cpp
+++ b/cpp/src/system_tests/ftp_remove_dir.cpp
@@ -13,9 +13,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const fs::path temp_dir = "folder";
 static const fs::path temp_file = "file.bin";

--- a/cpp/src/system_tests/ftp_remove_file.cpp
+++ b/cpp/src/system_tests/ftp_remove_file.cpp
@@ -14,9 +14,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const fs::path temp_file = "data.bin";
 

--- a/cpp/src/system_tests/ftp_rename_file.cpp
+++ b/cpp/src/system_tests/ftp_rename_file.cpp
@@ -14,9 +14,7 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
 
 static const fs::path temp_file = "data.bin";
 static const fs::path temp_file_renamed = "rhubarb.bin";

--- a/cpp/src/system_tests/ftp_upload_file.cpp
+++ b/cpp/src/system_tests/ftp_upload_file.cpp
@@ -16,12 +16,10 @@ using namespace mavsdk;
 
 static constexpr double reduced_timeout_s = 0.1;
 
-// TODO: make this compatible for Windows using GetTempPath2
-
 namespace fs = std::filesystem;
 
-static const fs::path temp_dir_provided = "/tmp/mavsdk_systemtest_temp_data/provided";
-static const fs::path temp_dir_to_upload = "/tmp/mavsdk_systemtest_temp_data/to_upload";
+static const fs::path temp_dir_provided = test_data_dir() / "provided";
+static const fs::path temp_dir_to_upload = test_data_dir() / "to_upload";
 
 static const fs::path temp_file = "data.bin";
 

--- a/cpp/src/system_tests/mission_raw_upload.cpp
+++ b/cpp/src/system_tests/mission_raw_upload.cpp
@@ -1,6 +1,7 @@
 #include "log.hpp"
 #include "mavsdk.hpp"
 #include "example_plan.hpp"
+#include "fs_helpers.hpp"
 #include "plugins/mission_raw/mission_raw.hpp"
 #include "plugins/mission_raw_server/mission_raw_server.hpp"
 #include <string>
@@ -31,13 +32,15 @@ TEST(Mission, RawUpload)
     ASSERT_TRUE(system->has_autopilot());
 
     // We take an example mission plan, write it to a temp file and then import it.
-    auto constexpr path = "/tmp/example.plan";
+    const auto temp_dir = test_data_dir() / "mission";
+    ASSERT_TRUE(reset_directories(temp_dir));
+    const auto path = temp_dir / "example.plan";
     std::ofstream out(path);
     out << plan;
     out.close();
 
     auto mission_raw = MissionRaw{system};
-    auto result_pair = mission_raw.import_qgroundcontrol_mission(path);
+    auto result_pair = mission_raw.import_qgroundcontrol_mission(path.string());
     ASSERT_EQ(result_pair.first, MissionRaw::Result::Success);
 
     EXPECT_EQ(


### PR DESCRIPTION
Windows is the only platform where we build the unit and system tests on every PR but never run them. This turns them on, for Intel and arm.

- **x64 and x86**: they build natively on the `windows-2025` runner, so the existing library build jobs just get a `unit tests` and a `system tests` step (with `install\bin` on `PATH` for `mavsdk.dll`).
- **arm64**: the library build is cross-compiled and can't run on that runner, so there's a separate `Windows arm64 tests` job on the native `windows-11-arm` runner which builds and tests only. The release artifacts keep coming from the existing cross build, untouched.
- The FTP and mission tests wrote to a hardcoded `/tmp/...` path — that's what the `TODO: make this compatible for Windows using GetTempPath2` comments were about. They now go through `std::filesystem::temp_directory_path()`.

Let's see what CI says. If some tests turn out flaky on Windows I'd rather find out here than after merging.