### PR TITLE
core: fix CopterMode AvoidAdsb typo

### DIFF
--- a/cpp/src/mavsdk/core/ardupilot_custom_mode.hpp
+++ b/cpp/src/mavsdk/core/ardupilot_custom_mode.hpp
@@ -37,7 +37,7 @@ enum class CopterMode {
     PosHold = 16,
     Break = 17,
     Throw = 18,
-    AvoidAdbs = 19,
+    AvoidAdsb = 19,
     GuidedNoGps = 20,
     SmartRtl = 21,
     FlowHold = 22,


### PR DESCRIPTION
## Summary
- Rename `CopterMode::AvoidAdbs` to `CopterMode::AvoidAdsb` so it matches ArduPilot and `PlaneMode::AvoidAdsb`.
- Enum value stays `19`; no protocol change.

## Why
Maintainer asked for this typo fix on https://github.com/mavlink/MAVSDK/issues/2172.

## Test plan
- Header-only identifier change; `flight_mode.cpp` does not switch on this enumerator.
- Confirmed no remaining `AvoidAdbs` references.

Fixes #2172